### PR TITLE
feat(metadata): Phase 9a — annotations, fact-checks, topic-trust data model + NIP draft

### DIFF
--- a/docs/NIP_DRAFT.md
+++ b/docs/NIP_DRAFT.md
@@ -1,0 +1,298 @@
+NIP-XX
+======
+
+Web Content Annotations, Fact-Checks, and Topic Trust
+-----------------------------------------------------
+
+`draft` `optional`
+
+This NIP defines five event kinds and one tag extension that together let users publish structured, anchored metadata about web content — annotations, fact-checks, ratings, topic-scoped trust assertions, and helpfulness votes — and lets readers query, rank, and surface that metadata in context.
+
+It composes with rather than replaces:
+
+- [NIP-22](22.md) (comments) — annotations are also valid NIP-22 comments and appear in NIP-22 readers.
+- [NIP-23](23.md) (long-form) — extends `kind:30023` with an optional `responds-to` tag.
+- [NIP-32](32.md) (labels) — labels remain the canonical taxonomy primitive; annotations carry richer structure.
+- [NIP-73](73.md) (external content IDs) — all URL anchoring uses NIP-73's `i`/`k` pattern.
+- [NIP-84](84.md) (highlights) — highlights remain the right primitive for "draw attention without commentary."
+- [NIP-85](85.md) (trusted assertions) — bridging-based ranking results are publishable as NIP-85 trusted assertions.
+
+## Concepts
+
+### Anchoring
+
+Every event defined in this NIP that targets web content MUST anchor to a normalized URL. Clients SHOULD apply standard URL canonicalization before constructing tags: lowercase scheme and host, strip default ports, remove tracking query parameters (`utm_*`, `fbclid`, `gclid`, `ref`, `mc_*`, etc.), remove URL fragments unless the fragment is meaningful (e.g., `#:~:text=` text fragments), and remove trailing slashes from path segments other than root.
+
+URL anchoring uses the NIP-73 + NIP-22 pattern jointly:
+
+```jsonc
+"tags": [
+  ["r", "https://example.com/article"],
+  ["i", "https://example.com/article"],
+  ["k", "web"],
+  ["I", "https://example.com/article"],
+  ["K", "web"]
+]
+```
+
+The `r` tag is for fast relay-side filtering. The `i`/`k` and `I`/`K` pairs are for NIP-22 / NIP-73 conformance — clients implementing those NIPs index against them, so this NIP's events appear in their UIs without bespoke handling.
+
+### Selectors
+
+Annotations and fact-checks may anchor to a specific span within a target. Selectors live inside the event `content` (which is a JSON object for these kinds) and follow the [W3C Web Annotation Data Model](https://www.w3.org/TR/annotation-model/) selector vocabulary.
+
+The recommended selector types, in order of robustness preference:
+
+1. `TextQuoteSelector` — `{ exact, prefix, suffix }`. The author captures ~32 characters of context on each side of the selection. The consumer searches `prefix + exact + suffix` first, falling back to `exact` alone with a uniqueness check. Robust to DOM and CSS changes.
+2. `RangeSelector` — `{ startContainer, startOffset, endContainer, endOffset }` with XPath. Faster on long documents but brittle to DOM restructuring.
+3. `CssSelector` — useful when the page has stable element ids/classes (e.g., paragraph ids on Substack).
+4. `FragmentSelector` — for media fragments only: `xywh=...` for images, `t=Ns` for time offsets in audio/video.
+
+Authors SHOULD include multiple selectors. Consumers SHOULD try them in order and treat the first match with confidence ≥ 0.7 as the resolution. Annotations whose selectors do not resolve on the current page are NOT discarded; they are surfaced as page-level annotations with a "could not be located" indicator.
+
+## Kind 30050 — Annotation
+
+Addressable. An anchored note with optional structured body and motivation.
+
+```jsonc
+{
+  "kind": 30050,
+  "tags": [
+    ["d", "<deterministic-id>"],
+    ["r", "<url>"],
+    ["i", "<url>"], ["k", "web"],
+    ["I", "<url>"], ["K", "web"],
+    ["motivation", "rebutting"],
+    ["t", "<topic>"],
+    ["a", "30023:<reviewer-pubkey>:<slug>", "<relay-hint>"],
+    ["lang", "en"]
+  ],
+  "content": "<JSON-LD body, see below>"
+}
+```
+
+The `d` tag MUST be deterministic so re-publishing an edit replaces (NIP-01 addressable-event semantics):
+
+```
+d = "ann:" + sha256(normalized_url + "|" + selector_hash + "|" + motivation).slice(0, 16)
+```
+
+The `motivation` tag MAY appear multiple times. Allowed values include but are not limited to: `commenting`, `highlighting`, `fact-checking`, `rebutting`, `supporting`, `contextualizing`, `correcting`, `responding-to`, `linking`, `tagging`. Clients SHOULD render unknown motivations as generic annotations.
+
+The `content` is a JSON-LD `Annotation` object using the `http://www.w3.org/ns/anno.jsonld` context. Minimum:
+
+```jsonc
+{
+  "@context": "http://www.w3.org/ns/anno.jsonld",
+  "type": "Annotation",
+  "motivation": "rebutting",
+  "body": {
+    "type": "TextualBody",
+    "format": "text/markdown",
+    "language": "en",
+    "value": "<markdown body>"
+  },
+  "target": {
+    "source": "<url>",
+    "selector": [
+      { "type": "TextQuoteSelector", "exact": "...", "prefix": "...", "suffix": "..." }
+    ]
+  }
+}
+```
+
+If `motivation` is `correcting`, the event SHOULD include a `correction-type` tag with one of: `headline`, `quote`, `stat`, `name`, `date`, `other`.
+
+If the annotation is itself a published article (e.g., a kind 30023 reaction post) being referenced as the "body" of the annotation, an `a` tag SHOULD reference the article event.
+
+## Kind 30051 — FactCheck
+
+Addressable. A `ClaimReview`-shaped event: a specific claim is reviewed against a specific scale.
+
+```jsonc
+{
+  "kind": 30051,
+  "tags": [
+    ["d", "factcheck:<sha256(url + '|' + claimReviewed)>.slice(0,16)"],
+    ["r", "<url>"],
+    ["i", "<url>"], ["k", "web"],
+    ["claim-reviewed", "<short text of the claim>"],
+    ["rating-value", "1"],
+    ["rating-best", "5"],
+    ["rating-worst", "1"],
+    ["rating-name", "False"],
+    ["rating-scale", "<scale-namespace>"],
+    ["t", "<topic>"],
+    ["e", "<related-claim-event-id>", "<relay-hint>"],
+    ["evidence", "<url-or-naddr>"]
+  ],
+  "content": "<JSON-LD ClaimReview body>"
+}
+```
+
+The `content` is a [Schema.org `ClaimReview`](https://schema.org/ClaimReview) object:
+
+```jsonc
+{
+  "@context": "https://schema.org",
+  "type": "ClaimReview",
+  "datePublished": "<ISO-8601>",
+  "claimReviewed": "<text>",
+  "itemReviewed": {
+    "type": "Claim",
+    "appearance": {
+      "type": "Article",
+      "url": "<url>",
+      "headline": "<headline>",
+      "datePublished": "<ISO-8601>"
+    }
+  },
+  "reviewRating": {
+    "type": "Rating",
+    "ratingValue": 1,
+    "bestRating": 5,
+    "worstRating": 1,
+    "alternateName": "False",
+    "ratingExplanation": "<explanation>"
+  }
+}
+```
+
+This NIP defines a reference rating scale at the namespace `nostr.dev/scale/v1` (provisional pending NIP merge) with values 1–5: False, Mostly False, Mixed, Mostly True, True. Reviewers MAY use other scales (PolitiFact's six-point, Snopes' fourteen-point, etc.) by setting `rating-scale` to a unique namespace identifier and providing a human-readable label in `rating-name`. Consumers rendering an unknown scale SHOULD display the `rating-name` text and a normalized 0–1 bar derived from `(rating-value - rating-worst) / (rating-best - rating-worst)`.
+
+The `evidence` tag MAY appear multiple times. Each value SHOULD be a URL or a `nostr:nevent1...` / `nostr:naddr1...`. Evidence pointing to a NOSTR event SHOULD also use an `e` or `a` tag for relay indexing.
+
+## Kind 30052 — Rating
+
+Addressable. An overall ordinal review of a URL, lighter than a fact-check.
+
+```jsonc
+{
+  "kind": 30052,
+  "tags": [
+    ["d", "rating:<sha256(url + '|' + author_pubkey)>.slice(0,16)"],
+    ["r", "<url>"],
+    ["i", "<url>"], ["k", "web"],
+    ["rating-value", "4"],
+    ["rating-best", "5"],
+    ["rating-name", "<short label>"],
+    ["t", "<topic>"]
+  ],
+  "content": "<plain markdown rationale>"
+}
+```
+
+A given (author, URL) pair has at most one rating, since the `d` tag includes the author's pubkey and is therefore unique per (author, URL).
+
+## Kind 9803 — HelpfulnessVote
+
+Regular event. The atomic input to bridging-based ranking algorithms (à la Community Notes / Birdwatch). One vote per (voter, target) pair; clients deduplicate by `created_at`, tie-breaking on event id.
+
+```jsonc
+{
+  "kind": 9803,
+  "tags": [
+    ["a", "<kind>:<author-pubkey>:<d-tag>", "<relay-hint>"],
+    ["e", "<event-id>", "<relay-hint>"],
+    ["p", "<author-pubkey>"],
+    ["helpful", "1"]
+  ],
+  "content": "<optional rationale>"
+}
+```
+
+The `helpful` tag value MUST be one of:
+
+- `1` — helpful
+- `-1` — not helpful
+- `0` — needs more context (a "soft no" that signals the annotation is unclear or insufficient rather than wrong)
+
+Helpfulness votes are typically applied to kind 30050 / 30051 / 30052 events, but MAY be applied to any kind whose author intends to receive them.
+
+A user revoking a vote SHOULD do so via [NIP-09](09.md) deletion request rather than by publishing a new vote with a different value. Clients SHOULD honor NIP-09 deletions of helpfulness votes.
+
+## Kind 30053 — TopicTrust
+
+Addressable. Topic-scoped trust assertion: "I trust pubkey X on topic Y."
+
+```jsonc
+{
+  "kind": 30053,
+  "tags": [
+    ["d", "trust:<topic>:<target-pubkey-hex-prefix>"],
+    ["p", "<target-pubkey>"],
+    ["t", "<topic>"],
+    ["weight", "85"],
+    ["expires", "<unix-time>"]
+  ],
+  "content": "<optional public rationale>"
+}
+```
+
+The `weight` tag is an integer 0–100. The `expires` tag is optional; assertions without expiration SHOULD be reaffirmed by clients on a periodic basis (e.g., yearly) to demonstrate the assertion is still held.
+
+The `d` tag's `<topic>` SHOULD be the same value used in `t` tags throughout the rest of NOSTR (lowercase, hyphenated). The `<target-pubkey-hex-prefix>` is the first 16 hex chars of the target pubkey.
+
+A user MAY publish a TopicTrust assertion encrypted to themselves (using [NIP-44](44.md) v2 with their own pubkey as recipient) when they want to record an assertion privately. Encrypted assertions appear in NOSTR with `content` as the NIP-44 ciphertext. Encrypted assertions do NOT contribute to other users' bridging scores.
+
+Clients computing trust graphs SHOULD treat the absence of an assertion as neutral, NOT as distrust. A separate distrust primitive is out of scope for this NIP and should be modeled via [NIP-51](51.md) mute lists or [NIP-56](56.md) reports.
+
+## Kind 30023 — `responds-to` tag (extension)
+
+A long-form article (kind 30023) MAY declare that it responds to one or more other pieces of content. Each response is a separate `responds-to` tag:
+
+```
+["responds-to", "<target>", "<relationship>", "<relay-hint>"?]
+```
+
+Where:
+
+- `<target>` is one of: a normalized URL, a `nostr:nevent1...`, or a `nostr:naddr1...`.
+- `<relationship>` is one of: `rebuts`, `supports`, `extends`, `contextualizes`, `corrects`.
+- `<relay-hint>` is optional and meaningful only for `nostr:` targets.
+
+Authors SHOULD also emit an `r` tag with the same target URL (or, for `nostr:` targets, an `a` or `e` tag) to enable relay-side indexing — multi-letter tag names are not indexed by default per NIP-01.
+
+Consumers visiting a URL or NOSTR event that is the target of a `responds-to` SHOULD surface the responding articles in addition to comments and other annotations. A standard query:
+
+```jsonc
+{ "kinds": [30023], "#r": ["<target-url>"], "limit": 50 }
+```
+
+Filtered client-side to events that carry a matching `responds-to` tag.
+
+## Querying
+
+A client wishing to display all metadata for a URL SHOULD issue these filters in parallel and merge the results:
+
+```jsonc
+[
+  { "kinds": [30050, 30051, 30052], "#r": ["<url>"], "limit": 200 },
+  { "kinds": [9802], "#r": ["<url>"], "limit": 100 },
+  { "kinds": [1111], "#i": ["<url>"], "limit": 200 },
+  { "kinds": [1985], "#r": ["<url>"], "limit": 100 },
+  { "kinds": [17], "#i": ["<url>"], "limit": 200 },
+  { "kinds": [1984], "#r": ["<url>"], "limit": 50 },
+  { "kinds": [30023], "#r": ["<url>"], "limit": 50 }
+]
+```
+
+The kind 30023 query catches articles published with `responds-to`; clients filter client-side to those with a matching `responds-to` tag.
+
+A client wishing to display helpfulness aggregates for a set of metadata events SHOULD then issue a follow-up `#a` query against kind 9803 keyed by the addressable coordinates of those events.
+
+## Privacy and trust
+
+This NIP makes events public by default. Clients MUST clearly indicate at publish time that an event will be visible to anyone with relay access. Encrypted variants (where defined, as in TopicTrust) MUST be opt-in.
+
+Reading metadata is private — relay queries do not authenticate the reader — provided the relay is not under [NIP-42](42.md) authentication. Clients SHOULD avoid using NIP-42-authenticated relays for metadata read queries unless the user has explicitly enabled such a relay.
+
+This NIP does not specify a ranking algorithm. Recommended approaches:
+
+- **First-order trust** — show events from authors in the user's [NIP-02](02.md) contact list and/or the user's TopicTrust list, hide others by default.
+- **Bridging-based ranking** — for clients with the compute budget or a [NIP-85](85.md) trusted-assertion provider, rank events by a Birdwatch-style matrix-factorization intercept term computed over (rater, event, helpfulness vote) triples. Notes that score helpful across diverse rater clusters surface higher than notes that score helpful within a single cluster.
+
+## Reference implementations
+
+- [x-ray browser extension](https://github.com/bryanmatthewsimonson/xray) — Phase 9, currently shipping kinds 30050 + the `responds-to` extension; remaining kinds scaffolded.
+- *(second client, TBD pre-merge)*

--- a/src/shared/archive-cache.js
+++ b/src/shared/archive-cache.js
@@ -39,9 +39,24 @@
 import { Utils } from './utils.js';
 
 const DB_NAME        = 'xray-archive';
-const DB_VERSION     = 1;
+const DB_VERSION     = 2;     // v2 (Phase 9a) added metadata stores
 const ARTICLES_STORE = 'articles';
 const MAX_ENTRIES    = 500;  // cheap starting budget; revisit if needed
+
+// Phase 9a metadata stores (XRAY_METADATA_SPEC.md §6, Implementation Plan §4).
+// All keyed on `eventId` so we can dedupe across relays. `urlHash`
+// indexes mirror the convention in `articles` for cross-store joins.
+export const ANNOTATIONS_STORE = 'annotations';
+export const FACTCHECKS_STORE  = 'factchecks';
+export const RATINGS_STORE     = 'ratings';
+export const HELPFULNESS_STORE = 'helpfulness';
+export const TRUST_GRAPH_STORE = 'trust_graph';
+
+// Per-URL eviction caps for metadata. Once exceeded, oldest-first within
+// the urlHash bucket. A global cap (5000 across all urlHashes) drives
+// the second eviction pass.
+export const ANNOTATIONS_PER_URL_CAP = 200;
+export const ANNOTATIONS_GLOBAL_CAP  = 5000;
 
 // ------------------------------------------------------------------
 // Helpers
@@ -95,11 +110,49 @@ export function openArchiveDb() {
 
         open.onupgradeneeded = (ev) => {
             const db = open.result;
-            if (!db.objectStoreNames.contains(ARTICLES_STORE)) {
+            const oldVersion = ev.oldVersion || 0;
+
+            // v1 — articles store (Phase 7).
+            if (oldVersion < 1 && !db.objectStoreNames.contains(ARTICLES_STORE)) {
                 const store = db.createObjectStore(ARTICLES_STORE, { keyPath: 'urlHash' });
                 store.createIndex('lastAccessed',    'lastAccessed',    { unique: false });
                 store.createIndex('publishedToRelay','publishedToRelay',{ unique: false });
                 store.createIndex('cachedAt',        'cachedAt',        { unique: false });
+            }
+
+            // v2 — Phase 9a metadata stores. Each row's keyPath is
+            // `eventId`; `urlHash` is the join key against `articles`.
+            if (oldVersion < 2) {
+                if (!db.objectStoreNames.contains(ANNOTATIONS_STORE)) {
+                    const ann = db.createObjectStore(ANNOTATIONS_STORE, { keyPath: 'eventId' });
+                    ann.createIndex('urlHash',    'urlHash',    { unique: false });
+                    ann.createIndex('motivation', 'motivation', { unique: false });
+                    ann.createIndex('author',     'author',     { unique: false });
+                    ann.createIndex('createdAt',  'createdAt',  { unique: false });
+                }
+                if (!db.objectStoreNames.contains(FACTCHECKS_STORE)) {
+                    const fc = db.createObjectStore(FACTCHECKS_STORE, { keyPath: 'eventId' });
+                    fc.createIndex('urlHash',     'urlHash',     { unique: false });
+                    fc.createIndex('ratingValue', 'ratingValue', { unique: false });
+                    fc.createIndex('createdAt',   'createdAt',   { unique: false });
+                }
+                if (!db.objectStoreNames.contains(RATINGS_STORE)) {
+                    const r = db.createObjectStore(RATINGS_STORE, { keyPath: 'eventId' });
+                    r.createIndex('urlHash',    'urlHash',    { unique: false });
+                    r.createIndex('createdAt',  'createdAt',  { unique: false });
+                }
+                if (!db.objectStoreNames.contains(HELPFULNESS_STORE)) {
+                    const h = db.createObjectStore(HELPFULNESS_STORE, { keyPath: 'eventId' });
+                    h.createIndex('targetEventId', 'targetEventId', { unique: false });
+                    h.createIndex('voter',         'voter',         { unique: false });
+                    h.createIndex('createdAt',     'createdAt',     { unique: false });
+                }
+                if (!db.objectStoreNames.contains(TRUST_GRAPH_STORE)) {
+                    // Materialized graph for the local user. Single row,
+                    // keyed on the local user's pubkey hex (so multi-
+                    // identity profiles can host distinct graphs).
+                    db.createObjectStore(TRUST_GRAPH_STORE, { keyPath: 'pubkey' });
+                }
             }
         };
         open.onsuccess = () => resolve(open.result);

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -12,6 +12,11 @@
 import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
 import { ContentExtractor } from './content-extractor.js';
+import { buildRespondsToTag, RESPONDS_TO_RELATIONSHIPS } from './metadata/builders.js';
+
+// Re-export the metadata helpers so callers that already import from
+// `event-builder.js` don't need a second import path. See spec §6.4.
+export { buildRespondsToTag, RESPONDS_TO_RELATIONSHIPS } from './metadata/builders.js';
 
 export const EventBuilder = {
   // Build NIP-23 article event (kind 30023)
@@ -106,7 +111,26 @@ export const EventBuilder = {
     if (article.byline) {
       tags.push(['author', article.byline]);
     }
-    
+
+    // Phase 9a — `responds-to` extension. Emit a tag for each declared
+    // response target (URL, naddr, or nevent). Per spec §6.4, also emit
+    // an indexed `r` tag for URL targets so relays can answer
+    // `#r=<url>` queries on the response side.
+    //
+    // Shape: article.respondsTo = [{ target, relationship, relayHint? }]
+    if (Array.isArray(article.respondsTo)) {
+      for (const ref of article.respondsTo) {
+        if (!ref || typeof ref.target !== 'string' || !ref.relationship) continue;
+        try {
+          tags.push(buildRespondsToTag(ref.target, ref.relationship, ref.relayHint || ''));
+          // Co-emit an `r` tag for URL targets (skip nostr: refs).
+          if (!/^nostr:/.test(ref.target)) {
+            tags.push(['r', ref.target]);
+          }
+        } catch (_) { /* invalid relationship; silently drop the entry */ }
+      }
+    }
+
     // Add entity tags
     const taggedPubkeys = new Set();
     for (const entityRef of entities) {

--- a/src/shared/metadata/anchor-capture.js
+++ b/src/shared/metadata/anchor-capture.js
@@ -1,0 +1,286 @@
+// Anchor capture — Phase 9a Day 2.
+//
+// Spec: XRAY_METADATA_SPEC.md §6.3 + §7 + Implementation Plan §6.
+//
+// Builds a W3C-Web-Annotation-style selector array from a user's text
+// selection. The output is what gets serialized into the kind 30050
+// event's content body so a future reader can locate the same span on
+// a page that may have been edited since the annotation was made.
+//
+// Two entry points:
+//
+//   - `buildSelectors(parts)` — PURE. Takes already-extracted strings
+//     and DOM-coordinate primitives; returns the selector array. This
+//     is what the test suite exercises.
+//
+//   - `captureFromSelection(selection, root)` — DOM-bound. Pulls the
+//     primitives out of a live `Selection` object and delegates to
+//     `buildSelectors`. Only meaningful in a content-script context.
+//
+// The selector array is ordered by robustness preference per the spec:
+//   1. TextQuoteSelector — exact + prefix + suffix
+//   2. RangeSelector     — XPath start/end + offsets
+//   3. CssSelector       — only if start container has a stable id
+
+const PREFIX_SUFFIX_CHARS = 32;
+const EXACT_LENGTH_CAP = 500;
+const EXACT_TRUNCATE_HEAD = 200;
+const EXACT_TRUNCATE_TAIL = 200;
+const ELLIPSIS_MARKER = '…'; // …
+
+/**
+ * Build a selector array from already-extracted primitives. Pure;
+ * does not touch the DOM.
+ *
+ * @param {object} parts
+ * @param {string} parts.exact         — selected text
+ * @param {string} [parts.prefix]      — text immediately preceding
+ * @param {string} [parts.suffix]      — text immediately following
+ * @param {string} [parts.startContainerXPath]
+ * @param {number} [parts.startOffset]
+ * @param {string} [parts.endContainerXPath]
+ * @param {number} [parts.endOffset]
+ * @param {string} [parts.startContainerId]      — stable id if present
+ * @param {string} [parts.startContainerCssPath] — fallback CSS path
+ * @param {string} [parts.lang]                  — page language
+ * @returns {{selectors: Array<object>, fullExact: string}}
+ *   The selector array suitable for inclusion under
+ *   `target.selector[]` in the JSON-LD body. `fullExact` is the
+ *   un-truncated exact text — callers MAY include it in the body's
+ *   `body.value` field if the selection was truncated for the
+ *   selector.
+ */
+export function buildSelectors(parts = {}) {
+  const exactRaw = String(parts.exact || '');
+  if (!exactRaw) return { selectors: [], fullExact: '' };
+
+  const truncated = truncateExact(exactRaw);
+
+  const selectors = [];
+
+  // 1) TextQuoteSelector — primary, robust to DOM changes.
+  const tqs = {
+    type: 'TextQuoteSelector',
+    exact: truncated.exact
+  };
+  const prefix = sliceTail(parts.prefix, PREFIX_SUFFIX_CHARS);
+  const suffix = sliceHead(parts.suffix, PREFIX_SUFFIX_CHARS);
+  if (prefix) tqs.prefix = prefix;
+  if (suffix) tqs.suffix = suffix;
+  selectors.push(tqs);
+
+  // 2) RangeSelector — secondary, used when TextQuoteSelector finds
+  //    multiple matches or none.
+  if (
+    typeof parts.startContainerXPath === 'string' &&
+    typeof parts.endContainerXPath === 'string' &&
+    Number.isFinite(parts.startOffset) &&
+    Number.isFinite(parts.endOffset)
+  ) {
+    selectors.push({
+      type: 'RangeSelector',
+      startContainer: parts.startContainerXPath,
+      startOffset: parts.startOffset,
+      endContainer: parts.endContainerXPath,
+      endOffset: parts.endOffset
+    });
+  }
+
+  // 3) CssSelector — fallback, only emitted when the container has a
+  //    *stable* id. Generated React class names look stable but flip
+  //    on every release; the spec says skip those. The caller is
+  //    responsible for the stability check.
+  if (typeof parts.startContainerId === 'string' && parts.startContainerId) {
+    selectors.push({
+      type: 'CssSelector',
+      value: '#' + cssEscape(parts.startContainerId)
+    });
+  } else if (typeof parts.startContainerCssPath === 'string' && parts.startContainerCssPath) {
+    selectors.push({
+      type: 'CssSelector',
+      value: parts.startContainerCssPath
+    });
+  }
+
+  return { selectors, fullExact: exactRaw };
+}
+
+/**
+ * Apply the spec's length cap on `exact`. If the selection is longer
+ * than 500 chars, keep the first 200 and last 200 with an ellipsis
+ * marker between them. The caller SHOULD also embed the full text in
+ * the annotation body so consumers that fail to anchor can still show
+ * what was selected.
+ *
+ * Visible-for-testing — exported indirectly via `buildSelectors`.
+ */
+function truncateExact(exact) {
+  if (exact.length <= EXACT_LENGTH_CAP) return { exact, truncated: false };
+  const head = exact.slice(0, EXACT_TRUNCATE_HEAD);
+  const tail = exact.slice(-EXACT_TRUNCATE_TAIL);
+  return {
+    exact: head + ' ' + ELLIPSIS_MARKER + ' ' + tail,
+    truncated: true
+  };
+}
+
+function sliceHead(s, n) {
+  if (typeof s !== 'string') return '';
+  return s.length > n ? s.slice(0, n) : s;
+}
+
+function sliceTail(s, n) {
+  if (typeof s !== 'string') return '';
+  return s.length > n ? s.slice(-n) : s;
+}
+
+/**
+ * Minimal CSS.escape polyfill (the function exists in browsers as
+ * `CSS.escape`, but we want to avoid depending on it for testability).
+ * Escapes the small set of chars that can break a `#id` selector.
+ */
+function cssEscape(str) {
+  return String(str).replace(/[^a-zA-Z0-9_-]/g, (c) =>
+    '\\' + c.charCodeAt(0).toString(16).padStart(2, '0') + ' '
+  );
+}
+
+// ------------------------------------------------------------------
+// DOM-bound helpers (content-script only)
+// ------------------------------------------------------------------
+
+/**
+ * Pull selector primitives out of a live `Selection` object and
+ * delegate to `buildSelectors`. Returns null if the selection is
+ * empty or collapsed.
+ *
+ * The `root` argument is the DOM root we treat as the article body.
+ * XPaths are computed relative to the document, but the prefix/suffix
+ * are read from the rendered text inside `root` so prefix/suffix do
+ * not leak text from the page chrome (header, footer, sidebar).
+ *
+ * @param {Selection} selection
+ * @param {Element} [root=document.body]
+ * @returns {ReturnType<typeof buildSelectors> | null}
+ */
+export function captureFromSelection(selection, root) {
+  if (!selection || typeof selection.rangeCount !== 'number' || selection.rangeCount === 0) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  if (!range || range.collapsed) return null;
+
+  const exact = String(selection.toString() || '');
+  if (!exact) return null;
+
+  const rootEl = root || (typeof document !== 'undefined' ? document.body : null);
+  if (!rootEl) {
+    // No DOM — return TextQuoteSelector only, with no prefix/suffix.
+    return buildSelectors({ exact });
+  }
+
+  // Prefix/suffix from the rendered text of `root`. We read up to
+  // PREFIX_SUFFIX_CHARS on each side. `Range`-based extraction is more
+  // accurate than walking textContent but harder to test; this naive
+  // textContent approach works for the typical article case.
+  const fullText = rootEl.textContent || '';
+  const exactIdx = fullText.indexOf(exact);
+  let prefix = '';
+  let suffix = '';
+  if (exactIdx >= 0) {
+    prefix = fullText.slice(Math.max(0, exactIdx - PREFIX_SUFFIX_CHARS), exactIdx);
+    suffix = fullText.slice(exactIdx + exact.length, exactIdx + exact.length + PREFIX_SUFFIX_CHARS);
+  }
+
+  // RangeSelector — XPath of start/end containers.
+  const startContainerXPath = xpathFor(range.startContainer, rootEl);
+  const endContainerXPath = xpathFor(range.endContainer, rootEl);
+
+  // CssSelector — only if start container's parent (or itself) has
+  // a stable id. We treat React-style generated ids (e.g. `:r0:`,
+  // `_h:42`) as unstable.
+  const startContainerEl = range.startContainer.nodeType === 1
+    ? range.startContainer
+    : range.startContainer.parentElement;
+  const stableId = startContainerEl && isStableId(startContainerEl.id || '')
+    ? startContainerEl.id
+    : null;
+
+  return buildSelectors({
+    exact,
+    prefix,
+    suffix,
+    startContainerXPath,
+    startOffset: range.startOffset,
+    endContainerXPath,
+    endOffset: range.endOffset,
+    startContainerId: stableId
+  });
+}
+
+/**
+ * Compute a positional XPath from `root` to `node`. Position-only,
+ * tag-aware. Does not use class names or text content (those break on
+ * publisher edits). Returns `''` if node is not under root.
+ */
+export function xpathFor(node, root) {
+  if (!node || !root) return '';
+  // Resolve to the parent element if node is a text/comment node.
+  let parts = [];
+  let cur = node;
+  // For text nodes we want `text()[N]`; for elements we want `tag[N]`.
+  while (cur && cur !== root) {
+    const parent = cur.parentNode || cur.parentElement;
+    if (!parent) return '';
+    const idx = childIndex(parent, cur);
+    if (cur.nodeType === 3) {
+      parts.unshift(`text()[${idx}]`);
+    } else if (cur.nodeType === 1) {
+      const tag = (cur.tagName || '').toLowerCase();
+      parts.unshift(`${tag}[${idx}]`);
+    } else {
+      // Comment / other — index by node().
+      parts.unshift(`node()[${idx}]`);
+    }
+    cur = parent;
+  }
+  if (cur !== root) return ''; // node was not under root
+  return '/' + parts.join('/');
+}
+
+/**
+ * 1-based index of `child` among its sibling nodes of the same type.
+ * Mirrors XPath semantics — text()[2] means the second text node
+ * sibling, not the second node overall.
+ */
+function childIndex(parent, child) {
+  if (!parent || !parent.childNodes) return 1;
+  let n = 0;
+  for (const sibling of parent.childNodes) {
+    if (sibling.nodeType === child.nodeType) {
+      if (child.nodeType === 1 && sibling.tagName !== child.tagName) continue;
+      n += 1;
+      if (sibling === child) return n;
+    }
+  }
+  return n || 1;
+}
+
+/**
+ * Heuristic: a "stable" id is one that doesn't look auto-generated by
+ * a framework. Stable: kebab-case slugs, snake_case, namespaces with
+ * dots. Unstable: emotion / styled-components / React fiber ids
+ * (`:r0:`, `_h:42`, `css-1abc23`, leading-digit), GUID-ish,
+ * hyperlong base64.
+ */
+export function isStableId(id) {
+  if (!id || typeof id !== 'string') return false;
+  if (id.length > 64) return false;
+  if (/^:r\w*:$/.test(id)) return false;            // React 18 useId
+  if (/^_h:/.test(id)) return false;                // emotion / styled
+  if (/^css-[a-z0-9]+$/i.test(id)) return false;    // emotion classnames-as-ids
+  if (/^[A-Fa-f0-9-]{16,}$/.test(id)) return false; // long hex / GUID
+  if (/^\d/.test(id)) return false;                 // leading digit
+  // Anything else: kebab/snake/dot/camelCase — probably stable.
+  return /^[A-Za-z][\w.\-:]*$/.test(id);
+}

--- a/src/shared/metadata/anchor-resolver.js
+++ b/src/shared/metadata/anchor-resolver.js
@@ -1,0 +1,316 @@
+// Anchor resolver — Phase 9a Day 3.
+//
+// Spec: XRAY_METADATA_SPEC.md §6.3 + §7 + Implementation Plan §6.
+//
+// Inverse of anchor-capture: given a selector array (from a stored
+// kind 30050 event) and a live page DOM, locate the span that the
+// annotation anchored to. Returns a { range, confidence, selectorUsed }
+// triple, or `null` if the annotation has been orphaned (the source
+// page changed beyond what the cascade can recover).
+//
+// Cascade (per the spec):
+//   1. TextQuoteSelector — prefix + exact + suffix → fall back to
+//      bare exact only if exact is unique on the page.
+//   2. RangeSelector — XPath start/end + offsets.
+//   3. CssSelector — anchor on the matched element; orient by exact.
+//
+// Confidence scoring (Plan §6):
+//   1.00 = exact prefix+exact+suffix match
+//   0.90 = prefix+exact match, suffix differs by ≤4 chars
+//   0.85 = exact+suffix match, prefix differs by ≤4 chars
+//   0.70 = bare exact, unique on page
+//   0.00 = ambiguous or no match (treated as orphaned)
+//
+// The 0.7 threshold is the cutoff for "trustworthy enough to render
+// as anchored." Below that we report `null` so the panel can render
+// the annotation with an "could not be located" badge instead of
+// pointing at the wrong span.
+
+const PARTIAL_DIFF_TOLERANCE = 4;
+
+/**
+ * Try each selector in order; return the highest-confidence resolved
+ * range that meets the threshold. Returns `null` if every selector
+ * fails or the best confidence is below threshold.
+ *
+ * @param {Array<object>} selectors  selector array from event content
+ * @param {Element} root             page root to resolve against
+ * @param {object} [opts]
+ * @param {number} [opts.threshold=0.7]
+ * @returns {{range: object, confidence: number, selectorUsed: string} | null}
+ */
+export function resolveSelectors(selectors, root, opts = {}) {
+  const { threshold = 0.7 } = opts;
+  if (!Array.isArray(selectors) || selectors.length === 0) return null;
+  if (!root) return null;
+
+  let best = null;
+  for (const sel of selectors) {
+    const result = trySelector(sel, root);
+    if (result && result.confidence >= threshold) {
+      // First selector to clear threshold wins (per cascade order).
+      return result;
+    }
+    if (result && (!best || result.confidence > best.confidence)) {
+      best = result;
+    }
+  }
+  return null;
+}
+
+/**
+ * Try a single selector. Returns null on failure.
+ */
+function trySelector(sel, root) {
+  if (!sel || typeof sel.type !== 'string') return null;
+  switch (sel.type) {
+    case 'TextQuoteSelector': return resolveTextQuote(sel, root);
+    case 'RangeSelector':     return resolveRange(sel, root);
+    case 'CssSelector':       return resolveCss(sel, root);
+    default:                  return null;
+  }
+}
+
+// ------------------------------------------------------------------
+// TextQuoteSelector
+// ------------------------------------------------------------------
+
+/**
+ * Resolve a TextQuoteSelector against the rendered text content of
+ * `root`. Search strategy:
+ *
+ *   1. prefix + exact + suffix — confidence 1.0 if unique
+ *   2. prefix + exact only — 0.9 if suffix mismatch ≤ 4 chars
+ *   3. exact + suffix only — 0.85 if prefix mismatch ≤ 4 chars
+ *   4. bare exact, unique — 0.7
+ *   5. otherwise → null (orphaned)
+ *
+ * Operates on `textContent` (string). The caller can map the resulting
+ * absolute offset back to a DOM Range if it needs to render a
+ * highlight (out of scope for v1; the side-panel "Jump to" button can
+ * be implemented as scrollIntoView on the surrounding element).
+ */
+export function resolveTextQuote(sel, root) {
+  const exact = String(sel.exact || '');
+  if (!exact) return null;
+  const text = root.textContent || '';
+
+  const prefix = String(sel.prefix || '');
+  const suffix = String(sel.suffix || '');
+
+  // Strategy 1 — full prefix+exact+suffix match.
+  if (prefix && suffix) {
+    const needle = prefix + exact + suffix;
+    const idx = indexOfUnique(text, needle);
+    if (idx >= 0) {
+      const exactStart = idx + prefix.length;
+      return {
+        range: { textStart: exactStart, textEnd: exactStart + exact.length },
+        confidence: 1.0,
+        selectorUsed: 'TextQuoteSelector'
+      };
+    }
+  }
+
+  // Strategy 2 — prefix + exact unique; suffix may differ slightly.
+  if (prefix) {
+    const needle = prefix + exact;
+    const idx = indexOfUnique(text, needle);
+    if (idx >= 0) {
+      const exactStart = idx + prefix.length;
+      const observedSuffix = text.slice(exactStart + exact.length, exactStart + exact.length + suffix.length);
+      const diff = stringDiff(suffix, observedSuffix);
+      if (diff <= PARTIAL_DIFF_TOLERANCE) {
+        return {
+          range: { textStart: exactStart, textEnd: exactStart + exact.length },
+          confidence: 0.9,
+          selectorUsed: 'TextQuoteSelector'
+        };
+      }
+    }
+  }
+
+  // Strategy 3 — exact + suffix unique; prefix may differ slightly.
+  if (suffix) {
+    const needle = exact + suffix;
+    const idx = indexOfUnique(text, needle);
+    if (idx >= 0) {
+      const exactStart = idx;
+      const observedPrefix = text.slice(Math.max(0, exactStart - prefix.length), exactStart);
+      const diff = stringDiff(prefix, observedPrefix);
+      if (diff <= PARTIAL_DIFF_TOLERANCE) {
+        return {
+          range: { textStart: exactStart, textEnd: exactStart + exact.length },
+          confidence: 0.85,
+          selectorUsed: 'TextQuoteSelector'
+        };
+      }
+    }
+  }
+
+  // Strategy 4 — bare exact, must be unique on the page.
+  const idx = indexOfUnique(text, exact);
+  if (idx >= 0) {
+    return {
+      range: { textStart: idx, textEnd: idx + exact.length },
+      confidence: 0.7,
+      selectorUsed: 'TextQuoteSelector'
+    };
+  }
+
+  // Strategy 5 — exact appears multiple times with no disambiguation,
+  // OR doesn't appear at all. Either way, orphaned.
+  return null;
+}
+
+/**
+ * Returns the index of `needle` in `haystack` IF AND ONLY IF it
+ * appears exactly once. Multiple matches → -1 (we don't guess).
+ */
+function indexOfUnique(haystack, needle) {
+  if (!needle) return -1;
+  const first = haystack.indexOf(needle);
+  if (first < 0) return -1;
+  const second = haystack.indexOf(needle, first + 1);
+  if (second >= 0) return -1;
+  return first;
+}
+
+/**
+ * Cheap string distance — counts non-matching characters in the
+ * length-aligned overlap. Not Levenshtein (which is expensive); we
+ * only need to detect "close enough" within a small tolerance.
+ */
+function stringDiff(a, b) {
+  if (a === b) return 0;
+  const la = a.length;
+  const lb = b.length;
+  if (la === 0) return lb;
+  if (lb === 0) return la;
+  let n = 0;
+  const minLen = Math.min(la, lb);
+  for (let i = 0; i < minLen; i++) {
+    if (a[i] !== b[i]) n += 1;
+  }
+  // Length differences count as additional diffs.
+  n += Math.abs(la - lb);
+  return n;
+}
+
+// ------------------------------------------------------------------
+// RangeSelector
+// ------------------------------------------------------------------
+
+/**
+ * Resolve a RangeSelector by walking the DOM along the stored XPath.
+ * Returns confidence 1.0 if both endpoints resolve and the captured
+ * `exact` from the resolved range matches; 0.7 if the XPath resolves
+ * but the resolved text doesn't match the original exact (still
+ * "trustworthy" enough to render); null otherwise.
+ *
+ * Resolution intentionally degrades gracefully — many publishers
+ * tweak the DOM structure without changing visible text, and the
+ * TextQuoteSelector should already have caught those. RangeSelector
+ * is the fallback for cases where the publisher edited the text but
+ * left the structure intact (e.g., a typo correction).
+ */
+export function resolveRange(sel, root) {
+  if (!root) return null;
+  const startNode = resolveXPath(sel.startContainer, root);
+  const endNode = resolveXPath(sel.endContainer, root);
+  if (!startNode || !endNode) return null;
+  // We don't reconstruct a live DOM Range here (the caller can do
+  // that with document.createRange()); we just return the resolved
+  // node references and offsets so the caller can build the Range.
+  return {
+    range: {
+      startContainer: startNode,
+      startOffset: sel.startOffset || 0,
+      endContainer: endNode,
+      endOffset: sel.endOffset || 0
+    },
+    confidence: 0.7,
+    selectorUsed: 'RangeSelector'
+  };
+}
+
+/**
+ * Walk `root` along an XPath of the form produced by
+ * `anchor-capture.xpathFor()`. Supports tag[N], text()[N], node()[N]
+ * — no axes, no predicates beyond positional, no functions.
+ *
+ * Returns the matched node or null if the path is unresolvable.
+ */
+export function resolveXPath(xpath, root) {
+  if (typeof xpath !== 'string' || !xpath || !root) return null;
+  let path = xpath;
+  if (path.startsWith('/')) path = path.slice(1);
+  const segments = path.split('/').filter(Boolean);
+  let cur = root;
+  for (const seg of segments) {
+    cur = stepXPath(cur, seg);
+    if (!cur) return null;
+  }
+  return cur;
+}
+
+function stepXPath(node, segment) {
+  // Parse `tag[N]` or `text()[N]` or `node()[N]`.
+  const m = /^([a-zA-Z]+|text\(\)|node\(\))(?:\[(\d+)\])?$/.exec(segment);
+  if (!m) return null;
+  const kind = m[1];
+  const idx = m[2] ? parseInt(m[2], 10) : 1;
+  const wantTextNodes = kind === 'text()';
+  const wantAnyNode = kind === 'node()';
+  const wantTag = !wantTextNodes && !wantAnyNode ? kind.toUpperCase() : null;
+
+  let n = 0;
+  for (const child of node.childNodes || []) {
+    if (wantTextNodes) {
+      if (child.nodeType !== 3) continue;
+      n += 1;
+      if (n === idx) return child;
+    } else if (wantAnyNode) {
+      n += 1;
+      if (n === idx) return child;
+    } else {
+      if (child.nodeType !== 1) continue;
+      if ((child.tagName || '').toUpperCase() !== wantTag) continue;
+      n += 1;
+      if (n === idx) return child;
+    }
+  }
+  return null;
+}
+
+// ------------------------------------------------------------------
+// CssSelector
+// ------------------------------------------------------------------
+
+/**
+ * Resolve a CssSelector. Confidence 0.7 (matches "bare exact" tier
+ * since CSS resolution is purely structural). Caller is responsible
+ * for orienting offset within the matched element.
+ *
+ * Implementation note: the runtime is responsible for providing a
+ * `querySelector` method on the root. In real browsers, `Element`
+ * has it built in. In the test fake DOM we pass through to a hand-
+ * rolled walker.
+ */
+export function resolveCss(sel, root) {
+  if (!root) return null;
+  const value = String(sel.value || '');
+  if (!value) return null;
+  let element = null;
+  try {
+    if (typeof root.querySelector === 'function') {
+      element = root.querySelector(value);
+    }
+  } catch (_) { /* selector parse error */ }
+  if (!element) return null;
+  return {
+    range: { container: element },
+    confidence: 0.7,
+    selectorUsed: 'CssSelector'
+  };
+}

--- a/src/shared/metadata/builders.js
+++ b/src/shared/metadata/builders.js
@@ -1,0 +1,427 @@
+// Metadata event builders — Phase 9a Day 5.
+//
+// Spec: XRAY_METADATA_SPEC.md §6 + Implementation Plan §9.
+//
+// Builds *unsigned* events for:
+//
+//   - Kind 30050 (Annotation)             — buildAnnotationEvent
+//   - Kind 30051 (FactCheck)               — buildFactCheckEvent (gated)
+//   - Kind 30052 (Rating)                  — buildRatingEvent (gated)
+//   - Kind 9803  (HelpfulnessVote)         — buildHelpfulnessEvent (gated)
+//   - Kind 30053 (TopicTrust)              — buildTopicTrustEvent (lives
+//     in topic-trust-builder.js so the trust-tab can import without
+//     pulling in the rest of this module)
+//
+// Plus: `buildRespondsToTag()` — the kind 30023 extension tag.
+//
+// All builders return `{ event, body, dTag }`:
+//   - `event`  — unsigned NIP-01 event (no `pubkey`, no `id`, no `sig`)
+//   - `body`   — the JSON-LD body string assigned to `event.content`
+//                (also returned separately so callers can verify shape
+//                without re-parsing)
+//   - `dTag`   — the deterministic d-tag value (also in `event.tags`)
+//
+// Signing happens via the existing Signer façade
+// (`src/shared/signer.js`); these builders don't touch crypto or
+// network. Tests verify each builder produces a tag set that matches
+// the spec's tag table verbatim.
+
+import { normalize } from './url-normalizer.js';
+
+// ------------------------------------------------------------------
+// Common helpers
+// ------------------------------------------------------------------
+
+/** SHA-256 of a UTF-8 string, returned as lowercase hex. */
+async function sha256Hex(s) {
+  const bytes = new TextEncoder().encode(s);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** First 16 hex chars of sha256(s). */
+async function sha16(s) {
+  return (await sha256Hex(s)).slice(0, 16);
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function tag(name, ...values) {
+  return [name, ...values.map((v) => (v === null || v === undefined ? '' : String(v)))];
+}
+
+/** Build the standard NIP-22 + NIP-73 anchor tags for a URL target. */
+function urlAnchorTags(url) {
+  return [
+    tag('r', url),
+    tag('i', url),
+    tag('k', 'web'),
+    tag('I', url),
+    tag('K', 'web')
+  ];
+}
+
+// ------------------------------------------------------------------
+// Annotation — kind 30050
+// ------------------------------------------------------------------
+
+const ANNO_CONTEXT = [
+  'http://www.w3.org/ns/anno.jsonld',
+  'https://x-ray.dev/ns/v1.jsonld'
+];
+
+/**
+ * Build an unsigned kind 30050 Annotation event.
+ *
+ * @param {object} args
+ * @param {string} args.url                    — target URL (will be normalized)
+ * @param {string} args.motivation             — primary motivation (see spec §6.3.2)
+ * @param {string|string[]} [args.motivations] — additional motivations
+ * @param {string} args.bodyMarkdown           — annotation body (Markdown)
+ * @param {Array<object>} [args.selectors]     — from anchor-capture.buildSelectors
+ * @param {string|string[]} [args.topic]       — `t` tag(s)
+ * @param {string} [args.lang='en']
+ * @param {string} [args.respondsToArticleAddress]
+ *   `30023:<pubkey>:<slug>` — when motivation is `responding-to`, the
+ *   reaction article we're pointing at.
+ * @param {object} [args.targetEvent]          — kind/id/relayHint for `e` tag
+ * @param {number} [args.createdAt]            — clock override for tests
+ * @returns {Promise<{event, body, dTag}>}
+ */
+export async function buildAnnotationEvent({
+  url,
+  motivation,
+  motivations,
+  bodyMarkdown,
+  selectors = [],
+  topic,
+  lang = 'en',
+  respondsToArticleAddress = null,
+  targetEvent = null,
+  createdAt = nowSeconds()
+} = {}) {
+  if (typeof url !== 'string' || !url) throw new Error('buildAnnotationEvent: url required');
+  if (typeof motivation !== 'string' || !motivation) {
+    throw new Error('buildAnnotationEvent: motivation required');
+  }
+
+  const normalizedUrl = normalize(url);
+
+  // Deterministic d-tag — see spec §6.3.1.
+  const selectorHash = selectors.length === 0
+    ? ''
+    : await sha256Hex(JSON.stringify(selectors));
+  const dTag = 'ann:' + (await sha16(
+    normalizedUrl + '|' + selectorHash + '|' + motivation
+  ));
+
+  const motivationList = uniqueStrings([motivation, ...arrayify(motivations)]);
+  const topicList = uniqueStrings(arrayify(topic));
+
+  const tags = [
+    tag('d', dTag),
+    ...urlAnchorTags(normalizedUrl),
+    ...motivationList.map((m) => tag('motivation', m)),
+    ...topicList.map((t) => tag('t', t)),
+    tag('lang', lang)
+  ];
+  if (respondsToArticleAddress) tags.push(tag('a', respondsToArticleAddress));
+  if (targetEvent && targetEvent.id) {
+    tags.push(tag('e', targetEvent.id, targetEvent.relayHint || ''));
+  }
+
+  const body = JSON.stringify({
+    '@context': ANNO_CONTEXT,
+    type: 'Annotation',
+    motivation: motivationList.length === 1 ? motivationList[0] : motivationList,
+    body: {
+      type: 'TextualBody',
+      format: 'text/markdown',
+      language: lang,
+      value: String(bodyMarkdown || '')
+    },
+    target: {
+      source: normalizedUrl,
+      selector: selectors
+    }
+  });
+
+  return {
+    event: { kind: 30050, created_at: createdAt, tags, content: body },
+    body,
+    dTag
+  };
+}
+
+// ------------------------------------------------------------------
+// FactCheck — kind 30051 (gated; data path lands in 9a)
+// ------------------------------------------------------------------
+
+const RATING_SCALE_DEFAULT = 'x-ray.dev/scale/v1';
+
+/**
+ * Build an unsigned kind 30051 FactCheck event.
+ *
+ * @param {object} args
+ * @param {string} args.url
+ * @param {string} args.claimReviewed       — the specific claim text
+ * @param {number|string} args.ratingValue
+ * @param {number} [args.ratingBest=5]
+ * @param {number} [args.ratingWorst=1]
+ * @param {string} args.ratingName
+ * @param {string} [args.ratingScale='x-ray.dev/scale/v1']
+ * @param {string} [args.ratingExplanation='']
+ * @param {Array<string>} [args.evidence]    — URLs / nostr: refs
+ * @param {string|string[]} [args.topic]
+ * @param {string} [args.lang='en']
+ * @param {object} [args.appearance]         — { headline, datePublished } for ClaimReview
+ * @param {string} [args.relatedClaimEventId]
+ * @param {number} [args.createdAt]
+ */
+export async function buildFactCheckEvent({
+  url,
+  claimReviewed,
+  ratingValue,
+  ratingBest = 5,
+  ratingWorst = 1,
+  ratingName,
+  ratingScale = RATING_SCALE_DEFAULT,
+  ratingExplanation = '',
+  evidence = [],
+  topic,
+  lang = 'en',
+  appearance = null,
+  relatedClaimEventId = null,
+  createdAt = nowSeconds()
+} = {}) {
+  if (typeof url !== 'string' || !url) throw new Error('buildFactCheckEvent: url required');
+  if (typeof claimReviewed !== 'string' || !claimReviewed) {
+    throw new Error('buildFactCheckEvent: claimReviewed required');
+  }
+  if (ratingValue === undefined || ratingValue === null) {
+    throw new Error('buildFactCheckEvent: ratingValue required');
+  }
+  if (typeof ratingName !== 'string' || !ratingName) {
+    throw new Error('buildFactCheckEvent: ratingName required');
+  }
+
+  const normalizedUrl = normalize(url);
+  const dTag = 'factcheck:' + (await sha16(normalizedUrl + '|' + claimReviewed));
+  const topicList = uniqueStrings(arrayify(topic));
+
+  const tags = [
+    tag('d', dTag),
+    ...urlAnchorTags(normalizedUrl),
+    tag('claim-reviewed', claimReviewed),
+    tag('rating-value', String(ratingValue)),
+    tag('rating-best',  String(ratingBest)),
+    tag('rating-worst', String(ratingWorst)),
+    tag('rating-name',  ratingName),
+    tag('rating-scale', ratingScale),
+    tag('lang', lang),
+    ...topicList.map((t) => tag('t', t))
+  ];
+  if (relatedClaimEventId) tags.push(tag('e', relatedClaimEventId));
+  for (const ev of arrayify(evidence)) {
+    if (typeof ev === 'string' && ev) tags.push(tag('evidence', ev));
+  }
+
+  const body = JSON.stringify({
+    '@context': 'https://schema.org',
+    type: 'ClaimReview',
+    datePublished: new Date(createdAt * 1000).toISOString().slice(0, 10),
+    claimReviewed,
+    itemReviewed: {
+      type: 'Claim',
+      appearance: {
+        type: 'Article',
+        url: normalizedUrl,
+        ...(appearance && appearance.headline ? { headline: String(appearance.headline) } : {}),
+        ...(appearance && appearance.datePublished ? { datePublished: String(appearance.datePublished) } : {})
+      }
+    },
+    reviewRating: {
+      type: 'Rating',
+      ratingValue: typeof ratingValue === 'number' ? ratingValue : Number(ratingValue),
+      bestRating: ratingBest,
+      worstRating: ratingWorst,
+      alternateName: ratingName,
+      ratingExplanation: String(ratingExplanation || '')
+    }
+  });
+
+  return {
+    event: { kind: 30051, created_at: createdAt, tags, content: body },
+    body,
+    dTag
+  };
+}
+
+// ------------------------------------------------------------------
+// Rating — kind 30052 (gated)
+// ------------------------------------------------------------------
+
+/**
+ * Build an unsigned kind 30052 Rating event.
+ *
+ * @param {object} args
+ * @param {string} args.url
+ * @param {number|string} args.ratingValue
+ * @param {number} [args.ratingBest=5]
+ * @param {string} args.ratingName
+ * @param {string} args.content              — Markdown body
+ * @param {string|string[]} [args.topic]
+ * @param {string} args.authorPubkey         — needed for the d-tag
+ *   (so the same author can edit their rating)
+ * @param {number} [args.createdAt]
+ */
+export async function buildRatingEvent({
+  url,
+  ratingValue,
+  ratingBest = 5,
+  ratingName,
+  content,
+  topic,
+  authorPubkey,
+  createdAt = nowSeconds()
+} = {}) {
+  if (typeof url !== 'string' || !url) throw new Error('buildRatingEvent: url required');
+  if (ratingValue === undefined || ratingValue === null) {
+    throw new Error('buildRatingEvent: ratingValue required');
+  }
+  if (typeof ratingName !== 'string' || !ratingName) {
+    throw new Error('buildRatingEvent: ratingName required');
+  }
+  if (typeof authorPubkey !== 'string' || !authorPubkey) {
+    throw new Error('buildRatingEvent: authorPubkey required (used in deterministic d-tag)');
+  }
+
+  const normalizedUrl = normalize(url);
+  const dTag = 'rating:' + (await sha16(normalizedUrl + '|' + authorPubkey));
+  const topicList = uniqueStrings(arrayify(topic));
+
+  const tags = [
+    tag('d', dTag),
+    ...urlAnchorTags(normalizedUrl),
+    tag('rating-value', String(ratingValue)),
+    tag('rating-best',  String(ratingBest)),
+    tag('rating-name',  ratingName),
+    ...topicList.map((t) => tag('t', t))
+  ];
+
+  return {
+    event: { kind: 30052, created_at: createdAt, tags, content: String(content || '') },
+    body: String(content || ''),
+    dTag
+  };
+}
+
+// ------------------------------------------------------------------
+// HelpfulnessVote — kind 9803 (gated, but data accumulates from day one)
+// ------------------------------------------------------------------
+
+/**
+ * Build an unsigned kind 9803 HelpfulnessVote event.
+ *
+ * @param {object} args
+ * @param {string} args.targetCoord     — `30050:<pubkey>:<d>` or similar
+ * @param {string} [args.targetEventId]
+ * @param {string} [args.targetAuthor]
+ * @param {string} [args.relayHint]
+ * @param {1 | -1 | 0} args.helpful
+ * @param {string} [args.rationale]
+ * @param {number} [args.createdAt]
+ */
+export function buildHelpfulnessEvent({
+  targetCoord,
+  targetEventId,
+  targetAuthor,
+  relayHint,
+  helpful,
+  rationale = '',
+  createdAt = nowSeconds()
+} = {}) {
+  if (typeof targetCoord !== 'string' || !targetCoord) {
+    throw new Error('buildHelpfulnessEvent: targetCoord required');
+  }
+  if (helpful !== 1 && helpful !== -1 && helpful !== 0) {
+    throw new Error('buildHelpfulnessEvent: helpful must be 1, -1, or 0');
+  }
+
+  const tags = [
+    tag('a', targetCoord, relayHint || '')
+  ];
+  if (targetEventId) tags.push(tag('e', targetEventId, relayHint || ''));
+  if (targetAuthor) tags.push(tag('p', targetAuthor));
+  tags.push(tag('helpful', String(helpful)));
+
+  return {
+    event: { kind: 9803, created_at: createdAt, tags, content: String(rationale || '') },
+    body: String(rationale || ''),
+    dTag: null    // 9803 is regular, not addressable
+  };
+}
+
+// ------------------------------------------------------------------
+// `responds-to` tag for kind 30023 (extension)
+// ------------------------------------------------------------------
+
+const ALLOWED_RELATIONSHIPS = new Set([
+  'rebuts', 'supports', 'extends', 'contextualizes', 'corrects'
+]);
+
+/**
+ * Build a `["responds-to", target, relationship, relayHint?]` tag for
+ * inclusion in a kind 30023 article event. See spec §6.4.
+ *
+ * @param {string} target           — URL or `nostr:naddr1...` / `nostr:nevent1...`
+ * @param {string} relationship     — one of: rebuts / supports / extends /
+ *                                   contextualizes / corrects
+ * @param {string} [relayHint]
+ * @returns {Array<string>}
+ */
+export function buildRespondsToTag(target, relationship, relayHint = '') {
+  if (typeof target !== 'string' || !target) {
+    throw new Error('buildRespondsToTag: target required');
+  }
+  if (!ALLOWED_RELATIONSHIPS.has(relationship)) {
+    throw new Error('buildRespondsToTag: relationship must be one of ' +
+      Array.from(ALLOWED_RELATIONSHIPS).join(', '));
+  }
+  // Normalize URL targets so cross-reader hashing agrees. Leave nostr:
+  // refs alone.
+  const normalizedTarget = /^nostr:/.test(target) ? target : normalize(target);
+  return relayHint
+    ? ['responds-to', normalizedTarget, relationship, relayHint]
+    : ['responds-to', normalizedTarget, relationship];
+}
+
+/** The set of valid relationship values, exported for UI dropdowns. */
+export const RESPONDS_TO_RELATIONSHIPS = Object.freeze(
+  Array.from(ALLOWED_RELATIONSHIPS)
+);
+
+// ------------------------------------------------------------------
+// Internal helpers
+// ------------------------------------------------------------------
+
+function arrayify(v) {
+  if (v === undefined || v === null) return [];
+  if (Array.isArray(v)) return v;
+  return [v];
+}
+
+function uniqueStrings(arr) {
+  const seen = new Set();
+  const out = [];
+  for (const v of arr) {
+    if (typeof v !== 'string' || !v) continue;
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}

--- a/src/shared/metadata/builders.js
+++ b/src/shared/metadata/builders.js
@@ -53,25 +53,39 @@ function tag(name, ...values) {
   return [name, ...values.map((v) => (v === null || v === undefined ? '' : String(v)))];
 }
 
-/** Build the standard NIP-22 + NIP-73 anchor tags for a URL target. */
-function urlAnchorTags(url) {
-  return [
+/**
+ * Build the URL anchor tags for a metadata event.
+ *
+ * Every kind carries the NIP-73 trio `r` + `i` + `k=web`. Only the
+ * Annotation kind (30050) additionally carries the NIP-22 root-scope
+ * pair `I` + `K=web` — annotations are also valid NIP-22 comments and
+ * surface in NIP-22 readers (per the NIP draft's intro). FactCheck
+ * (30051) and Rating (30052) are standalone structured kinds, not
+ * NIP-22 comments, so they omit `I`/`K` — matching the per-kind tag
+ * examples in NIP_DRAFT.md.
+ */
+function urlAnchorTags(url, { nip22Root = false } = {}) {
+  const tags = [
     tag('r', url),
     tag('i', url),
-    tag('k', 'web'),
-    tag('I', url),
-    tag('K', 'web')
+    tag('k', 'web')
   ];
+  if (nip22Root) {
+    tags.push(tag('I', url));
+    tags.push(tag('K', 'web'));
+  }
+  return tags;
 }
 
 // ------------------------------------------------------------------
 // Annotation — kind 30050
 // ------------------------------------------------------------------
 
-const ANNO_CONTEXT = [
-  'http://www.w3.org/ns/anno.jsonld',
-  'https://x-ray.dev/ns/v1.jsonld'
-];
+// NIP_DRAFT.md specifies the single W3C Web Annotation context. The
+// xray-private `x-ray.dev/ns/v1.jsonld` context from the spec draft
+// was dropped: the body emits only standard W3C anno vocabulary, so a
+// vendor context adds nothing, and a NIP must be vendor-neutral.
+const ANNO_CONTEXT = 'http://www.w3.org/ns/anno.jsonld';
 
 /**
  * Build an unsigned kind 30050 Annotation event.
@@ -88,6 +102,9 @@ const ANNO_CONTEXT = [
  *   `30023:<pubkey>:<slug>` — when motivation is `responding-to`, the
  *   reaction article we're pointing at.
  * @param {object} [args.targetEvent]          — kind/id/relayHint for `e` tag
+ * @param {string} [args.correctionType]       — when a motivation is
+ *   `correcting`, one of: headline / quote / stat / name / date / other.
+ *   Emitted as a `correction-type` tag (NIP_DRAFT.md kind 30050).
  * @param {number} [args.createdAt]            — clock override for tests
  * @returns {Promise<{event, body, dTag}>}
  */
@@ -101,6 +118,7 @@ export async function buildAnnotationEvent({
   lang = 'en',
   respondsToArticleAddress = null,
   targetEvent = null,
+  correctionType = null,
   createdAt = nowSeconds()
 } = {}) {
   if (typeof url !== 'string' || !url) throw new Error('buildAnnotationEvent: url required');
@@ -121,13 +139,31 @@ export async function buildAnnotationEvent({
   const motivationList = uniqueStrings([motivation, ...arrayify(motivations)]);
   const topicList = uniqueStrings(arrayify(topic));
 
+  // Annotations are also valid NIP-22 comments → carry the `I`/`K`
+  // root-scope pair (nip22Root: true).
   const tags = [
     tag('d', dTag),
-    ...urlAnchorTags(normalizedUrl),
+    ...urlAnchorTags(normalizedUrl, { nip22Root: true }),
     ...motivationList.map((m) => tag('motivation', m)),
     ...topicList.map((t) => tag('t', t)),
     tag('lang', lang)
   ];
+
+  // `correction-type` — NIP_DRAFT.md: SHOULD accompany a `correcting`
+  // motivation. We only emit it when the motivation set actually
+  // includes `correcting`, so a stray param can't mislabel an event.
+  if (correctionType) {
+    const ALLOWED_CORRECTION_TYPES = ['headline', 'quote', 'stat', 'name', 'date', 'other'];
+    if (!ALLOWED_CORRECTION_TYPES.includes(correctionType)) {
+      throw new Error('buildAnnotationEvent: correctionType must be one of ' +
+        ALLOWED_CORRECTION_TYPES.join(', '));
+    }
+    if (!motivationList.includes('correcting')) {
+      throw new Error('buildAnnotationEvent: correctionType requires a `correcting` motivation');
+    }
+    tags.push(tag('correction-type', correctionType));
+  }
+
   if (respondsToArticleAddress) tags.push(tag('a', respondsToArticleAddress));
   if (targetEvent && targetEvent.id) {
     tags.push(tag('e', targetEvent.id, targetEvent.relayHint || ''));
@@ -160,7 +196,10 @@ export async function buildAnnotationEvent({
 // FactCheck — kind 30051 (gated; data path lands in 9a)
 // ------------------------------------------------------------------
 
-const RATING_SCALE_DEFAULT = 'x-ray.dev/scale/v1';
+// NIP_DRAFT.md and the implementation plan both name the reference
+// rating scale `nostr.dev/scale/v1` (vendor-neutral). The metadata
+// spec draft said `x-ray.dev/scale/v1`; the NIP wins for wire format.
+const RATING_SCALE_DEFAULT = 'nostr.dev/scale/v1';
 
 /**
  * Build an unsigned kind 30051 FactCheck event.
@@ -172,11 +211,10 @@ const RATING_SCALE_DEFAULT = 'x-ray.dev/scale/v1';
  * @param {number} [args.ratingBest=5]
  * @param {number} [args.ratingWorst=1]
  * @param {string} args.ratingName
- * @param {string} [args.ratingScale='x-ray.dev/scale/v1']
+ * @param {string} [args.ratingScale='nostr.dev/scale/v1']
  * @param {string} [args.ratingExplanation='']
  * @param {Array<string>} [args.evidence]    — URLs / nostr: refs
  * @param {string|string[]} [args.topic]
- * @param {string} [args.lang='en']
  * @param {object} [args.appearance]         — { headline, datePublished } for ClaimReview
  * @param {string} [args.relatedClaimEventId]
  * @param {number} [args.createdAt]
@@ -192,7 +230,6 @@ export async function buildFactCheckEvent({
   ratingExplanation = '',
   evidence = [],
   topic,
-  lang = 'en',
   appearance = null,
   relatedClaimEventId = null,
   createdAt = nowSeconds()
@@ -212,6 +249,8 @@ export async function buildFactCheckEvent({
   const dTag = 'factcheck:' + (await sha16(normalizedUrl + '|' + claimReviewed));
   const topicList = uniqueStrings(arrayify(topic));
 
+  // FactCheck is a standalone structured kind, not a NIP-22 comment —
+  // r/i/k only, no I/K (NIP_DRAFT.md kind 30051).
   const tags = [
     tag('d', dTag),
     ...urlAnchorTags(normalizedUrl),
@@ -221,7 +260,6 @@ export async function buildFactCheckEvent({
     tag('rating-worst', String(ratingWorst)),
     tag('rating-name',  ratingName),
     tag('rating-scale', ratingScale),
-    tag('lang', lang),
     ...topicList.map((t) => tag('t', t))
   ];
   if (relatedClaimEventId) tags.push(tag('e', relatedClaimEventId));

--- a/src/shared/metadata/feature-flags.js
+++ b/src/shared/metadata/feature-flags.js
@@ -1,0 +1,157 @@
+// Feature flags — Phase 9a Day 5.
+//
+// Spec: Implementation Plan §14.
+//
+// Single source of truth for which Phase 9 features are user-visible.
+// Day-1 motivations:
+//   - Scaffold the deferred kinds (30051 / 30052 / 9803) in Phase 9a
+//     so the data pipes are tested and the schemas are correct.
+//     Flipping `factchecks: true` in 9b becomes a UI-surface change,
+//     not a data-model change. Same for ratings / helpfulnessVoting.
+//   - Reader-side: the SW always accepts incoming events of every
+//     kind. Only PUBLISH paths and panel TABS are gated. So a user
+//     who flips the flag manually starts contributing to the bridging
+//     dataset before the v3 ranker ships.
+//
+// Override mechanism:
+//   chrome.storage.local key `xray:flags`, plain object of
+//   `{ flagName: boolean }`. The Advanced settings tab will expose a
+//   "show experimental flags" disclosure in Week 2; for now flags
+//   can be flipped via DevTools.
+
+export const FLAGS_DEFAULTS = Object.freeze({
+  // Live in 9a:
+  annotations: true,
+  respondsTo: true,
+  topicTrust: true,
+  trustGraphFilter: true,
+
+  // Scaffolded but UI-gated in 9a; flip in 9b/9c:
+  factchecks: false,
+  ratings: false,
+  helpfulnessVoting: false, // UI gate; SW always accepts incoming votes
+  bridgingRanking: false,   // v3
+  transitiveTrust: false    // v2
+});
+
+/**
+ * In-memory flag cache. Populated by `loadFlags`; refreshed when the
+ * SW receives a `xray:flags:reload` ping. Read with `isEnabled()`.
+ */
+let _flags = { ...FLAGS_DEFAULTS };
+
+/**
+ * Hydrate the in-memory flag cache from chrome.storage.local. Safe to
+ * call multiple times. Falls back to defaults on read error.
+ *
+ * @returns {Promise<typeof FLAGS_DEFAULTS>} the resolved flag map
+ */
+export async function loadFlags() {
+  try {
+    const overrides = await readOverridesFromStorage();
+    _flags = { ...FLAGS_DEFAULTS, ...sanitize(overrides) };
+  } catch (_) {
+    _flags = { ...FLAGS_DEFAULTS };
+  }
+  return _flags;
+}
+
+/**
+ * Synchronous read for hot paths. Returns the last value loaded by
+ * `loadFlags` (or the defaults if `loadFlags` has never been called).
+ *
+ * @param {keyof typeof FLAGS_DEFAULTS} flag
+ * @returns {boolean}
+ */
+export function isEnabled(flag) {
+  if (!Object.prototype.hasOwnProperty.call(FLAGS_DEFAULTS, flag)) return false;
+  return _flags[flag] === true;
+}
+
+/**
+ * Returns a snapshot of the current flag map (for diagnostics / the
+ * Advanced settings tab UI).
+ */
+export function snapshot() {
+  return { ..._flags };
+}
+
+/**
+ * Persist a flag override. Used by the Advanced settings tab. Pass
+ * `value === null` to revert to the default.
+ *
+ * @param {keyof typeof FLAGS_DEFAULTS} flag
+ * @param {boolean | null} value
+ * @returns {Promise<void>}
+ */
+export async function setOverride(flag, value) {
+  if (!Object.prototype.hasOwnProperty.call(FLAGS_DEFAULTS, flag)) {
+    throw new Error('Unknown flag: ' + flag);
+  }
+  const overrides = (await readOverridesFromStorage()) || {};
+  if (value === null) delete overrides[flag];
+  else overrides[flag] = !!value;
+  await writeOverridesToStorage(overrides);
+  await loadFlags();
+}
+
+/**
+ * Reset all overrides. Useful for tests and "restore defaults" UI.
+ */
+export async function resetOverrides() {
+  await writeOverridesToStorage({});
+  await loadFlags();
+}
+
+// ------------------------------------------------------------------
+// Storage shim
+// ------------------------------------------------------------------
+
+const STORAGE_KEY = 'xray:flags';
+
+function readOverridesFromStorage() {
+  return new Promise((resolve) => {
+    const area = chromeStorage();
+    if (!area) return resolve({});
+    try {
+      area.get([STORAGE_KEY], (res) => {
+        const raw = res && res[STORAGE_KEY];
+        if (raw === undefined || raw === null) return resolve({});
+        if (typeof raw === 'string') {
+          try { return resolve(JSON.parse(raw) || {}); } catch (_) { return resolve({}); }
+        }
+        if (typeof raw === 'object') return resolve(raw || {});
+        return resolve({});
+      });
+    } catch (_) { resolve({}); }
+  });
+}
+
+function writeOverridesToStorage(overrides) {
+  return new Promise((resolve) => {
+    const area = chromeStorage();
+    if (!area) return resolve();
+    try {
+      area.set({ [STORAGE_KEY]: JSON.stringify(overrides || {}) }, () => resolve());
+    } catch (_) { resolve(); }
+  });
+}
+
+function chromeStorage() {
+  if (typeof browser !== 'undefined' && browser.storage && browser.storage.local) {
+    return browser.storage.local;
+  }
+  if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+    return chrome.storage.local;
+  }
+  return null;
+}
+
+function sanitize(overrides) {
+  const out = {};
+  if (!overrides || typeof overrides !== 'object') return out;
+  for (const key of Object.keys(FLAGS_DEFAULTS)) {
+    if (typeof overrides[key] === 'boolean') out[key] = overrides[key];
+  }
+  return out;
+}

--- a/src/shared/metadata/ranker.js
+++ b/src/shared/metadata/ranker.js
@@ -1,0 +1,65 @@
+// Ranker — Phase 9a Day 5.
+//
+// Spec: XRAY_METADATA_SPEC.md §8.1 + Implementation Plan §8.
+//
+// v1 implements layer 1 only — a binary trust filter. Annotations from
+// authors in the user's first-order trust graph go in `trusted`; the
+// rest go in `untrusted` (only computed when `includeUntrusted`).
+// v3 will add bridging-based ranking in the same return shape.
+
+import { isTrusted } from './trust-graph.js';
+
+/**
+ * Rank a list of annotations against a trust-graph state.
+ *
+ * @param {Array<object>} annotations
+ *   Each must have at least `pubkey` (author) and `created_at`. Event
+ *   id (for tie-break) is read from `id`.
+ * @param {object} graphState  — from trust-graph.composeGraph
+ * @param {object} [opts]
+ * @param {string} [opts.topic]              — topic for `isTrusted`
+ * @param {number} [opts.threshold=50]
+ * @param {boolean} [opts.includeUntrusted=false]
+ * @param {boolean} [opts.followsTrustAllTopics=true]
+ * @returns {{trusted: Array, untrusted: Array, bridging: null}}
+ */
+export function rankAnnotations(annotations, graphState, opts = {}) {
+  const {
+    topic = null,
+    threshold = 50,
+    includeUntrusted = false,
+    followsTrustAllTopics = true
+  } = opts;
+
+  const arr = Array.isArray(annotations) ? annotations : [];
+  const trusted = [];
+  const untrusted = [];
+
+  for (const a of arr) {
+    if (!a || typeof a.pubkey !== 'string' || !a.pubkey) continue;
+    const ok = isTrusted(graphState, a.pubkey, topic, { threshold, followsTrustAllTopics });
+    if (ok) trusted.push(a);
+    else if (includeUntrusted) untrusted.push(a);
+  }
+
+  trusted.sort(byCreatedAtThenIdDesc);
+  untrusted.sort(byCreatedAtThenIdDesc);
+
+  return {
+    trusted,
+    untrusted,
+    bridging: null   // v3 placeholder
+  };
+}
+
+function byCreatedAtThenIdDesc(a, b) {
+  const aT = (a && a.created_at) || 0;
+  const bT = (b && b.created_at) || 0;
+  if (aT !== bT) return bT - aT;
+  // Same timestamp: tie-break lexicographically by event id, descending
+  // (so the larger id is first — gives stable, deterministic order).
+  const aId = (a && a.id) || '';
+  const bId = (b && b.id) || '';
+  if (aId === bId) return 0;
+  return aId < bId ? 1 : -1;
+}

--- a/src/shared/metadata/topic-trust-builder.js
+++ b/src/shared/metadata/topic-trust-builder.js
@@ -1,0 +1,68 @@
+// TopicTrust builder — kind 30053. Phase 9a Day 5.
+//
+// Spec: XRAY_METADATA_SPEC.md §6.8.
+//
+// Lives in its own module so the Trust tab in Settings can import the
+// builder without pulling in the rest of the metadata builders. Keeps
+// the trust-list editor's dep graph tight.
+
+import { normalize as _normalize } from './url-normalizer.js';
+
+function nowSeconds() { return Math.floor(Date.now() / 1000); }
+function tag(name, ...values) {
+  return [name, ...values.map((v) => (v == null ? '' : String(v)))];
+}
+
+/**
+ * Build an unsigned kind 30053 TopicTrust event.
+ *
+ * @param {object} args
+ * @param {string} args.targetPubkey   — hex pubkey we trust
+ * @param {string} args.topic          — short slug (e.g. `bitcoin`)
+ * @param {number} args.weight         — 0..100
+ * @param {string} [args.rationale]    — free-text content
+ * @param {number} [args.expires]      — unix seconds; 0 = never
+ * @param {number} [args.createdAt]    — clock override for tests
+ * @returns {{event: object, dTag: string}}
+ */
+export function buildTopicTrustEvent({
+  targetPubkey,
+  topic,
+  weight,
+  rationale = '',
+  expires = 0,
+  createdAt = nowSeconds()
+} = {}) {
+  if (typeof targetPubkey !== 'string' || !/^[0-9a-fA-F]{64}$/.test(targetPubkey)) {
+    throw new Error('buildTopicTrustEvent: targetPubkey must be 64-hex');
+  }
+  if (typeof topic !== 'string' || !topic) {
+    throw new Error('buildTopicTrustEvent: topic required');
+  }
+  if (!Number.isFinite(weight) || weight < 0 || weight > 100) {
+    throw new Error('buildTopicTrustEvent: weight must be 0..100');
+  }
+
+  // Deterministic d-tag — `trust:<topic>:<target-prefix>`. Prefix
+  // length 16 keeps the d-tag short while remaining unambiguous in
+  // practice. Replaceable-event semantics mean re-publishing
+  // overwrites the prior assertion.
+  const dTag = 'trust:' + topic + ':' + targetPubkey.toLowerCase().slice(0, 16);
+
+  const tags = [
+    tag('d', dTag),
+    tag('p', targetPubkey.toLowerCase()),
+    tag('t', topic),
+    tag('weight', String(Math.round(weight)))
+  ];
+  if (expires && Number.isFinite(expires)) tags.push(tag('expires', String(Math.round(expires))));
+
+  return {
+    event: { kind: 30053, created_at: createdAt, tags, content: String(rationale || '') },
+    dTag
+  };
+}
+
+// `_normalize` is imported but unused in this module today — kept so
+// future revisions that include URL fields don't accidentally drop it.
+void _normalize;

--- a/src/shared/metadata/trust-graph.js
+++ b/src/shared/metadata/trust-graph.js
@@ -1,0 +1,291 @@
+// Trust graph — Phase 9a Day 4.
+//
+// Spec: XRAY_METADATA_SPEC.md §8.1 + Implementation Plan §7.
+//
+// Composes the user's first-order trust graph from:
+//   - kind 3   (NIP-02 contact list — the user's social follows)
+//   - kind 30053 (TopicTrust — explicit "I trust X on topic Y")
+//
+// The graph answers two questions:
+//
+//   isTrusted(authorPubkey, topic, threshold) — boolean
+//   trustedAuthors(topic, threshold) — Set<pubkey>
+//
+// v1 ships layer 1 only (binary trust filter). Transitive walks (v2)
+// and bridging-based ranking (v3) consume different events; this
+// module is the foundation they build on.
+//
+// Persistence:
+//   - chrome.storage.local — small, fast first-paint cache (single
+//     key 'xr_trust_graph_<userPubkey>').
+//   - IDB trust_graph store — full graph; survives chrome.storage
+//     eviction.
+//
+// The graph is rebuilt on incoming kind 3 / kind 30053 events; the
+// SW invalidates and triggers a reload. Tests below exercise the
+// composition logic against synthesized event fixtures — the
+// persistence side is tested via mocks.
+
+/**
+ * @typedef {object} Kind3Event
+ * @property {number} kind
+ * @property {string} pubkey
+ * @property {Array<Array<string>>} tags
+ *   `["p", "<followed-pubkey>", "<relay-hint?>", "<petname?>"]` per NIP-02
+ * @property {number} created_at
+ * @property {string} id
+ *
+ * @typedef {object} Kind30053Event
+ * @property {30053} kind
+ * @property {string} pubkey
+ * @property {Array<Array<string>>} tags
+ *   - `["p", "<target-pubkey>"]`
+ *   - `["t", "<topic>"]`
+ *   - `["weight", "<0..100>"]`
+ *   - `["expires", "<unix-time>"]` (optional)
+ * @property {number} created_at
+ *
+ * @typedef {object} TrustGraphState
+ * @property {string} pubkey                                — owner
+ * @property {Set<string>} firstOrderFollows                — kind 3 derived
+ * @property {Map<string, Map<string, TrustEntry>>} topicTrust
+ *   topic → (target-pubkey → entry)
+ * @property {number} builtAt                               — unix seconds
+ *
+ * @typedef {object} TrustEntry
+ * @property {number} weight     — 0..100
+ * @property {number} expires    — unix seconds, 0 = never
+ * @property {string} eventId    — source kind 30053 event id
+ * @property {number} createdAt
+ */
+
+const DEFAULT_THRESHOLD = 50;
+
+/**
+ * Compose a TrustGraphState from raw events. Pure; no I/O.
+ *
+ * @param {object} args
+ * @param {string} args.pubkey               — graph owner's pubkey
+ * @param {Kind3Event} [args.contactList]    — latest kind 3 by `pubkey`
+ * @param {Kind30053Event[]} [args.topicTrustEvents]
+ * @param {number} [args.now]                — clock override for tests
+ * @returns {TrustGraphState}
+ */
+export function composeGraph({
+  pubkey,
+  contactList = null,
+  topicTrustEvents = [],
+  now = Math.floor(Date.now() / 1000)
+} = {}) {
+  if (typeof pubkey !== 'string' || !pubkey) {
+    throw new Error('composeGraph: owner pubkey required');
+  }
+
+  const firstOrderFollows = new Set();
+  if (contactList && Array.isArray(contactList.tags)) {
+    for (const tag of contactList.tags) {
+      if (Array.isArray(tag) && tag[0] === 'p' && typeof tag[1] === 'string') {
+        firstOrderFollows.add(tag[1]);
+      }
+    }
+  }
+
+  // Topic trust: latest event wins per (topic, target). The d-tag in
+  // kind 30053 is `trust:<topic>:<target-prefix>` so NIP-01 replaceable
+  // semantics make this work — but the *materialized* state has to
+  // pick the latest if we receive multiple in-flight versions.
+  const topicTrust = new Map();
+  const seen = new Map(); // key = topic + '|' + targetPubkey, value = createdAt
+
+  for (const evt of topicTrustEvents) {
+    if (!evt || evt.kind !== 30053) continue;
+    if (!Array.isArray(evt.tags)) continue;
+    let target = null;
+    let topic = null;
+    let weight = NaN;
+    let expires = 0;
+    for (const tag of evt.tags) {
+      if (!Array.isArray(tag)) continue;
+      if (tag[0] === 'p' && typeof tag[1] === 'string') target = tag[1];
+      else if (tag[0] === 't' && typeof tag[1] === 'string') topic = tag[1];
+      else if (tag[0] === 'weight' && typeof tag[1] === 'string') {
+        weight = parseInt(tag[1], 10);
+      }
+      else if (tag[0] === 'expires' && typeof tag[1] === 'string') {
+        expires = parseInt(tag[1], 10) || 0;
+      }
+    }
+    if (!target || !topic) continue;
+    if (!Number.isFinite(weight)) continue;
+    if (weight < 0 || weight > 100) continue;
+    if (expires && expires < now) continue; // skip expired
+
+    const key = topic + '|' + target;
+    const prevAt = seen.get(key);
+    if (prevAt !== undefined && evt.created_at <= prevAt) continue;
+    seen.set(key, evt.created_at);
+
+    if (!topicTrust.has(topic)) topicTrust.set(topic, new Map());
+    topicTrust.get(topic).set(target, {
+      weight,
+      expires,
+      eventId: evt.id || '',
+      createdAt: evt.created_at
+    });
+  }
+
+  return {
+    pubkey,
+    firstOrderFollows,
+    topicTrust,
+    builtAt: now
+  };
+}
+
+/**
+ * Boolean trust check for a single (author, topic).
+ *
+ * @param {TrustGraphState} state
+ * @param {string} authorPubkey
+ * @param {string} [topic]
+ * @param {object} [opts]
+ * @param {number} [opts.threshold=50]
+ * @param {boolean} [opts.followsTrustAllTopics=true]
+ *   If true (default), an author in `firstOrderFollows` is trusted
+ *   regardless of topic. If false, follows only count when there is
+ *   an explicit topic-trust entry for that author on the relevant
+ *   topic. Mirrors the user-facing toggle in Settings → Trust.
+ * @returns {boolean}
+ */
+export function isTrusted(state, authorPubkey, topic = null, opts = {}) {
+  if (!state) return false;
+  if (typeof authorPubkey !== 'string' || !authorPubkey) return false;
+  const { threshold = DEFAULT_THRESHOLD, followsTrustAllTopics = true } = opts;
+
+  if (followsTrustAllTopics && state.firstOrderFollows.has(authorPubkey)) {
+    return true;
+  }
+
+  if (topic) {
+    const tEntries = state.topicTrust.get(topic);
+    if (tEntries) {
+      const entry = tEntries.get(authorPubkey);
+      if (entry && entry.weight >= threshold) return true;
+    }
+  } else if (!followsTrustAllTopics) {
+    // No topic supplied AND follows don't auto-trust. Look across
+    // all topic-trust entries for this author and pick the highest
+    // weight — passes if ANY topic clears the threshold.
+    for (const tEntries of state.topicTrust.values()) {
+      const entry = tEntries.get(authorPubkey);
+      if (entry && entry.weight >= threshold) return true;
+    }
+  } else if (!state.firstOrderFollows.has(authorPubkey)) {
+    // Follows don't include them, no topic supplied → not trusted
+    // unless we set followsTrustAllTopics=false above.
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Set of pubkeys trusted on the given topic (or globally when topic
+ * is null and follows-trust-all-topics is true).
+ *
+ * @param {TrustGraphState} state
+ * @param {string} [topic]
+ * @param {object} [opts]
+ * @returns {Set<string>}
+ */
+export function trustedAuthors(state, topic = null, opts = {}) {
+  const { threshold = DEFAULT_THRESHOLD, followsTrustAllTopics = true } = opts;
+  const out = new Set();
+  if (!state) return out;
+
+  if (followsTrustAllTopics) {
+    for (const p of state.firstOrderFollows) out.add(p);
+  }
+
+  if (topic) {
+    const tEntries = state.topicTrust.get(topic);
+    if (tEntries) {
+      for (const [target, entry] of tEntries) {
+        if (entry.weight >= threshold) out.add(target);
+      }
+    }
+  } else {
+    for (const tEntries of state.topicTrust.values()) {
+      for (const [target, entry] of tEntries) {
+        if (entry.weight >= threshold) out.add(target);
+      }
+    }
+  }
+
+  return out;
+}
+
+/**
+ * For a given pubkey, return the topics on which they're trusted (and
+ * by what mechanism). Useful for "Y is trusted on Bitcoin" badges in
+ * the metadata panel.
+ *
+ * @param {TrustGraphState} state
+ * @param {string} pubkey
+ * @returns {Array<{topic: string|null, weight: number, source: 'follows' | 'topic-trust'}>}
+ */
+export function getTrustedTopicsFor(state, pubkey) {
+  const out = [];
+  if (!state) return out;
+
+  if (state.firstOrderFollows.has(pubkey)) {
+    out.push({ topic: null, weight: 100, source: 'follows' });
+  }
+  for (const [topic, tEntries] of state.topicTrust) {
+    const entry = tEntries.get(pubkey);
+    if (entry) {
+      out.push({ topic, weight: entry.weight, source: 'topic-trust' });
+    }
+  }
+  return out;
+}
+
+/**
+ * Serialize a TrustGraphState for storage (Sets → arrays, Maps →
+ * plain objects). Inverse of `deserializeGraph`.
+ */
+export function serializeGraph(state) {
+  if (!state) return null;
+  const topicTrust = {};
+  for (const [topic, tEntries] of state.topicTrust) {
+    const entries = {};
+    for (const [target, entry] of tEntries) entries[target] = entry;
+    topicTrust[topic] = entries;
+  }
+  return {
+    pubkey: state.pubkey,
+    firstOrderFollows: Array.from(state.firstOrderFollows),
+    topicTrust,
+    builtAt: state.builtAt
+  };
+}
+
+/**
+ * Deserialize a serialized graph back to runtime state.
+ */
+export function deserializeGraph(serialized) {
+  if (!serialized) return null;
+  const state = {
+    pubkey: serialized.pubkey,
+    firstOrderFollows: new Set(serialized.firstOrderFollows || []),
+    topicTrust: new Map(),
+    builtAt: serialized.builtAt || 0
+  };
+  const tt = serialized.topicTrust || {};
+  for (const [topic, entries] of Object.entries(tt)) {
+    const m = new Map();
+    for (const [target, entry] of Object.entries(entries || {})) m.set(target, entry);
+    state.topicTrust.set(topic, m);
+  }
+  return state;
+}

--- a/src/shared/metadata/url-normalizer.js
+++ b/src/shared/metadata/url-normalizer.js
@@ -1,0 +1,218 @@
+// NIP-73-conformant URL normalization for X-Ray metadata events.
+//
+// Spec: XRAY_METADATA_SPEC.md §6.2 + Phase 9a Implementation Plan §5.
+//
+// Goal: every metadata event published against a URL must agree on the
+// canonical form of that URL so that relay-side `#r=<url>` and
+// `#i=<url>` filters return everything for that target. Without this,
+// every tracking-param variant forks the metadata graph and readers
+// see partial coverage.
+//
+// Rules (do NOT change without bumping the spec):
+//
+//   1. Lowercase scheme and host.
+//   2. Strip default ports (:80 for http, :443 for https, :21 for ftp).
+//   3. Drop tracking query parameters (utm_*, fbclid, gclid, msclkid,
+//      ref, referrer, mc_cid, mc_eid, _ga, igshid, feature, si,
+//      __source, __share). The list is deliberately conservative —
+//      only params that ARE tracking, never params that change content.
+//   4. Strip URL fragments unless they're explicit text fragments
+//      (`#:~:text=...` per the W3C Text Fragment proposal). Text
+//      fragments ARE part of the canonical URL because the metadata
+//      may be anchored to one.
+//   5. Remove trailing slashes from non-root paths. `/article/` →
+//      `/article`; `/` stays as `/`.
+//   6. Sort remaining query parameters alphabetically. `?b=2&a=1` and
+//      `?a=1&b=2` produce the same canonical URL → same hash → same
+//      metadata bucket.
+//   7. Leave path-case alone. Most servers are case-sensitive on the
+//      path; lowercasing the path would cause real false-negatives.
+//
+// Public surface:
+//   - normalize(url: string): string                    — canonical form
+//   - urlHash(url: string): Promise<string>             — sha256 prefix
+//
+// `Utils.normalizeUrl` (legacy, in `utils.js`) is now a thin wrapper
+// around `normalize()`. Existing call-sites continue to work; new code
+// should import from this module directly to make the dependency
+// explicit.
+
+const TRACKING_PARAMS = new Set([
+  // Universal analytics
+  'utm_source', 'utm_medium', 'utm_campaign', 'utm_content',
+  'utm_term', 'utm_id', 'utm_name', 'utm_brand',
+  // Ad-platform click ids
+  'fbclid', 'gclid', 'gclsrc', 'msclkid', 'dclid',
+  'yclid', 'twclid', 'wbraid', 'gbraid',
+  // Generic referrer / share trackers
+  'ref', 'referrer', 'referer', 'source',
+  // Mailchimp
+  'mc_cid', 'mc_eid',
+  // Google Analytics
+  '_ga', '_gl',
+  // Instagram share
+  'igshid', 'igsh',
+  // YouTube share
+  'feature',
+  // Spotify share
+  'si',
+  // Substack share / source
+  '__source', '__share',
+  // LinkedIn
+  'trk', 'trkCampaign',
+  // HubSpot
+  '_hsenc', '_hsmi', 'hsCtaTracking', 'hsa_acc', 'hsa_cam',
+  // X / Twitter share
+  's', 't', // careful: these are also content params on some sites; documented mismatch acceptable per spec §5
+  'cxt'
+]);
+
+// Some hosts use single-letter params (`s`, `t`) for content too. The
+// spec acknowledges this trade-off; X/Twitter status URLs don't use
+// them as content, and the cost of NOT stripping them on share-links
+// is large (every share gets a different URL hash). If a host arises
+// where `s=` or `t=` is meaningful content, that host gets a
+// per-domain exception here.
+const HOSTS_WHERE_S_T_ARE_TRACKING = new Set([
+  'x.com', 'twitter.com', 'mobile.twitter.com', 'mobile.x.com'
+]);
+
+/**
+ * Canonicalize a URL per the rules in this module's docstring.
+ * Returns the input unchanged if URL parsing fails (preserves the
+ * existing `Utils.normalizeUrl` contract — never throws).
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+export function normalize(url) {
+  if (typeof url !== 'string' || url.length === 0) return url;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch (_) {
+    return url;
+  }
+
+  // Rule 1 — scheme + host.
+  parsed.protocol = parsed.protocol.toLowerCase();
+  parsed.hostname = parsed.hostname.toLowerCase();
+
+  // Rule 2 — default ports.
+  if (
+    (parsed.protocol === 'https:' && parsed.port === '443') ||
+    (parsed.protocol === 'http:'  && parsed.port === '80') ||
+    (parsed.protocol === 'ftp:'   && parsed.port === '21') ||
+    (parsed.protocol === 'ws:'    && parsed.port === '80') ||
+    (parsed.protocol === 'wss:'   && parsed.port === '443')
+  ) {
+    parsed.port = '';
+  }
+
+  // Rule 3 — drop tracking params.
+  // URLSearchParams.delete is the correct API but we need to iterate
+  // over a snapshot of keys because deletion mutates the iterator.
+  const keys = Array.from(parsed.searchParams.keys());
+  const stripST = HOSTS_WHERE_S_T_ARE_TRACKING.has(parsed.hostname.replace(/^www\./, ''));
+  for (const key of keys) {
+    const lower = key.toLowerCase();
+    if (TRACKING_PARAMS.has(lower)) {
+      // The s/t single-letter keys are only stripped on hosts where
+      // they ARE tracking; on every other host treat them as content.
+      if ((lower === 's' || lower === 't') && !stripST) continue;
+      parsed.searchParams.delete(key);
+    }
+  }
+
+  // Rule 6 — sort remaining params alphabetically.
+  const sorted = Array.from(parsed.searchParams.entries())
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  // Rebuild searchParams in sorted order. Mutating in place is fragile
+  // across runtimes; reconstruct the search string by hand.
+  parsed.search = sorted.length === 0
+    ? ''
+    : '?' + sorted.map(([k, v]) =>
+        encodeURIComponent(k) + (v === '' ? '' : '=' + encodeURIComponent(v))
+      ).join('&');
+
+  // Rule 4 — fragments. Preserve only W3C Text Fragments (`#:~:text=...`).
+  // The Text Fragment spec uses `#:~:text=` as the prefix; technically
+  // a URL fragment can carry both a hash anchor AND a text fragment
+  // (`#some-anchor:~:text=foo`), but the canonical form for metadata
+  // anchoring is to keep the text fragment as-is.
+  if (parsed.hash) {
+    if (parsed.hash.includes(':~:text=')) {
+      // keep
+    } else {
+      parsed.hash = '';
+    }
+  }
+
+  let normalized = parsed.toString();
+
+  // Strip a bare trailing `#` that the URL serializer may emit even
+  // when the hash is empty. (Node's URL keeps the `#` separator from
+  // the input string in some versions; browsers vary.)
+  if (normalized.endsWith('#')) normalized = normalized.slice(0, -1);
+
+  // Rule 5 — strip trailing slash on non-root paths.
+  // The URL constructor doesn't expose a clean way to do this without
+  // round-tripping. Operate on the string. Watch for: trailing slash
+  // followed by `?` query or `#` fragment, where the slash is between
+  // path and search/hash.
+  normalized = stripTrailingPathSlash(normalized);
+
+  return normalized;
+}
+
+/**
+ * Strip a single trailing slash from a non-root path. Handles these
+ * shapes:
+ *   https://x.com/foo/   → https://x.com/foo
+ *   https://x.com/foo/?q=1 → https://x.com/foo?q=1
+ *   https://x.com/foo/#:~:text=hi → https://x.com/foo#:~:text=hi
+ *   https://x.com/         → https://x.com/      (root, untouched)
+ */
+function stripTrailingPathSlash(s) {
+  // Find where the path ends — at `?`, `#`, or end of string.
+  // The URL is already serialized; find the boundary after the host.
+  // `URL.toString()` always includes scheme://host[:port]/...
+  const m = /^([a-z][a-z0-9+\-.]*:\/\/[^/?#]+)(\/[^?#]*)?(\?[^#]*)?(#.*)?$/i.exec(s);
+  if (!m) return s;
+  const origin = m[1];
+  let path = m[2] || '';
+  const search = m[3] || '';
+  const hash = m[4] || '';
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.slice(0, -1);
+  }
+  return origin + path + search + hash;
+}
+
+/**
+ * 16-character hex prefix of sha256(normalize(url)). Matches the
+ * existing `urlHash` convention in `archive-cache.js` so cross-store
+ * joins work.
+ *
+ * Uses the WebCrypto subtle API which is available in:
+ *   - browser content scripts and pages
+ *   - service workers
+ *   - Node 20+ (where it lives on globalThis.crypto)
+ *
+ * @param {string} url
+ * @returns {Promise<string>}
+ */
+export async function urlHash(url) {
+  const canonical = normalize(url);
+  const bytes = new TextEncoder().encode(canonical);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+  return hex.slice(0, 16);
+}
+
+/**
+ * Synchronous variant for the small number of test fixtures that need
+ * a stable hash without async. Not exported on the public API; tests
+ * can import the async path.
+ */

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -1,6 +1,7 @@
 // Utility helpers. API-compatible with the userscript's Utils object.
 
 import { CONFIG } from './config.js';
+import { normalize as _normalize } from './metadata/url-normalizer.js';
 
 export const Utils = {
     generateId: () => Date.now().toString(36) + Math.random().toString(36).substr(2),
@@ -22,26 +23,11 @@ export const Utils = {
         return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
     },
 
-    normalizeUrl: (url) => {
-        try {
-            const parsed = new URL(url);
-            const trackingParams = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'fbclid', 'gclid'];
-            trackingParams.forEach(param => parsed.searchParams.delete(param));
-            parsed.hash = '';
-            parsed.hostname = parsed.hostname.toLowerCase();
-            if ((parsed.protocol === 'https:' && parsed.port === '443') ||
-                (parsed.protocol === 'http:'  && parsed.port === '80')) {
-                parsed.port = '';
-            }
-            let normalized = parsed.toString();
-            if (normalized.endsWith('/') && parsed.pathname !== '/') {
-                normalized = normalized.slice(0, -1);
-            }
-            return normalized;
-        } catch (e) {
-            return url;
-        }
-    },
+    // Thin wrapper over `src/shared/metadata/url-normalizer.js` (the
+    // canonical NIP-73-conformant implementation). Existing call-sites
+    // continue to work; new code should import `normalize` directly so
+    // the dependency is explicit.
+    normalizeUrl: (url) => _normalize(url),
 
     getDomain: (url) => {
         try { return new URL(url).hostname.replace(/^www\./, ''); }

--- a/tests/metadata-anchor-capture.test.mjs
+++ b/tests/metadata-anchor-capture.test.mjs
@@ -1,0 +1,421 @@
+// Anchor capture tests — Phase 9a Day 2.
+//
+// Spec: XRAY_METADATA_SPEC.md §6.3 + §7. The pure `buildSelectors`
+// function is exhaustively tested; `captureFromSelection` is sanity-
+// tested with a minimal fake DOM.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  buildSelectors,
+  captureFromSelection,
+  xpathFor,
+  isStableId
+} = await import('../src/shared/metadata/anchor-capture.js');
+
+// ------------------------------------------------------------------
+// buildSelectors — pure path
+// ------------------------------------------------------------------
+
+test('buildSelectors emits TextQuoteSelector with exact', () => {
+  const out = buildSelectors({ exact: 'the cat sat' });
+  assert.equal(out.selectors.length, 1);
+  assert.deepEqual(out.selectors[0], { type: 'TextQuoteSelector', exact: 'the cat sat' });
+});
+
+test('buildSelectors emits TextQuoteSelector with prefix + suffix', () => {
+  const out = buildSelectors({
+    exact: 'cat',
+    prefix: 'the',
+    suffix: ' sat'
+  });
+  assert.deepEqual(out.selectors[0], {
+    type: 'TextQuoteSelector',
+    exact: 'cat',
+    prefix: 'the',
+    suffix: ' sat'
+  });
+});
+
+test('buildSelectors caps prefix at 32 chars (keeps tail)', () => {
+  const longPrefix = 'a'.repeat(50) + 'PREFIX';
+  const out = buildSelectors({ exact: 'x', prefix: longPrefix });
+  // We want the 32 chars *immediately before* the selection.
+  assert.equal(out.selectors[0].prefix.length, 32);
+  assert.ok(out.selectors[0].prefix.endsWith('PREFIX'));
+});
+
+test('buildSelectors caps suffix at 32 chars (keeps head)', () => {
+  const longSuffix = 'SUFFIX' + 'a'.repeat(50);
+  const out = buildSelectors({ exact: 'x', suffix: longSuffix });
+  assert.equal(out.selectors[0].suffix.length, 32);
+  assert.ok(out.selectors[0].suffix.startsWith('SUFFIX'));
+});
+
+test('buildSelectors omits prefix/suffix when empty', () => {
+  const out = buildSelectors({ exact: 'x', prefix: '', suffix: '' });
+  assert.equal('prefix' in out.selectors[0], false);
+  assert.equal('suffix' in out.selectors[0], false);
+});
+
+test('buildSelectors emits RangeSelector when XPath + offsets present', () => {
+  const out = buildSelectors({
+    exact: 'foo',
+    startContainerXPath: '/html/body/article/p[3]/text()[1]',
+    startOffset: 14,
+    endContainerXPath: '/html/body/article/p[3]/text()[1]',
+    endOffset: 17
+  });
+  assert.equal(out.selectors.length, 2);
+  assert.deepEqual(out.selectors[1], {
+    type: 'RangeSelector',
+    startContainer: '/html/body/article/p[3]/text()[1]',
+    startOffset: 14,
+    endContainer: '/html/body/article/p[3]/text()[1]',
+    endOffset: 17
+  });
+});
+
+test('buildSelectors omits RangeSelector when offsets missing', () => {
+  const out = buildSelectors({
+    exact: 'foo',
+    startContainerXPath: '/html/body/p',
+    startOffset: 0,
+    endContainerXPath: '/html/body/p'
+    // endOffset missing
+  });
+  assert.equal(out.selectors.length, 1);
+  assert.equal(out.selectors[0].type, 'TextQuoteSelector');
+});
+
+test('buildSelectors emits CssSelector with stable id', () => {
+  const out = buildSelectors({
+    exact: 'foo',
+    startContainerId: 'main-content'
+  });
+  // [TextQuote, Css]
+  assert.equal(out.selectors.length, 2);
+  assert.deepEqual(out.selectors[1], { type: 'CssSelector', value: '#main-content' });
+});
+
+test('buildSelectors emits CssSelector from CSS path when no id', () => {
+  const out = buildSelectors({
+    exact: 'foo',
+    startContainerCssPath: 'article > div.body > p:nth-child(3)'
+  });
+  assert.equal(out.selectors[1].type, 'CssSelector');
+  assert.equal(out.selectors[1].value, 'article > div.body > p:nth-child(3)');
+});
+
+test('buildSelectors order: TextQuote, Range, Css', () => {
+  const out = buildSelectors({
+    exact: 'foo',
+    prefix: 'pre',
+    suffix: 'suf',
+    startContainerXPath: '/x',
+    startOffset: 0,
+    endContainerXPath: '/x',
+    endOffset: 3,
+    startContainerId: 'main'
+  });
+  assert.equal(out.selectors.length, 3);
+  assert.equal(out.selectors[0].type, 'TextQuoteSelector');
+  assert.equal(out.selectors[1].type, 'RangeSelector');
+  assert.equal(out.selectors[2].type, 'CssSelector');
+});
+
+test('buildSelectors returns empty selectors on empty exact', () => {
+  const out = buildSelectors({ exact: '' });
+  assert.deepEqual(out.selectors, []);
+  assert.equal(out.fullExact, '');
+});
+
+test('buildSelectors handles missing input safely', () => {
+  const out = buildSelectors();
+  assert.deepEqual(out.selectors, []);
+  assert.equal(out.fullExact, '');
+});
+
+// ------------------------------------------------------------------
+// Length cap on `exact`
+// ------------------------------------------------------------------
+
+test('buildSelectors does NOT truncate at exactly 500 chars', () => {
+  const exact = 'a'.repeat(500);
+  const out = buildSelectors({ exact });
+  assert.equal(out.selectors[0].exact, exact);
+  assert.equal(out.fullExact, exact);
+});
+
+test('buildSelectors truncates above 500 chars to head + tail', () => {
+  const head = 'H'.repeat(200);
+  const middle = 'M'.repeat(200);
+  const tail = 'T'.repeat(200);
+  const exact = head + middle + tail; // 600 chars
+  const out = buildSelectors({ exact });
+  // Truncated to first 200 + ' … ' + last 200 = head + ' … ' + tail
+  assert.ok(out.selectors[0].exact.startsWith(head));
+  assert.ok(out.selectors[0].exact.endsWith(tail));
+  assert.ok(out.selectors[0].exact.includes('…'));
+  assert.equal(out.fullExact, exact); // full text preserved for body
+});
+
+test('buildSelectors fullExact preserves the un-truncated selection', () => {
+  const exact = 'x'.repeat(1500);
+  const out = buildSelectors({ exact });
+  assert.equal(out.fullExact, exact);
+  assert.ok(out.selectors[0].exact.length < exact.length);
+});
+
+// ------------------------------------------------------------------
+// CSS escape
+// ------------------------------------------------------------------
+
+test('buildSelectors CSS-escapes id with special chars', () => {
+  const out = buildSelectors({ exact: 'x', startContainerId: 'foo:bar' });
+  // colon must be escaped to be valid in #selector
+  assert.match(out.selectors[1].value, /^#foo\\3a\s*bar$/);
+});
+
+// ------------------------------------------------------------------
+// isStableId
+// ------------------------------------------------------------------
+
+test('isStableId accepts kebab-case', () => {
+  assert.equal(isStableId('main-content'), true);
+  assert.equal(isStableId('article-body'), true);
+});
+
+test('isStableId accepts snake_case', () => {
+  assert.equal(isStableId('main_content'), true);
+});
+
+test('isStableId accepts dot-namespace', () => {
+  assert.equal(isStableId('app.main.body'), true);
+});
+
+test('isStableId rejects React 18 useId form `:r0:`', () => {
+  assert.equal(isStableId(':r0:'), false);
+  assert.equal(isStableId(':r5a:'), false);
+});
+
+test('isStableId rejects emotion `_h:` form', () => {
+  assert.equal(isStableId('_h:42'), false);
+});
+
+test('isStableId rejects emotion classname-as-id', () => {
+  assert.equal(isStableId('css-1abc23'), false);
+});
+
+test('isStableId rejects long hex / GUID', () => {
+  assert.equal(isStableId('a1b2c3d4e5f6789012345678'), false);
+  assert.equal(isStableId('A1B2C3D4-E5F6-7890-1234-567890ABCDEF'), false);
+});
+
+test('isStableId rejects leading-digit ids', () => {
+  assert.equal(isStableId('1main'), false);
+  assert.equal(isStableId('123abc'), false);
+});
+
+test('isStableId rejects too-long ids', () => {
+  assert.equal(isStableId('a'.repeat(65)), false);
+});
+
+test('isStableId rejects empty / non-string', () => {
+  assert.equal(isStableId(''), false);
+  assert.equal(isStableId(null), false);
+  assert.equal(isStableId(undefined), false);
+  assert.equal(isStableId(42), false);
+});
+
+// ------------------------------------------------------------------
+// xpathFor — minimal fake DOM
+// ------------------------------------------------------------------
+
+function el(tag, { id = null, children = [] } = {}) {
+  const node = {
+    nodeType: 1,
+    tagName: tag.toUpperCase(),
+    id,
+    children: [],
+    childNodes: [],
+    parentNode: null,
+    parentElement: null,
+    appendChild(c) {
+      c.parentNode = this;
+      c.parentElement = this.nodeType === 1 ? this : c.parentElement;
+      this.childNodes.push(c);
+      if (c.nodeType === 1) this.children.push(c);
+    },
+    get textContent() {
+      let out = '';
+      const walk = (n) => {
+        if (n.nodeType === 3) { out += n.data || ''; return; }
+        for (const c of n.childNodes || []) walk(c);
+      };
+      walk(this);
+      return out;
+    }
+  };
+  for (const c of children) node.appendChild(c);
+  return node;
+}
+
+function text(data) {
+  return {
+    nodeType: 3,
+    data,
+    parentNode: null,
+    parentElement: null,
+    childNodes: []
+  };
+}
+
+test('xpathFor: text node under p[1]', () => {
+  const t = text('hello');
+  const p = el('p', { children: [t] });
+  const root = el('article', { children: [p] });
+  const xp = xpathFor(t, root);
+  assert.equal(xp, '/p[1]/text()[1]');
+});
+
+test('xpathFor: nested element p[3]', () => {
+  const root = el('article', {
+    children: [
+      el('p', { children: [text('one')] }),
+      el('p', { children: [text('two')] }),
+      el('p', { children: [text('three')] })
+    ]
+  });
+  const target = root.children[2]; // the third <p>
+  assert.equal(xpathFor(target, root), '/p[3]');
+});
+
+test('xpathFor: returns "" when node is not under root', () => {
+  const stranger = el('span');
+  const root = el('article', { children: [el('p')] });
+  assert.equal(xpathFor(stranger, root), '');
+});
+
+// ------------------------------------------------------------------
+// captureFromSelection — fake selection
+// ------------------------------------------------------------------
+
+function fakeSelection({ exact, range }) {
+  return {
+    rangeCount: 1,
+    getRangeAt: () => range,
+    toString: () => exact
+  };
+}
+
+test('captureFromSelection extracts prefix + suffix from rendered text', () => {
+  const t = text('the quick brown fox jumps over the lazy dog');
+  const root = el('article', { children: [el('p', { children: [t] })] });
+  const range = {
+    collapsed: false,
+    startContainer: t,
+    endContainer: t,
+    startOffset: 4,
+    endOffset: 9
+  };
+  const sel = fakeSelection({ exact: 'quick', range });
+  const out = captureFromSelection(sel, root);
+  assert.equal(out.selectors[0].type, 'TextQuoteSelector');
+  assert.equal(out.selectors[0].exact, 'quick');
+  assert.equal(out.selectors[0].prefix, 'the ');
+  assert.equal(out.selectors[0].suffix, ' brown fox jumps over the lazy d');
+});
+
+test('captureFromSelection returns null on collapsed range', () => {
+  const t = text('hello');
+  const root = el('article', { children: [el('p', { children: [t] })] });
+  const range = { collapsed: true, startContainer: t, endContainer: t, startOffset: 0, endOffset: 0 };
+  const sel = fakeSelection({ exact: '', range });
+  assert.equal(captureFromSelection(sel, root), null);
+});
+
+test('captureFromSelection returns null on empty selection', () => {
+  assert.equal(captureFromSelection(null, null), null);
+  assert.equal(captureFromSelection({ rangeCount: 0 }, null), null);
+});
+
+test('captureFromSelection emits RangeSelector with XPaths', () => {
+  const t = text('the quick brown fox');
+  const root = el('article', { children: [el('p', { children: [t] })] });
+  const range = {
+    collapsed: false,
+    startContainer: t,
+    endContainer: t,
+    startOffset: 4,
+    endOffset: 9
+  };
+  const out = captureFromSelection(fakeSelection({ exact: 'quick', range }), root);
+  // Should have TextQuote then Range
+  assert.equal(out.selectors[1].type, 'RangeSelector');
+  assert.equal(out.selectors[1].startContainer, '/p[1]/text()[1]');
+  assert.equal(out.selectors[1].startOffset, 4);
+  assert.equal(out.selectors[1].endContainer, '/p[1]/text()[1]');
+  assert.equal(out.selectors[1].endOffset, 9);
+});
+
+test('captureFromSelection emits CssSelector when start container has stable id', () => {
+  const t = text('the quick brown fox');
+  const p = el('p', { id: 'lead-paragraph', children: [t] });
+  const root = el('article', { children: [p] });
+  const range = {
+    collapsed: false,
+    startContainer: t,
+    endContainer: t,
+    startOffset: 4,
+    endOffset: 9
+  };
+  const out = captureFromSelection(fakeSelection({ exact: 'quick', range }), root);
+  const css = out.selectors.find((s) => s.type === 'CssSelector');
+  assert.ok(css);
+  assert.equal(css.value, '#lead-paragraph');
+});
+
+test('captureFromSelection skips CssSelector when start container has unstable id', () => {
+  const t = text('the quick brown fox');
+  const p = el('p', { id: ':r5:', children: [t] });
+  const root = el('article', { children: [p] });
+  const range = {
+    collapsed: false,
+    startContainer: t,
+    endContainer: t,
+    startOffset: 4,
+    endOffset: 9
+  };
+  const out = captureFromSelection(fakeSelection({ exact: 'quick', range }), root);
+  const css = out.selectors.find((s) => s.type === 'CssSelector');
+  assert.equal(css, undefined);
+});
+
+test('captureFromSelection: selection spans multiple paragraphs', () => {
+  const t1 = text('paragraph one ends with rebuttal. ');
+  const t2 = text('Paragraph two starts.');
+  const p1 = el('p', { children: [t1] });
+  const p2 = el('p', { children: [t2] });
+  const root = el('article', { children: [p1, p2] });
+  const range = {
+    collapsed: false,
+    startContainer: t1,
+    endContainer: t2,
+    startOffset: 24,        // 'rebuttal. '
+    endOffset: 13           // 'Paragraph two'
+  };
+  const sel = fakeSelection({ exact: 'rebuttal. Paragraph two', range });
+  // The captureFromSelection helper uses textContent which won't
+  // produce 'rebuttal. Paragraph two' contiguously (textContent
+  // concatenates without separator); accept that prefix/suffix may
+  // be empty in that case.
+  const out = captureFromSelection(sel, root);
+  assert.equal(out.selectors[0].type, 'TextQuoteSelector');
+  assert.equal(out.selectors[0].exact, 'rebuttal. Paragraph two');
+  // RangeSelector with XPaths in two different paragraphs
+  const range_sel = out.selectors.find((s) => s.type === 'RangeSelector');
+  assert.equal(range_sel.startContainer, '/p[1]/text()[1]');
+  assert.equal(range_sel.endContainer, '/p[2]/text()[1]');
+});

--- a/tests/metadata-anchor-resolver.test.mjs
+++ b/tests/metadata-anchor-resolver.test.mjs
@@ -1,0 +1,445 @@
+// Anchor resolver tests — Phase 9a Day 3.
+//
+// Covers the cascade (TextQuoteSelector primary, RangeSelector,
+// CssSelector), confidence scoring, and orphan handling. Resolves
+// against a small corpus of fixture pages with perturbations
+// applied between capture and resolve to verify the cascade actually
+// degrades gracefully.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  resolveSelectors,
+  resolveTextQuote,
+  resolveRange,
+  resolveCss,
+  resolveXPath
+} = await import('../src/shared/metadata/anchor-resolver.js');
+
+// ------------------------------------------------------------------
+// Fake DOM (matches anchor-capture.test.mjs shape)
+// ------------------------------------------------------------------
+
+function el(tag, { id = null, attrs = {}, children = [] } = {}) {
+  const node = {
+    nodeType: 1,
+    tagName: tag.toUpperCase(),
+    id,
+    _attrs: new Map(Object.entries(attrs)),
+    children: [],
+    childNodes: [],
+    parentNode: null,
+    parentElement: null,
+    appendChild(c) {
+      c.parentNode = this;
+      c.parentElement = this.nodeType === 1 ? this : c.parentElement;
+      this.childNodes.push(c);
+      if (c.nodeType === 1) this.children.push(c);
+    },
+    get textContent() {
+      let out = '';
+      const walk = (n) => {
+        if (n.nodeType === 3) { out += n.data || ''; return; }
+        for (const c of n.childNodes || []) walk(c);
+      };
+      walk(this);
+      return out;
+    },
+    querySelector(selector) {
+      // Implements only `#id` selectors (sufficient for our resolver
+      // — anchor-capture only emits `#id` form).
+      if (typeof selector !== 'string') return null;
+      const m = /^#(.+)$/.exec(selector);
+      if (!m) return null;
+      const target = unescape(m[1]);
+      const stack = [this];
+      while (stack.length) {
+        const cur = stack.pop();
+        if (cur.id === target) return cur;
+        for (const c of cur.children) stack.push(c);
+      }
+      return null;
+    }
+  };
+  for (const c of children) node.appendChild(c);
+  return node;
+}
+
+function text(data) {
+  return {
+    nodeType: 3,
+    data,
+    parentNode: null,
+    parentElement: null,
+    childNodes: []
+  };
+}
+
+// CSS-escape inverse for the simple `\3a ` form used by our capturer.
+function unescape(s) {
+  return s.replace(/\\([0-9a-fA-F]{2})\s?/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
+// Build a fixture article with a stable shape for the cascade tests.
+function fixture(text1 = 'the federal reserve targets 2% inflation. inflation, defined as the year-over-year change in cpi, remained elevated through q3.') {
+  const t = text(text1);
+  const p = el('p', { id: 'lead', children: [t] });
+  return el('article', { children: [p] });
+}
+
+// ------------------------------------------------------------------
+// resolveTextQuote — strategy ladder
+// ------------------------------------------------------------------
+
+test('TextQuote: full prefix+exact+suffix → confidence 1.0', () => {
+  const root = fixture();
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'inflation, defined as the year-over-year change in cpi',
+    prefix: 'the federal reserve targets 2% inflation. ',
+    suffix: ', remained elevated through q3'
+  }, root);
+  assert.equal(result.confidence, 1.0);
+  assert.equal(result.selectorUsed, 'TextQuoteSelector');
+});
+
+test('TextQuote: prefix+exact match, slightly different suffix → 0.9', () => {
+  const root = fixture();
+  // The stored suffix differs by 1 char from what's on the page.
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'inflation, defined as the year-over-year change in cpi',
+    prefix: 'the federal reserve targets 2% inflation. ',
+    // Original suffix had a typo or extra space; close but not exact.
+    suffix: ', remained elevated through Q3'
+  }, root);
+  assert.equal(result.confidence, 0.9);
+});
+
+test('TextQuote: exact+suffix match, slightly different prefix → 0.85', () => {
+  const root = fixture();
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'inflation, defined as the year-over-year change in cpi',
+    // Prefix differs by a couple chars.
+    prefix: 'the federal reserve targets 2% iNflation. ',
+    suffix: ', remained elevated through q3'
+  }, root);
+  assert.equal(result.confidence, 0.85);
+});
+
+test('TextQuote: bare exact, unique → 0.7', () => {
+  const root = fixture();
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'year-over-year change in cpi'
+  }, root);
+  assert.equal(result.confidence, 0.7);
+});
+
+test('TextQuote: ambiguous bare exact → null (orphaned)', () => {
+  const root = fixture('inflation rises. inflation falls. inflation flat.');
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'inflation'
+  }, root);
+  assert.equal(result, null);
+});
+
+test('TextQuote: exact missing → null', () => {
+  const root = fixture();
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'no such phrase appears anywhere'
+  }, root);
+  assert.equal(result, null);
+});
+
+test('TextQuote: empty exact → null', () => {
+  const root = fixture();
+  assert.equal(resolveTextQuote({ type: 'TextQuoteSelector', exact: '' }, root), null);
+  assert.equal(resolveTextQuote({ type: 'TextQuoteSelector' }, root), null);
+});
+
+test('TextQuote: range carries text offsets', () => {
+  const t1 = 'first sentence. ';
+  const t2 = 'second sentence here. ';
+  const t3 = 'third sentence ends.';
+  const root = el('article', { children: [el('p', { children: [text(t1 + t2 + t3)] })] });
+  const result = resolveTextQuote({
+    type: 'TextQuoteSelector',
+    exact: 'second sentence here',
+    prefix: 'first sentence. ',
+    suffix: '. third sentence'
+  }, root);
+  assert.equal(result.range.textStart, t1.length);
+  assert.equal(result.range.textEnd, t1.length + 'second sentence here'.length);
+});
+
+// ------------------------------------------------------------------
+// resolveSelectors — cascade priority
+// ------------------------------------------------------------------
+
+test('cascade: TextQuote with confidence 1.0 wins immediately', () => {
+  const root = fixture();
+  const result = resolveSelectors([
+    {
+      type: 'TextQuoteSelector',
+      exact: 'inflation, defined as the year-over-year change in cpi',
+      prefix: 'the federal reserve targets 2% inflation. ',
+      suffix: ', remained elevated through q3'
+    },
+    { type: 'RangeSelector', startContainer: '/p[1]/text()[1]', startOffset: 0,
+      endContainer: '/p[1]/text()[1]', endOffset: 5 }
+  ], root);
+  assert.equal(result.selectorUsed, 'TextQuoteSelector');
+  assert.equal(result.confidence, 1.0);
+});
+
+test('cascade: falls through to Range when TextQuote orphans', () => {
+  const root = fixture();
+  const result = resolveSelectors([
+    { type: 'TextQuoteSelector', exact: 'phrase that does not exist anywhere' },
+    { type: 'RangeSelector', startContainer: '/p[1]/text()[1]', startOffset: 0,
+      endContainer: '/p[1]/text()[1]', endOffset: 5 }
+  ], root);
+  assert.equal(result.selectorUsed, 'RangeSelector');
+  assert.equal(result.confidence, 0.7);
+});
+
+test('cascade: returns null when every selector fails', () => {
+  const root = fixture();
+  const result = resolveSelectors([
+    { type: 'TextQuoteSelector', exact: 'phrase that does not exist anywhere' },
+    { type: 'RangeSelector', startContainer: '/p[42]/text()[1]', startOffset: 0,
+      endContainer: '/p[42]/text()[1]', endOffset: 5 },
+    { type: 'CssSelector', value: '#nonexistent' }
+  ], root);
+  assert.equal(result, null);
+});
+
+test('cascade: returns null on empty selector array', () => {
+  assert.equal(resolveSelectors([], el('article')), null);
+  assert.equal(resolveSelectors(null, el('article')), null);
+});
+
+test('cascade: returns null when root is null', () => {
+  assert.equal(resolveSelectors([{ type: 'TextQuoteSelector', exact: 'x' }], null), null);
+});
+
+test('cascade: respects custom threshold', () => {
+  const root = fixture();
+  // Bare-exact gives 0.7. Threshold 0.8 should reject it.
+  const result = resolveSelectors([
+    { type: 'TextQuoteSelector', exact: 'year-over-year change in cpi' }
+  ], root, { threshold: 0.8 });
+  assert.equal(result, null);
+});
+
+// ------------------------------------------------------------------
+// resolveXPath
+// ------------------------------------------------------------------
+
+test('resolveXPath: tag[N] path', () => {
+  const target = el('p', { id: 'target' });
+  const root = el('article', {
+    children: [
+      el('p'),
+      el('p'),
+      target
+    ]
+  });
+  assert.equal(resolveXPath('/p[3]', root), target);
+});
+
+test('resolveXPath: text()[N] path', () => {
+  const t1 = text('first');
+  const t2 = text('second');
+  const p = el('p');
+  // Append text nodes manually; el() helper handles only Elements via children
+  p.appendChild(t1);
+  p.appendChild(t2);
+  const root = el('article', { children: [p] });
+  assert.equal(resolveXPath('/p[1]/text()[2]', root), t2);
+});
+
+test('resolveXPath: returns null on missing index', () => {
+  const root = el('article', { children: [el('p'), el('p')] });
+  assert.equal(resolveXPath('/p[99]', root), null);
+});
+
+test('resolveXPath: returns null on malformed segment', () => {
+  const root = el('article', { children: [el('p')] });
+  assert.equal(resolveXPath('/<bogus>', root), null);
+});
+
+// ------------------------------------------------------------------
+// resolveRange
+// ------------------------------------------------------------------
+
+test('Range: resolves XPath endpoints + offsets', () => {
+  const t = text('the quick brown fox');
+  const p = el('p', { children: [t] });
+  const root = el('article', { children: [p] });
+  const result = resolveRange({
+    type: 'RangeSelector',
+    startContainer: '/p[1]/text()[1]',
+    startOffset: 4,
+    endContainer: '/p[1]/text()[1]',
+    endOffset: 9
+  }, root);
+  assert.equal(result.confidence, 0.7);
+  assert.equal(result.range.startContainer, t);
+  assert.equal(result.range.endContainer, t);
+  assert.equal(result.range.startOffset, 4);
+  assert.equal(result.range.endOffset, 9);
+});
+
+test('Range: returns null on unresolvable XPath', () => {
+  const root = el('article', { children: [el('p')] });
+  assert.equal(resolveRange({
+    type: 'RangeSelector',
+    startContainer: '/p[99]/text()[1]',
+    startOffset: 0,
+    endContainer: '/p[99]/text()[1]',
+    endOffset: 5
+  }, root), null);
+});
+
+// ------------------------------------------------------------------
+// resolveCss
+// ------------------------------------------------------------------
+
+test('Css: resolves #id selector', () => {
+  const target = el('p', { id: 'main-content' });
+  const root = el('article', {
+    children: [el('p', { id: 'header' }), target]
+  });
+  const result = resolveCss({ type: 'CssSelector', value: '#main-content' }, root);
+  assert.equal(result.confidence, 0.7);
+  assert.equal(result.range.container, target);
+});
+
+test('Css: returns null on no match', () => {
+  const root = el('article');
+  assert.equal(resolveCss({ type: 'CssSelector', value: '#nonexistent' }, root), null);
+});
+
+// ------------------------------------------------------------------
+// Perturbation suite — verify graceful degradation
+// ------------------------------------------------------------------
+
+// Each scenario captures a selector array from a "before" page and
+// then resolves against an "after" page that has been perturbed.
+// We expect specific confidence levels per perturbation.
+
+test('perturbation: identical page → confidence 1.0', () => {
+  const root = fixture();
+  const result = resolveSelectors([{
+    type: 'TextQuoteSelector',
+    exact: 'year-over-year change in cpi',
+    prefix: 'inflation, defined as the ',
+    suffix: ', remained elevated through'
+  }], root);
+  assert.equal(result.confidence, 1.0);
+});
+
+test('perturbation: paragraph reorder (XPath breaks, TextQuote saves us)', () => {
+  const t = text('the federal reserve targets 2% inflation. inflation, defined as the year-over-year change in cpi, remained elevated through q3.');
+  const root = el('article', {
+    children: [
+      el('p', { children: [text('an unrelated paragraph appended above')] }),  // moved to top
+      el('p', { id: 'lead', children: [t] })
+    ]
+  });
+  const result = resolveSelectors([
+    {
+      type: 'TextQuoteSelector',
+      exact: 'year-over-year change in cpi',
+      prefix: 'inflation, defined as the ',
+      suffix: ', remained elevated through'
+    },
+    {
+      type: 'RangeSelector',
+      // Captured when lead was /p[1]; after perturbation it's /p[2].
+      startContainer: '/p[1]/text()[1]', startOffset: 0,
+      endContainer: '/p[1]/text()[1]', endOffset: 5
+    }
+  ], root);
+  assert.equal(result.selectorUsed, 'TextQuoteSelector');
+  assert.equal(result.confidence, 1.0);
+});
+
+test('perturbation: class-name change does not affect TextQuote', () => {
+  // Captured against `<p class="old-class">`. After perturbation,
+  // class is renamed but visible text identical.
+  const t = text('inflation, defined as the year-over-year change in cpi, remained elevated through q3.');
+  const root = el('article', { children: [el('p', { id: 'lead', children: [t] })] });
+  const result = resolveSelectors([{
+    type: 'TextQuoteSelector',
+    exact: 'year-over-year change in cpi',
+    prefix: 'inflation, defined as the ',
+    suffix: ', remained elevated through'
+  }], root);
+  assert.equal(result.confidence, 1.0);
+});
+
+test('perturbation: typo correction in suffix → 0.9', () => {
+  // Original suffix was ", remained elevated through q3." with q3 lowercase.
+  // After correction, it's "Q3" — single-char change.
+  const t = text('inflation, defined as the year-over-year change in cpi, remained elevated through Q3.');
+  const root = el('article', { children: [el('p', { children: [t] })] });
+  const result = resolveSelectors([{
+    type: 'TextQuoteSelector',
+    exact: 'year-over-year change in cpi',
+    prefix: 'inflation, defined as the ',
+    suffix: ', remained elevated through q3'
+  }], root);
+  // Suffix differs at position [27] only (q→Q). Diff = 1.
+  assert.equal(result.confidence, 0.9);
+});
+
+test('perturbation: exact removed entirely → orphaned (null)', () => {
+  const t = text('the article has been completely rewritten with no original phrasing.');
+  const root = el('article', { children: [el('p', { children: [t] })] });
+  const result = resolveSelectors([{
+    type: 'TextQuoteSelector',
+    exact: 'year-over-year change in cpi',
+    prefix: 'inflation, defined as the ',
+    suffix: ', remained elevated through'
+  }], root);
+  assert.equal(result, null);
+});
+
+test('perturbation: extra inline emphasis tags do not break TextQuote', () => {
+  // Visible text identical; inline <em> tags added around 'cpi'.
+  // textContent flattens to identical string.
+  const root = el('article', {
+    children: [el('p', {
+      children: [
+        text('inflation, defined as the year-over-year change in '),
+        el('em', { children: [text('cpi')] }),
+        text(', remained elevated through q3.')
+      ]
+    })]
+  });
+  const result = resolveSelectors([{
+    type: 'TextQuoteSelector',
+    exact: 'year-over-year change in cpi',
+    prefix: 'inflation, defined as the ',
+    suffix: ', remained elevated through'
+  }], root);
+  assert.equal(result.confidence, 1.0);
+});
+
+test('perturbation: same exact appears twice on a page without prefix → orphaned', () => {
+  const t = text('inflation matters. inflation matters more. inflation again.');
+  const root = el('article', { children: [el('p', { children: [t] })] });
+  const result = resolveSelectors([{
+    type: 'TextQuoteSelector',
+    exact: 'inflation'
+    // no prefix or suffix to disambiguate
+  }], root);
+  assert.equal(result, null);
+});

--- a/tests/metadata-builders.test.mjs
+++ b/tests/metadata-builders.test.mjs
@@ -132,7 +132,9 @@ test('annotation: targetEvent emits `e` tag with relay hint', async () => {
   assert.deepEqual(eTag, ['e', 'event123', 'wss://relay.example']);
 });
 
-test('annotation: body content is JSON-LD with anno + xray contexts', async () => {
+test('annotation: body content is JSON-LD with the single W3C anno context', async () => {
+  // NIP_DRAFT.md specifies the single W3C context string — no
+  // vendor-namespaced context entry.
   const out = await buildAnnotationEvent({
     url: URL,
     motivation: 'commenting',
@@ -140,10 +142,7 @@ test('annotation: body content is JSON-LD with anno + xray contexts', async () =
     selectors: [{ type: 'TextQuoteSelector', exact: 'world' }]
   });
   const body = JSON.parse(out.event.content);
-  assert.deepEqual(body['@context'], [
-    'http://www.w3.org/ns/anno.jsonld',
-    'https://x-ray.dev/ns/v1.jsonld'
-  ]);
+  assert.equal(body['@context'], 'http://www.w3.org/ns/anno.jsonld');
   assert.equal(body.type, 'Annotation');
   assert.equal(body.body.value, 'Hello');
   assert.equal(body.body.format, 'text/markdown');
@@ -154,6 +153,54 @@ test('annotation: body content is JSON-LD with anno + xray contexts', async () =
 test('annotation: rejects missing url / motivation', async () => {
   await assert.rejects(() => buildAnnotationEvent({ motivation: 'x', bodyMarkdown: 'y' }));
   await assert.rejects(() => buildAnnotationEvent({ url: URL, bodyMarkdown: 'y' }));
+});
+
+test('annotation: carries the NIP-22 root pair (I + K)', async () => {
+  // Annotations are also valid NIP-22 comments — they MUST carry the
+  // root-scope I/K pair per NIP_DRAFT.md.
+  const out = await buildAnnotationEvent({ url: URL, motivation: 'commenting', bodyMarkdown: 'x' });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.I[0], URL);
+  assert.equal(tagMap.K[0], 'web');
+});
+
+test('annotation: correcting motivation emits correction-type tag', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'correcting',
+    bodyMarkdown: 'The headline is wrong.',
+    correctionType: 'headline'
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap['correction-type'][0], 'headline');
+});
+
+test('annotation: correction-type works when correcting is a secondary motivation', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'commenting',
+    motivations: ['correcting'],
+    bodyMarkdown: 'x',
+    correctionType: 'stat'
+  });
+  assert.equal(tagsAsMap(out.event.tags)['correction-type'][0], 'stat');
+});
+
+test('annotation: rejects correction-type without a correcting motivation', async () => {
+  await assert.rejects(() => buildAnnotationEvent({
+    url: URL, motivation: 'commenting', bodyMarkdown: 'x', correctionType: 'headline'
+  }));
+});
+
+test('annotation: rejects unknown correction-type', async () => {
+  await assert.rejects(() => buildAnnotationEvent({
+    url: URL, motivation: 'correcting', bodyMarkdown: 'x', correctionType: 'vibes'
+  }));
+});
+
+test('annotation: omits correction-type when not provided', async () => {
+  const out = await buildAnnotationEvent({ url: URL, motivation: 'correcting', bodyMarkdown: 'x' });
+  assert.equal(tagsAsMap(out.event.tags)['correction-type'], undefined);
 });
 
 // ------------------------------------------------------------------
@@ -176,7 +223,7 @@ test('factcheck: kind 30051 with claim-reviewed + rating tags', async () => {
   assert.equal(tagMap['rating-best'][0], '5');
   assert.equal(tagMap['rating-worst'][0], '1');
   assert.equal(tagMap['rating-name'][0], 'False');
-  assert.equal(tagMap['rating-scale'][0], 'x-ray.dev/scale/v1');
+  assert.equal(tagMap['rating-scale'][0], 'nostr.dev/scale/v1');
   assert.equal(tagMap.r[0], URL);
 });
 
@@ -246,6 +293,34 @@ test('factcheck: custom rating-scale namespace passes through', async () => {
   assert.equal(tagMap['rating-scale'][0], 'politifact.com/scale/v1');
 });
 
+test('factcheck: default rating-scale is nostr.dev/scale/v1', async () => {
+  const out = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 1, ratingName: 'False'
+  });
+  assert.equal(tagsAsMap(out.event.tags)['rating-scale'][0], 'nostr.dev/scale/v1');
+});
+
+test('factcheck: standalone kind — r/i/k anchor tags, NO I/K root pair', async () => {
+  // NIP_DRAFT.md kind 30051: FactCheck is not a NIP-22 comment.
+  const out = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 1, ratingName: 'False'
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.r[0], URL);
+  assert.equal(tagMap.i[0], URL);
+  assert.equal(tagMap.k[0], 'web');
+  assert.equal(tagMap.I, undefined);
+  assert.equal(tagMap.K, undefined);
+});
+
+test('factcheck: carries no `lang` tag', async () => {
+  // lang is not in the NIP_DRAFT.md / spec FactCheck tag set.
+  const out = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 1, ratingName: 'False'
+  });
+  assert.equal(tagsAsMap(out.event.tags).lang, undefined);
+});
+
 // ------------------------------------------------------------------
 // Rating — kind 30052
 // ------------------------------------------------------------------
@@ -285,6 +360,19 @@ test('rating: rejects missing fields', async () => {
   await assert.rejects(() => buildRatingEvent({ url: URL, ratingName: 'X', authorPubkey: TARGET_PUBKEY }));
   await assert.rejects(() => buildRatingEvent({ url: URL, ratingValue: 1, authorPubkey: TARGET_PUBKEY }));
   await assert.rejects(() => buildRatingEvent({ url: URL, ratingValue: 1, ratingName: 'X' }));
+});
+
+test('rating: standalone kind — r/i/k anchor tags, NO I/K root pair', async () => {
+  // NIP_DRAFT.md kind 30052: Rating is not a NIP-22 comment.
+  const out = await buildRatingEvent({
+    url: URL, ratingValue: 4, ratingName: 'X', content: 'a', authorPubkey: TARGET_PUBKEY
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.r[0], URL);
+  assert.equal(tagMap.i[0], URL);
+  assert.equal(tagMap.k[0], 'web');
+  assert.equal(tagMap.I, undefined);
+  assert.equal(tagMap.K, undefined);
 });
 
 // ------------------------------------------------------------------

--- a/tests/metadata-builders.test.mjs
+++ b/tests/metadata-builders.test.mjs
@@ -1,0 +1,440 @@
+// Metadata builders tests — Phase 9a Day 5.
+//
+// Covers all five builders + the responds-to tag helper. Each builder
+// is verified for:
+//   - tag shape (NIP-22/NIP-73 anchor tags + builder-specific tags)
+//   - deterministic d-tag (same inputs → same d-tag)
+//   - URL normalization on inputs
+//   - argument validation
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  buildAnnotationEvent,
+  buildFactCheckEvent,
+  buildRatingEvent,
+  buildHelpfulnessEvent,
+  buildRespondsToTag,
+  RESPONDS_TO_RELATIONSHIPS
+} = await import('../src/shared/metadata/builders.js');
+const { buildTopicTrustEvent } = await import('../src/shared/metadata/topic-trust-builder.js');
+
+const URL = 'https://example.com/article';
+const TARGET_PUBKEY = 'a'.repeat(64);
+
+// ------------------------------------------------------------------
+// Annotation — kind 30050
+// ------------------------------------------------------------------
+
+test('annotation: kind 30050 with anchor tags + motivation + lang', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'rebutting',
+    bodyMarkdown: 'Counter-argument here.',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'foo' }],
+    topic: 'bitcoin',
+    lang: 'en',
+    createdAt: 1700000000
+  });
+  assert.equal(out.event.kind, 30050);
+  assert.equal(out.event.created_at, 1700000000);
+  // Required NIP-73 anchor pattern: r/i/k=web/I/K=web
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.r[0], URL);
+  assert.equal(tagMap.i[0], URL);
+  assert.equal(tagMap.k[0], 'web');
+  assert.equal(tagMap.I[0], URL);
+  assert.equal(tagMap.K[0], 'web');
+  assert.equal(tagMap.motivation[0], 'rebutting');
+  assert.equal(tagMap.t[0], 'bitcoin');
+  assert.equal(tagMap.lang[0], 'en');
+  assert.match(tagMap.d[0], /^ann:[0-9a-f]{16}$/);
+});
+
+test('annotation: deterministic d-tag (same inputs → same d-tag)', async () => {
+  const args = {
+    url: URL,
+    motivation: 'commenting',
+    bodyMarkdown: 'A',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'foo' }]
+  };
+  const a = await buildAnnotationEvent(args);
+  const b = await buildAnnotationEvent(args);
+  assert.equal(a.dTag, b.dTag);
+});
+
+test('annotation: d-tag changes when selector changes', async () => {
+  const a = await buildAnnotationEvent({
+    url: URL, motivation: 'commenting', bodyMarkdown: 'x',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'foo' }]
+  });
+  const b = await buildAnnotationEvent({
+    url: URL, motivation: 'commenting', bodyMarkdown: 'x',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'bar' }]
+  });
+  assert.notEqual(a.dTag, b.dTag);
+});
+
+test('annotation: d-tag stable across body edits (replaceable semantics)', async () => {
+  const a = await buildAnnotationEvent({
+    url: URL, motivation: 'commenting', bodyMarkdown: 'first draft',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'foo' }]
+  });
+  const b = await buildAnnotationEvent({
+    url: URL, motivation: 'commenting', bodyMarkdown: 'second draft',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'foo' }]
+  });
+  assert.equal(a.dTag, b.dTag);
+});
+
+test('annotation: URL normalization runs (UTM stripped + host lowercased)', async () => {
+  const out = await buildAnnotationEvent({
+    url: 'HTTPS://Example.COM/article?utm_source=foo&id=5',
+    motivation: 'commenting',
+    bodyMarkdown: 'x'
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.r[0], 'https://example.com/article?id=5');
+  assert.equal(tagMap.i[0], 'https://example.com/article?id=5');
+});
+
+test('annotation: multiple motivations supported', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'correcting',
+    motivations: ['contextualizing'],
+    bodyMarkdown: 'x'
+  });
+  const motivationTags = out.event.tags.filter((t) => t[0] === 'motivation');
+  assert.deepEqual(motivationTags.map((t) => t[1]).sort(), ['contextualizing', 'correcting']);
+});
+
+test('annotation: respondsToArticleAddress emits `a` tag', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'responding-to',
+    bodyMarkdown: 'see my response',
+    respondsToArticleAddress: '30023:abc:my-slug'
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.a[0], '30023:abc:my-slug');
+});
+
+test('annotation: targetEvent emits `e` tag with relay hint', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'commenting',
+    bodyMarkdown: 'x',
+    targetEvent: { id: 'event123', relayHint: 'wss://relay.example' }
+  });
+  const eTag = out.event.tags.find((t) => t[0] === 'e');
+  assert.deepEqual(eTag, ['e', 'event123', 'wss://relay.example']);
+});
+
+test('annotation: body content is JSON-LD with anno + xray contexts', async () => {
+  const out = await buildAnnotationEvent({
+    url: URL,
+    motivation: 'commenting',
+    bodyMarkdown: 'Hello',
+    selectors: [{ type: 'TextQuoteSelector', exact: 'world' }]
+  });
+  const body = JSON.parse(out.event.content);
+  assert.deepEqual(body['@context'], [
+    'http://www.w3.org/ns/anno.jsonld',
+    'https://x-ray.dev/ns/v1.jsonld'
+  ]);
+  assert.equal(body.type, 'Annotation');
+  assert.equal(body.body.value, 'Hello');
+  assert.equal(body.body.format, 'text/markdown');
+  assert.equal(body.target.source, URL);
+  assert.deepEqual(body.target.selector[0], { type: 'TextQuoteSelector', exact: 'world' });
+});
+
+test('annotation: rejects missing url / motivation', async () => {
+  await assert.rejects(() => buildAnnotationEvent({ motivation: 'x', bodyMarkdown: 'y' }));
+  await assert.rejects(() => buildAnnotationEvent({ url: URL, bodyMarkdown: 'y' }));
+});
+
+// ------------------------------------------------------------------
+// FactCheck — kind 30051
+// ------------------------------------------------------------------
+
+test('factcheck: kind 30051 with claim-reviewed + rating tags', async () => {
+  const out = await buildFactCheckEvent({
+    url: URL,
+    claimReviewed: 'The Earth is flat.',
+    ratingValue: 1,
+    ratingName: 'False',
+    ratingExplanation: 'Geodesy disagrees.',
+    topic: 'science'
+  });
+  assert.equal(out.event.kind, 30051);
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap['claim-reviewed'][0], 'The Earth is flat.');
+  assert.equal(tagMap['rating-value'][0], '1');
+  assert.equal(tagMap['rating-best'][0], '5');
+  assert.equal(tagMap['rating-worst'][0], '1');
+  assert.equal(tagMap['rating-name'][0], 'False');
+  assert.equal(tagMap['rating-scale'][0], 'x-ray.dev/scale/v1');
+  assert.equal(tagMap.r[0], URL);
+});
+
+test('factcheck: deterministic d-tag (url + claim)', async () => {
+  const a = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 3, ratingName: 'Mixed'
+  });
+  const b = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 5, ratingName: 'True'
+  });
+  // Same URL + claim → same d-tag (re-rating the same claim updates).
+  assert.equal(a.dTag, b.dTag);
+});
+
+test('factcheck: different claim → different d-tag', async () => {
+  const a = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 1, ratingName: 'False'
+  });
+  const b = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'Y', ratingValue: 1, ratingName: 'False'
+  });
+  assert.notEqual(a.dTag, b.dTag);
+});
+
+test('factcheck: evidence tags emitted', async () => {
+  const out = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 1, ratingName: 'False',
+    evidence: ['https://primarysource.example.org/data', 'nostr:naddr1xyz']
+  });
+  const evTags = out.event.tags.filter((t) => t[0] === 'evidence');
+  assert.equal(evTags.length, 2);
+  assert.equal(evTags[0][1], 'https://primarysource.example.org/data');
+});
+
+test('factcheck: body is ClaimReview JSON-LD', async () => {
+  const out = await buildFactCheckEvent({
+    url: URL,
+    claimReviewed: 'A claim.',
+    ratingValue: 2,
+    ratingName: 'Mostly False',
+    ratingExplanation: 'Because.',
+    appearance: { headline: "Headline", datePublished: '2026-01-01' }
+  });
+  const body = JSON.parse(out.event.content);
+  assert.equal(body['@context'], 'https://schema.org');
+  assert.equal(body.type, 'ClaimReview');
+  assert.equal(body.claimReviewed, 'A claim.');
+  assert.equal(body.itemReviewed.appearance.url, URL);
+  assert.equal(body.itemReviewed.appearance.headline, 'Headline');
+  assert.equal(body.reviewRating.ratingValue, 2);
+  assert.equal(body.reviewRating.alternateName, 'Mostly False');
+  assert.equal(body.reviewRating.ratingExplanation, 'Because.');
+});
+
+test('factcheck: rejects missing required fields', async () => {
+  await assert.rejects(() => buildFactCheckEvent({ url: URL, ratingValue: 1, ratingName: 'X' }));
+  await assert.rejects(() => buildFactCheckEvent({ url: URL, claimReviewed: 'X', ratingName: 'F' }));
+  await assert.rejects(() => buildFactCheckEvent({ url: URL, claimReviewed: 'X', ratingValue: 1 }));
+});
+
+test('factcheck: custom rating-scale namespace passes through', async () => {
+  const out = await buildFactCheckEvent({
+    url: URL, claimReviewed: 'X', ratingValue: 3, ratingName: 'Half True',
+    ratingScale: 'politifact.com/scale/v1'
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap['rating-scale'][0], 'politifact.com/scale/v1');
+});
+
+// ------------------------------------------------------------------
+// Rating — kind 30052
+// ------------------------------------------------------------------
+
+test('rating: kind 30052 with rating-* tags', async () => {
+  const out = await buildRatingEvent({
+    url: URL, ratingValue: 4, ratingName: 'Strong analysis',
+    content: 'Solid empirical work.', topic: 'bitcoin',
+    authorPubkey: TARGET_PUBKEY
+  });
+  assert.equal(out.event.kind, 30052);
+  assert.equal(out.event.content, 'Solid empirical work.');
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap['rating-value'][0], '4');
+  assert.equal(tagMap['rating-best'][0], '5');
+  assert.equal(tagMap['rating-name'][0], 'Strong analysis');
+  assert.equal(tagMap.t[0], 'bitcoin');
+  assert.match(tagMap.d[0], /^rating:[0-9a-f]{16}$/);
+});
+
+test('rating: same author + url → same d-tag (replaceable)', async () => {
+  const args = { url: URL, ratingValue: 4, ratingName: 'X', content: 'a', authorPubkey: TARGET_PUBKEY };
+  const a = await buildRatingEvent(args);
+  const b = await buildRatingEvent({ ...args, ratingValue: 5, ratingName: 'Y', content: 'b' });
+  assert.equal(a.dTag, b.dTag);
+});
+
+test('rating: different author → different d-tag', async () => {
+  const args = { url: URL, ratingValue: 4, ratingName: 'X', content: 'a' };
+  const a = await buildRatingEvent({ ...args, authorPubkey: 'a'.repeat(64) });
+  const b = await buildRatingEvent({ ...args, authorPubkey: 'b'.repeat(64) });
+  assert.notEqual(a.dTag, b.dTag);
+});
+
+test('rating: rejects missing fields', async () => {
+  await assert.rejects(() => buildRatingEvent({ ratingValue: 1, ratingName: 'X', authorPubkey: TARGET_PUBKEY }));
+  await assert.rejects(() => buildRatingEvent({ url: URL, ratingName: 'X', authorPubkey: TARGET_PUBKEY }));
+  await assert.rejects(() => buildRatingEvent({ url: URL, ratingValue: 1, authorPubkey: TARGET_PUBKEY }));
+  await assert.rejects(() => buildRatingEvent({ url: URL, ratingValue: 1, ratingName: 'X' }));
+});
+
+// ------------------------------------------------------------------
+// HelpfulnessVote — kind 9803
+// ------------------------------------------------------------------
+
+test('helpfulness: kind 9803 with `a`, `p`, `helpful` tags', () => {
+  const out = buildHelpfulnessEvent({
+    targetCoord: '30050:abc:dxyz',
+    targetEventId: 'event123',
+    targetAuthor: 'authorabc',
+    relayHint: 'wss://relay.example',
+    helpful: 1,
+    rationale: 'Yes, this is well-sourced.'
+  });
+  assert.equal(out.event.kind, 9803);
+  assert.equal(out.event.content, 'Yes, this is well-sourced.');
+  const aTag = out.event.tags.find((t) => t[0] === 'a');
+  assert.deepEqual(aTag, ['a', '30050:abc:dxyz', 'wss://relay.example']);
+  const pTag = out.event.tags.find((t) => t[0] === 'p');
+  assert.equal(pTag[1], 'authorabc');
+  const helpfulTag = out.event.tags.find((t) => t[0] === 'helpful');
+  assert.equal(helpfulTag[1], '1');
+  // dTag is null because 9803 is regular (not addressable).
+  assert.equal(out.dTag, null);
+});
+
+test('helpfulness: `helpful: -1` and `helpful: 0` accepted', () => {
+  const a = buildHelpfulnessEvent({ targetCoord: 'x', helpful: -1 });
+  const b = buildHelpfulnessEvent({ targetCoord: 'x', helpful: 0 });
+  assert.equal(a.event.tags.find((t) => t[0] === 'helpful')[1], '-1');
+  assert.equal(b.event.tags.find((t) => t[0] === 'helpful')[1], '0');
+});
+
+test('helpfulness: rejects invalid helpful value', () => {
+  assert.throws(() => buildHelpfulnessEvent({ targetCoord: 'x', helpful: 2 }));
+  assert.throws(() => buildHelpfulnessEvent({ targetCoord: 'x', helpful: 'yes' }));
+});
+
+test('helpfulness: rejects missing targetCoord', () => {
+  assert.throws(() => buildHelpfulnessEvent({ helpful: 1 }));
+});
+
+// ------------------------------------------------------------------
+// TopicTrust — kind 30053
+// ------------------------------------------------------------------
+
+test('topic-trust: kind 30053 with p/t/weight + d-tag', () => {
+  const out = buildTopicTrustEvent({
+    targetPubkey: TARGET_PUBKEY,
+    topic: 'bitcoin',
+    weight: 85,
+    rationale: 'Long-time domain expert.'
+  });
+  assert.equal(out.event.kind, 30053);
+  assert.equal(out.event.content, 'Long-time domain expert.');
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.p[0], TARGET_PUBKEY);
+  assert.equal(tagMap.t[0], 'bitcoin');
+  assert.equal(tagMap.weight[0], '85');
+  assert.match(tagMap.d[0], /^trust:bitcoin:[0-9a-f]{16}$/);
+});
+
+test('topic-trust: emits `expires` when provided', () => {
+  const out = buildTopicTrustEvent({
+    targetPubkey: TARGET_PUBKEY, topic: 'x', weight: 50, expires: 1798761600
+  });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.expires[0], '1798761600');
+});
+
+test('topic-trust: omits `expires` when not provided', () => {
+  const out = buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'x', weight: 50 });
+  const tagMap = tagsAsMap(out.event.tags);
+  assert.equal(tagMap.expires, undefined);
+});
+
+test('topic-trust: same target + topic → same d-tag (replaceable)', () => {
+  const a = buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'bitcoin', weight: 50 });
+  const b = buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'bitcoin', weight: 80 });
+  assert.equal(a.dTag, b.dTag);
+});
+
+test('topic-trust: different topic → different d-tag', () => {
+  const a = buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'bitcoin', weight: 50 });
+  const b = buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'cooking', weight: 50 });
+  assert.notEqual(a.dTag, b.dTag);
+});
+
+test('topic-trust: rejects bad target pubkey', () => {
+  assert.throws(() => buildTopicTrustEvent({
+    targetPubkey: 'too-short', topic: 'x', weight: 50
+  }));
+});
+
+test('topic-trust: rejects out-of-range weight', () => {
+  assert.throws(() => buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'x', weight: -1 }));
+  assert.throws(() => buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'x', weight: 101 }));
+  assert.throws(() => buildTopicTrustEvent({ targetPubkey: TARGET_PUBKEY, topic: 'x', weight: NaN }));
+});
+
+// ------------------------------------------------------------------
+// responds-to tag (kind 30023 extension)
+// ------------------------------------------------------------------
+
+test('respondsTo: emits canonical 3-tuple form', () => {
+  const t = buildRespondsToTag('https://example.com/a', 'rebuts');
+  assert.deepEqual(t, ['responds-to', 'https://example.com/a', 'rebuts']);
+});
+
+test('respondsTo: emits 4-tuple with relay hint', () => {
+  const t = buildRespondsToTag('nostr:naddr1xyz', 'extends', 'wss://relay.example');
+  assert.deepEqual(t, ['responds-to', 'nostr:naddr1xyz', 'extends', 'wss://relay.example']);
+});
+
+test('respondsTo: normalizes URL targets', () => {
+  const t = buildRespondsToTag('HTTPS://Example.COM/a?utm_source=x', 'supports');
+  assert.equal(t[1], 'https://example.com/a');
+});
+
+test('respondsTo: leaves nostr: refs alone', () => {
+  const t = buildRespondsToTag('nostr:naddr1abc', 'supports');
+  assert.equal(t[1], 'nostr:naddr1abc');
+});
+
+test('respondsTo: rejects unknown relationship', () => {
+  assert.throws(() => buildRespondsToTag('https://x', 'destroys'));
+});
+
+test('respondsTo: rejects missing target', () => {
+  assert.throws(() => buildRespondsToTag('', 'rebuts'));
+});
+
+test('respondsTo: relationships set is exposed for UIs', () => {
+  assert.deepEqual(
+    [...RESPONDS_TO_RELATIONSHIPS].sort(),
+    ['contextualizes', 'corrects', 'extends', 'rebuts', 'supports']
+  );
+});
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+function tagsAsMap(tags) {
+  const out = {};
+  for (const t of tags) {
+    if (!Array.isArray(t) || t.length === 0) continue;
+    if (!out[t[0]]) out[t[0]] = [];
+    out[t[0]].push(...t.slice(1));
+  }
+  return out;
+}

--- a/tests/metadata-ranker.test.mjs
+++ b/tests/metadata-ranker.test.mjs
@@ -1,0 +1,125 @@
+// Ranker tests — Phase 9a Day 5.
+//
+// Spec: XRAY_METADATA_SPEC.md §8.1 + Implementation Plan §8.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { rankAnnotations } = await import('../src/shared/metadata/ranker.js');
+const { composeGraph } = await import('../src/shared/metadata/trust-graph.js');
+
+const ME = 'me';
+const ALICE = 'alice'.padEnd(64, 'a');
+const BOB = 'bob'.padEnd(64, 'b');
+const CAROL = 'carol'.padEnd(64, 'c');
+
+function ann(pubkey, created_at, id = '') {
+  return { pubkey, created_at, id };
+}
+
+test('ranker: trusted bucket contains follows', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] }
+  });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'a1'),
+    ann(BOB,   100, 'b1')
+  ], g);
+  assert.equal(out.trusted.length, 1);
+  assert.equal(out.trusted[0].pubkey, ALICE);
+  assert.equal(out.untrusted.length, 0); // includeUntrusted defaults to false
+});
+
+test('ranker: includeUntrusted populates untrusted bucket', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] }
+  });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'a1'),
+    ann(BOB,   100, 'b1')
+  ], g, { includeUntrusted: true });
+  assert.equal(out.trusted.length, 1);
+  assert.equal(out.untrusted.length, 1);
+  assert.equal(out.untrusted[0].pubkey, BOB);
+});
+
+test('ranker: sort by created_at descending within bucket', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE], ['p', BOB], ['p', CAROL]] }
+  });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'a1'),
+    ann(BOB,   300, 'b1'),
+    ann(CAROL, 200, 'c1')
+  ], g);
+  assert.deepEqual(out.trusted.map((a) => a.created_at), [300, 200, 100]);
+});
+
+test('ranker: tie-break on event id (descending)', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE], ['p', BOB]] }
+  });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'aaa'),
+    ann(BOB,   100, 'bbb')
+  ], g);
+  // Both same timestamp; bbb > aaa lexicographically → bbb first.
+  assert.deepEqual(out.trusted.map((a) => a.id), ['bbb', 'aaa']);
+});
+
+test('ranker: empty trust graph + includeUntrusted=false → empty trusted', () => {
+  const g = composeGraph({ pubkey: ME });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'a1'),
+    ann(BOB,   100, 'b1')
+  ], g);
+  assert.equal(out.trusted.length, 0);
+  assert.equal(out.untrusted.length, 0);
+});
+
+test('ranker: empty trust graph + includeUntrusted=true → all in untrusted', () => {
+  const g = composeGraph({ pubkey: ME });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'a1'),
+    ann(BOB,   100, 'b1')
+  ], g, { includeUntrusted: true });
+  assert.equal(out.trusted.length, 0);
+  assert.equal(out.untrusted.length, 2);
+});
+
+test('ranker: topic + threshold filtering', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1', tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e2', tags: [['p', BOB],   ['t', 'bitcoin'], ['weight', '40']] }
+    ]
+  });
+  const out = rankAnnotations([
+    ann(ALICE, 100, 'a1'),
+    ann(BOB,   100, 'b1')
+  ], g, { topic: 'bitcoin', threshold: 60 });
+  // ALICE clears 60; BOB doesn't.
+  assert.equal(out.trusted.length, 1);
+  assert.equal(out.trusted[0].pubkey, ALICE);
+});
+
+test('ranker: skips entries without pubkey', () => {
+  const g = composeGraph({ pubkey: ME, contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] } });
+  const out = rankAnnotations([
+    null,
+    ann(ALICE, 100, 'a1'),
+    { created_at: 100 } // no pubkey
+  ], g);
+  assert.equal(out.trusted.length, 1);
+});
+
+test('ranker: bridging is a v3 placeholder (null in v1)', () => {
+  const g = composeGraph({ pubkey: ME });
+  const out = rankAnnotations([], g);
+  assert.equal(out.bridging, null);
+});

--- a/tests/metadata-trust-graph.test.mjs
+++ b/tests/metadata-trust-graph.test.mjs
@@ -1,0 +1,356 @@
+// Trust graph tests — Phase 9a Day 4.
+//
+// Spec: XRAY_METADATA_SPEC.md §8.1 + Implementation Plan §7.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+  composeGraph,
+  isTrusted,
+  trustedAuthors,
+  getTrustedTopicsFor,
+  serializeGraph,
+  deserializeGraph
+} = await import('../src/shared/metadata/trust-graph.js');
+
+const ME = 'ownerpubkey';
+const ALICE = 'alice'.padEnd(64, 'a');
+const BOB = 'bob'.padEnd(64, 'b');
+const CAROL = 'carol'.padEnd(64, 'c');
+const DAVE = 'dave'.padEnd(64, 'd');
+
+// ------------------------------------------------------------------
+// composeGraph
+// ------------------------------------------------------------------
+
+test('composeGraph: empty inputs yield empty graph', () => {
+  const g = composeGraph({ pubkey: ME });
+  assert.equal(g.firstOrderFollows.size, 0);
+  assert.equal(g.topicTrust.size, 0);
+});
+
+test('composeGraph: rejects missing owner pubkey', () => {
+  assert.throws(() => composeGraph({}));
+});
+
+test('composeGraph: extracts NIP-02 follows from kind 3', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: {
+      kind: 3,
+      pubkey: ME,
+      created_at: 100,
+      tags: [
+        ['p', ALICE, 'wss://relay.example/', 'alice'],
+        ['p', BOB],
+        ['e', 'unrelated'],     // ignore
+        ['p']                    // malformed; ignore
+      ]
+    }
+  });
+  assert.equal(g.firstOrderFollows.size, 2);
+  assert.ok(g.firstOrderFollows.has(ALICE));
+  assert.ok(g.firstOrderFollows.has(BOB));
+});
+
+test('composeGraph: builds topic-trust from kind 30053', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      {
+        kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']]
+      },
+      {
+        kind: 30053, pubkey: ME, created_at: 100, id: 'e2',
+        tags: [['p', BOB], ['t', 'bitcoin'], ['weight', '40']]
+      },
+      {
+        kind: 30053, pubkey: ME, created_at: 100, id: 'e3',
+        tags: [['p', ALICE], ['t', 'macroeconomics'], ['weight', '60']]
+      }
+    ]
+  });
+  assert.equal(g.topicTrust.get('bitcoin').get(ALICE).weight, 85);
+  assert.equal(g.topicTrust.get('bitcoin').get(BOB).weight, 40);
+  assert.equal(g.topicTrust.get('macroeconomics').get(ALICE).weight, 60);
+});
+
+test('composeGraph: latest event wins per (topic, target)', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'older', tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '40']] },
+      { kind: 30053, pubkey: ME, created_at: 200, id: 'newer', tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] }
+    ]
+  });
+  assert.equal(g.topicTrust.get('bitcoin').get(ALICE).weight, 85);
+  assert.equal(g.topicTrust.get('bitcoin').get(ALICE).eventId, 'newer');
+});
+
+test('composeGraph: ignores non-30053 events in topicTrustEvents', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 1, pubkey: ME, created_at: 100, tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] }
+    ]
+  });
+  assert.equal(g.topicTrust.size, 0);
+});
+
+test('composeGraph: rejects invalid weight (out of range)', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'a', tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '-5']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'b', tags: [['p', BOB], ['t', 'bitcoin'], ['weight', '105']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'c', tags: [['p', CAROL], ['t', 'bitcoin'], ['weight', 'foo']] }
+    ]
+  });
+  assert.equal(g.topicTrust.size, 0);
+});
+
+test('composeGraph: rejects events missing required tags', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'no-target', tags: [['t', 'bitcoin'], ['weight', '50']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'no-topic',  tags: [['p', ALICE], ['weight', '50']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'no-weight', tags: [['p', ALICE], ['t', 'bitcoin']] }
+    ]
+  });
+  assert.equal(g.topicTrust.size, 0);
+});
+
+test('composeGraph: excludes expired entries', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    now: 1000,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85'], ['expires', '500']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e2',
+        tags: [['p', BOB], ['t', 'bitcoin'], ['weight', '85'], ['expires', '2000']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e3',
+        tags: [['p', CAROL], ['t', 'bitcoin'], ['weight', '85']] }     // never expires
+    ]
+  });
+  assert.equal(g.topicTrust.get('bitcoin').size, 2);
+  assert.ok(g.topicTrust.get('bitcoin').has(BOB));
+  assert.ok(g.topicTrust.get('bitcoin').has(CAROL));
+  assert.equal(g.topicTrust.get('bitcoin').has(ALICE), false);
+});
+
+// ------------------------------------------------------------------
+// isTrusted
+// ------------------------------------------------------------------
+
+test('isTrusted: NIP-02 follow → trusted on any topic by default', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] }
+  });
+  assert.equal(isTrusted(g, ALICE), true);
+  assert.equal(isTrusted(g, ALICE, 'bitcoin'), true);
+  assert.equal(isTrusted(g, ALICE, 'cooking'), true);
+});
+
+test('isTrusted: non-follow with no topic-trust → not trusted', () => {
+  const g = composeGraph({ pubkey: ME });
+  assert.equal(isTrusted(g, ALICE), false);
+});
+
+test('isTrusted: topic-trust above threshold → trusted on that topic', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '60']] }
+    ]
+  });
+  assert.equal(isTrusted(g, ALICE, 'bitcoin'), true);
+  assert.equal(isTrusted(g, ALICE, 'cooking'), false);
+});
+
+test('isTrusted: weight below threshold → not trusted on that topic', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '40']] }
+    ]
+  });
+  assert.equal(isTrusted(g, ALICE, 'bitcoin'), false);
+});
+
+test('isTrusted: weight exactly at threshold → trusted (>=)', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '50']] }
+    ]
+  });
+  assert.equal(isTrusted(g, ALICE, 'bitcoin'), true);
+  assert.equal(isTrusted(g, ALICE, 'bitcoin', { threshold: 50 }), true);
+  assert.equal(isTrusted(g, ALICE, 'bitcoin', { threshold: 51 }), false);
+});
+
+test('isTrusted: custom threshold respected', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] }
+    ]
+  });
+  assert.equal(isTrusted(g, ALICE, 'bitcoin', { threshold: 90 }), false);
+  assert.equal(isTrusted(g, ALICE, 'bitcoin', { threshold: 85 }), true);
+});
+
+test('isTrusted: followsTrustAllTopics=false requires explicit topic trust', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] }
+  });
+  assert.equal(isTrusted(g, ALICE, 'bitcoin', { followsTrustAllTopics: false }), false);
+});
+
+test('isTrusted: followsTrustAllTopics=false + explicit topic trust → trusted', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] },
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '60']] }
+    ]
+  });
+  assert.equal(isTrusted(g, ALICE, 'bitcoin', { followsTrustAllTopics: false }), true);
+  assert.equal(isTrusted(g, ALICE, 'cooking', { followsTrustAllTopics: false }), false);
+});
+
+// ------------------------------------------------------------------
+// trustedAuthors
+// ------------------------------------------------------------------
+
+test('trustedAuthors: union of follows + topic-trust above threshold', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] },
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', BOB], ['t', 'bitcoin'], ['weight', '60']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e2',
+        tags: [['p', CAROL], ['t', 'cooking'], ['weight', '60']] }
+    ]
+  });
+  const all = trustedAuthors(g);
+  assert.equal(all.size, 3);
+  const onBitcoin = trustedAuthors(g, 'bitcoin');
+  // ALICE (follow) + BOB (bitcoin trust) — but not CAROL (cooking only).
+  assert.equal(onBitcoin.size, 2);
+  assert.ok(onBitcoin.has(ALICE));
+  assert.ok(onBitcoin.has(BOB));
+  assert.equal(onBitcoin.has(CAROL), false);
+});
+
+test('trustedAuthors: filters by threshold', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'a',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'b',
+        tags: [['p', BOB], ['t', 'bitcoin'], ['weight', '40']] }
+    ]
+  });
+  const set = trustedAuthors(g, 'bitcoin', { threshold: 60 });
+  assert.equal(set.size, 1);
+  assert.ok(set.has(ALICE));
+  assert.equal(set.has(BOB), false);
+});
+
+// ------------------------------------------------------------------
+// getTrustedTopicsFor
+// ------------------------------------------------------------------
+
+test('getTrustedTopicsFor: lists all reasons a pubkey is trusted', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE]] },
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] },
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e2',
+        tags: [['p', ALICE], ['t', 'macroeconomics'], ['weight', '60']] }
+    ]
+  });
+  const reasons = getTrustedTopicsFor(g, ALICE);
+  // 1 from follows + 2 from topic-trust = 3 reasons
+  assert.equal(reasons.length, 3);
+  assert.ok(reasons.find(r => r.source === 'follows'));
+  assert.ok(reasons.find(r => r.source === 'topic-trust' && r.topic === 'bitcoin' && r.weight === 85));
+  assert.ok(reasons.find(r => r.source === 'topic-trust' && r.topic === 'macroeconomics' && r.weight === 60));
+});
+
+test('getTrustedTopicsFor: empty for unknown pubkey', () => {
+  const g = composeGraph({ pubkey: ME });
+  assert.deepEqual(getTrustedTopicsFor(g, DAVE), []);
+});
+
+// ------------------------------------------------------------------
+// serialize / deserialize
+// ------------------------------------------------------------------
+
+test('serialize/deserialize round-trips graph state', () => {
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags: [['p', ALICE], ['p', BOB]] },
+    topicTrustEvents: [
+      { kind: 30053, pubkey: ME, created_at: 100, id: 'e1',
+        tags: [['p', ALICE], ['t', 'bitcoin'], ['weight', '85']] }
+    ]
+  });
+
+  const ser = serializeGraph(g);
+  const json = JSON.stringify(ser);            // must be JSON-safe
+  const back = deserializeGraph(JSON.parse(json));
+
+  assert.equal(back.pubkey, ME);
+  assert.ok(back.firstOrderFollows.has(ALICE));
+  assert.ok(back.firstOrderFollows.has(BOB));
+  assert.equal(back.topicTrust.get('bitcoin').get(ALICE).weight, 85);
+
+  // isTrusted continues to work on the deserialized state.
+  assert.equal(isTrusted(back, ALICE, 'bitcoin'), true);
+  assert.equal(isTrusted(back, BOB, 'bitcoin'), true);
+});
+
+test('serializeGraph: returns null for null input', () => {
+  assert.equal(serializeGraph(null), null);
+});
+
+test('deserializeGraph: returns null for null input', () => {
+  assert.equal(deserializeGraph(null), null);
+});
+
+// ------------------------------------------------------------------
+// Performance budget — composeGraph builds < 200ms on 10k follows
+// ------------------------------------------------------------------
+
+test('composeGraph: 10k follows builds in under 200ms', () => {
+  const tags = [];
+  for (let i = 0; i < 10000; i++) {
+    // padStart with hex makes each 64-char id unique.
+    tags.push(['p', i.toString(16).padStart(64, '0')]);
+  }
+  const t0 = performance.now();
+  const g = composeGraph({
+    pubkey: ME,
+    contactList: { kind: 3, pubkey: ME, created_at: 100, tags }
+  });
+  const t1 = performance.now();
+  assert.equal(g.firstOrderFollows.size, 10000);
+  assert.ok(t1 - t0 < 200, `expected < 200ms, got ${t1 - t0}ms`);
+});

--- a/tests/metadata-url-normalizer.test.mjs
+++ b/tests/metadata-url-normalizer.test.mjs
@@ -1,0 +1,440 @@
+// URL normalizer tests — Phase 9a Day 1.
+//
+// Spec: XRAY_METADATA_SPEC.md §6.2 + Phase 9a Implementation Plan §5.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { normalize, urlHash } = await import('../src/shared/metadata/url-normalizer.js');
+
+// ------------------------------------------------------------------
+// Rule 1 — lowercase scheme + host
+// ------------------------------------------------------------------
+
+test('lowercases scheme', () => {
+  assert.equal(normalize('HTTPS://example.com/'), 'https://example.com/');
+  assert.equal(normalize('HTTP://example.com/'), 'http://example.com/');
+});
+
+test('lowercases hostname', () => {
+  assert.equal(normalize('https://Example.COM/foo'), 'https://example.com/foo');
+  assert.equal(normalize('https://NEWS.YCombinator.com/item?id=1'), 'https://news.ycombinator.com/item?id=1');
+});
+
+test('does NOT lowercase path', () => {
+  // Many servers are case-sensitive on path. We must preserve case.
+  assert.equal(
+    normalize('https://example.com/Article-About-Things'),
+    'https://example.com/Article-About-Things'
+  );
+});
+
+test('does NOT lowercase query values', () => {
+  assert.equal(
+    normalize('https://example.com/?q=Hello+World'),
+    'https://example.com/?q=Hello%20World'
+  );
+});
+
+// ------------------------------------------------------------------
+// Rule 2 — strip default ports
+// ------------------------------------------------------------------
+
+test('strips default port :443 for https', () => {
+  assert.equal(normalize('https://example.com:443/path'), 'https://example.com/path');
+});
+
+test('strips default port :80 for http', () => {
+  assert.equal(normalize('http://example.com:80/path'), 'http://example.com/path');
+});
+
+test('strips default port :21 for ftp', () => {
+  assert.equal(normalize('ftp://example.com:21/file'), 'ftp://example.com/file');
+});
+
+test('strips default port :443 for wss', () => {
+  assert.equal(normalize('wss://relay.example:443/'), 'wss://relay.example/');
+});
+
+test('preserves non-default ports', () => {
+  assert.equal(normalize('https://example.com:8443/path'), 'https://example.com:8443/path');
+  assert.equal(normalize('http://localhost:3000/'), 'http://localhost:3000/');
+});
+
+// ------------------------------------------------------------------
+// Rule 3 — drop tracking params
+// ------------------------------------------------------------------
+
+test('strips utm_* tracking params', () => {
+  assert.equal(
+    normalize('https://example.com/article?utm_source=newsletter&utm_medium=email&utm_campaign=launch'),
+    'https://example.com/article'
+  );
+});
+
+test('strips fbclid', () => {
+  assert.equal(
+    normalize('https://example.com/article?fbclid=IwAR1234'),
+    'https://example.com/article'
+  );
+});
+
+test('strips gclid', () => {
+  assert.equal(
+    normalize('https://example.com/article?gclid=Cj0K'),
+    'https://example.com/article'
+  );
+});
+
+test('strips msclkid', () => {
+  assert.equal(
+    normalize('https://example.com/article?msclkid=abc'),
+    'https://example.com/article'
+  );
+});
+
+test('strips Mailchimp ids', () => {
+  assert.equal(
+    normalize('https://example.com/article?mc_cid=abc&mc_eid=def'),
+    'https://example.com/article'
+  );
+});
+
+test('strips Substack share trackers', () => {
+  assert.equal(
+    normalize('https://author.substack.com/p/post?__source=share-preview&__share=foo'),
+    'https://author.substack.com/p/post'
+  );
+});
+
+test('strips Instagram igshid', () => {
+  assert.equal(
+    normalize('https://www.instagram.com/p/ABC/?igshid=xyz'),
+    'https://www.instagram.com/p/ABC'
+  );
+});
+
+test('strips YouTube share `feature` param', () => {
+  assert.equal(
+    normalize('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=share'),
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  );
+});
+
+test('strips Spotify `si` share param', () => {
+  assert.equal(
+    normalize('https://open.spotify.com/track/foo?si=abc123'),
+    'https://open.spotify.com/track/foo'
+  );
+});
+
+test('strips X/Twitter `s` and `t` share params', () => {
+  // s and t are the X share trackers. On X domains we strip them; on
+  // other domains they're treated as content (per the documented
+  // trade-off).
+  assert.equal(
+    normalize('https://x.com/user/status/12345?s=20&t=abc'),
+    'https://x.com/user/status/12345'
+  );
+  assert.equal(
+    normalize('https://twitter.com/user/status/12345?s=20'),
+    'https://twitter.com/user/status/12345'
+  );
+});
+
+test('preserves `s` and `t` params on non-X hosts', () => {
+  // Some hosts use `s=` or `t=` as content. We don't strip on those.
+  assert.equal(
+    normalize('https://example.com/search?s=query&t=results'),
+    'https://example.com/search?s=query&t=results'
+  );
+});
+
+test('preserves content query params alongside trackers', () => {
+  assert.equal(
+    normalize('https://example.com/article?id=42&utm_source=newsletter&page=3'),
+    'https://example.com/article?id=42&page=3'
+  );
+});
+
+test('tracking-param stripping is case-insensitive on key', () => {
+  assert.equal(
+    normalize('https://example.com/article?UTM_SOURCE=Foo&Fbclid=Bar'),
+    'https://example.com/article'
+  );
+});
+
+test('strips multiple known trackers in one URL', () => {
+  assert.equal(
+    normalize('https://example.com/x?utm_source=a&utm_medium=b&fbclid=c&gclid=d&msclkid=e&_ga=f'),
+    'https://example.com/x'
+  );
+});
+
+test('strips mc_cid, mc_eid, _ga, _gl', () => {
+  assert.equal(
+    normalize('https://example.com/article?mc_cid=a&mc_eid=b&_ga=c&_gl=d'),
+    'https://example.com/article'
+  );
+});
+
+test('strips ref/referrer/source generic trackers', () => {
+  assert.equal(
+    normalize('https://example.com/article?ref=twitter&referrer=foo&source=bar'),
+    'https://example.com/article'
+  );
+});
+
+// ------------------------------------------------------------------
+// Rule 4 — fragments
+// ------------------------------------------------------------------
+
+test('strips plain fragment', () => {
+  assert.equal(normalize('https://example.com/article#section-1'), 'https://example.com/article');
+});
+
+test('strips empty fragment', () => {
+  assert.equal(normalize('https://example.com/article#'), 'https://example.com/article');
+});
+
+test('preserves W3C text fragment', () => {
+  // Text Fragments are part of the canonical URL because annotations
+  // may anchor to a text fragment.
+  const url = 'https://example.com/article#:~:text=specific%20phrase';
+  assert.equal(normalize(url), url);
+});
+
+test('preserves text fragment with anchor prefix', () => {
+  const url = 'https://example.com/article#section:~:text=specific';
+  // Both forms acceptable per spec; current rule keeps the whole hash
+  // when ":~:text=" is present.
+  assert.equal(normalize(url), url);
+});
+
+// ------------------------------------------------------------------
+// Rule 5 — trailing slash on non-root path
+// ------------------------------------------------------------------
+
+test('strips trailing slash on non-root path', () => {
+  assert.equal(normalize('https://example.com/article/'), 'https://example.com/article');
+});
+
+test('strips trailing slash even with query', () => {
+  assert.equal(
+    normalize('https://example.com/article/?id=1'),
+    'https://example.com/article?id=1'
+  );
+});
+
+test('strips trailing slash even with text fragment', () => {
+  assert.equal(
+    normalize('https://example.com/article/#:~:text=hi'),
+    'https://example.com/article#:~:text=hi'
+  );
+});
+
+test('preserves root slash', () => {
+  assert.equal(normalize('https://example.com/'), 'https://example.com/');
+});
+
+test('preserves trailing slash inside path (only strips final)', () => {
+  // Foo/bar/ → Foo/bar (only one slash stripped from the end)
+  assert.equal(normalize('https://example.com/Foo/bar/'), 'https://example.com/Foo/bar');
+});
+
+// ------------------------------------------------------------------
+// Rule 6 — sort query parameters
+// ------------------------------------------------------------------
+
+test('sorts query parameters alphabetically', () => {
+  assert.equal(
+    normalize('https://example.com/?b=2&a=1&c=3'),
+    'https://example.com/?a=1&b=2&c=3'
+  );
+});
+
+test('sorted output is invariant under input ordering', () => {
+  const a = normalize('https://example.com/?id=5&page=2&sort=date');
+  const b = normalize('https://example.com/?sort=date&id=5&page=2');
+  const c = normalize('https://example.com/?page=2&sort=date&id=5');
+  assert.equal(a, b);
+  assert.equal(b, c);
+});
+
+test('sort handles repeated keys (stable, by value)', () => {
+  // URL spec preserves repeated keys; sort by key, then by value.
+  // URLSearchParams.entries() preserves insertion order for same key.
+  const out = normalize('https://example.com/?b=2&a=2&a=1');
+  // Both `a` entries before `b`. Within `a`, original order preserved.
+  assert.match(out, /^https:\/\/example\.com\/\?a=2&a=1&b=2$/);
+});
+
+// ------------------------------------------------------------------
+// Edge cases
+// ------------------------------------------------------------------
+
+test('returns input unchanged on parse failure', () => {
+  assert.equal(normalize('not a url'), 'not a url');
+  assert.equal(normalize(''), '');
+  assert.equal(normalize('::::'), '::::');
+});
+
+test('handles non-string input safely', () => {
+  assert.equal(normalize(null), null);
+  assert.equal(normalize(undefined), undefined);
+  // numbers/objects are passed through (no string ops to do)
+  assert.equal(normalize(42), 42);
+});
+
+test('handles URL with username/password (preserves them)', () => {
+  // Rare but possible. Don't strip auth.
+  assert.equal(
+    normalize('https://user:pass@example.com/'),
+    'https://user:pass@example.com/'
+  );
+});
+
+test('handles IDN hostname', () => {
+  // The URL constructor punycodes IDN automatically. We just make sure
+  // we don't accidentally lowercase the punycoded form (it's already
+  // lowercase ASCII).
+  const out = normalize('https://Bücher.example/');
+  assert.match(out, /^https:\/\/xn--/);
+});
+
+test('handles IPv6 host', () => {
+  assert.equal(normalize('https://[::1]:443/'), 'https://[::1]/');
+  assert.equal(normalize('http://[::1]:80/'), 'http://[::1]/');
+});
+
+test('handles port 0 (preserves it)', () => {
+  // Edge case but valid syntax. Don't accidentally strip.
+  assert.equal(normalize('http://example.com:0/'), 'http://example.com:0/');
+});
+
+test('handles URL-encoded path correctly', () => {
+  assert.equal(
+    normalize('https://example.com/Hello%20World'),
+    'https://example.com/Hello%20World'
+  );
+});
+
+test('combined: strips trackers, sorts params, lowercases host, strips slash', () => {
+  assert.equal(
+    normalize('HTTPS://Example.COM:443/Article/?utm_source=Foo&id=5&fbclid=Bar&page=2#section'),
+    'https://example.com/Article?id=5&page=2'
+  );
+});
+
+// ------------------------------------------------------------------
+// Cross-platform / real-world URL fixtures
+// ------------------------------------------------------------------
+
+test('Substack post with share trackers', () => {
+  assert.equal(
+    normalize('https://noahpinion.substack.com/p/the-fed-is-now-pricing-in-recession?__source=share-preview&utm_source=email&utm_medium=email-share-preview&__share=foo'),
+    'https://noahpinion.substack.com/p/the-fed-is-now-pricing-in-recession'
+  );
+});
+
+test('YouTube watch URL with share feature', () => {
+  assert.equal(
+    normalize('https://www.youtube.com/watch?v=dQw4w9WgXcQ&feature=youtu.be'),
+    'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  );
+});
+
+test('YouTube short URL (youtu.be) is NOT canonicalized to youtube.com', () => {
+  // We don't do host rewrites — that would change semantics. The user
+  // can configure per-host equivalences higher up the stack.
+  assert.equal(
+    normalize('https://youtu.be/dQw4w9WgXcQ?si=abc'),
+    'https://youtu.be/dQw4w9WgXcQ'
+  );
+});
+
+test('Twitter/X status URL with share params', () => {
+  assert.equal(
+    normalize('https://x.com/jack/status/20?s=20&t=ABC'),
+    'https://x.com/jack/status/20'
+  );
+});
+
+test('Mobile m. host preserved', () => {
+  // We do NOT rewrite m.x.com → x.com. Different content (mobile site).
+  assert.equal(
+    normalize('https://m.example.com/article'),
+    'https://m.example.com/article'
+  );
+});
+
+test('AMP URL preserved as-is', () => {
+  // We do NOT rewrite /amp/ paths to non-AMP. That's a per-publisher
+  // policy decision that doesn't belong in URL normalization.
+  assert.equal(
+    normalize('https://example.com/article/amp/'),
+    'https://example.com/article/amp'
+  );
+});
+
+test('Bitcoin Magazine deep article URL', () => {
+  assert.equal(
+    normalize('https://bitcoinmagazine.com/business/article-slug?utm_source=feed'),
+    'https://bitcoinmagazine.com/business/article-slug'
+  );
+});
+
+test('FT article with subscriber-share token preserved (no known tracker key)', () => {
+  // Don't strip params we don't recognize. False positives are worse
+  // than false negatives here — a missed tracker just slightly forks
+  // the metadata graph; an over-stripped param breaks article access.
+  assert.equal(
+    normalize('https://www.ft.com/content/abc-123?shareType=nongift'),
+    'https://www.ft.com/content/abc-123?shareType=nongift'
+  );
+});
+
+test('Bitcoin Optech newsletter URL with utm_*', () => {
+  assert.equal(
+    normalize('https://bitcoinops.org/en/newsletters/2026/04/30/?utm_source=newsletter&utm_medium=email'),
+    'https://bitcoinops.org/en/newsletters/2026/04/30'
+  );
+});
+
+test('Stacker News post URL', () => {
+  assert.equal(
+    normalize('https://stacker.news/items/12345/r/foo'),
+    'https://stacker.news/items/12345/r/foo'
+  );
+});
+
+// ------------------------------------------------------------------
+// urlHash
+// ------------------------------------------------------------------
+
+test('urlHash returns 16-character hex prefix', async () => {
+  const h = await urlHash('https://example.com/article');
+  assert.match(h, /^[0-9a-f]{16}$/);
+});
+
+test('urlHash is deterministic', async () => {
+  const a = await urlHash('https://example.com/article');
+  const b = await urlHash('https://example.com/article');
+  assert.equal(a, b);
+});
+
+test('urlHash equates URLs that normalize equal', async () => {
+  // Different surface forms that all normalize to the same canonical
+  // URL must hash identically. This is the load-bearing property.
+  const a = await urlHash('https://Example.COM/article?utm_source=x&id=5');
+  const b = await urlHash('HTTPS://example.com:443/article?id=5');
+  const c = await urlHash('https://example.com/article?id=5#section');
+  assert.equal(a, b);
+  assert.equal(b, c);
+});
+
+test('urlHash differs for different normalized URLs', async () => {
+  const a = await urlHash('https://example.com/article-1');
+  const b = await urlHash('https://example.com/article-2');
+  assert.notEqual(a, b);
+});


### PR DESCRIPTION
Phase 9a Week 1 — the data-model foundation for crowdsourced URL metadata (annotations / fact-checks / ratings / topic-trust / helpfulness votes), conforming to `docs/NIP_DRAFT.md`.

## Contents (3 commits)
- **Phase 9a Week 1** — `src/shared/metadata/`: NIP-73 URL normalizer, W3C-selector anchor capture + resolver (confidence cascade), trust graph (kind 3 + kind 30053), v1 ranker, all five event builders (30050/30051/30052/30053/9803) + the kind 30023 `responds-to` extension, feature flags. IDB v2 stores in `archive-cache.js`.
- **NIP conformance** — reconciled builders to `NIP_DRAFT.md` (anchor-tag sets per kind, single W3C `@context`, `nostr.dev/scale/v1`, `correction-type`).
- **NIP draft** — `docs/NIP_DRAFT.md` committed as the wire-format reference.

Pure data model — no UI surfaces (Week 2+). All best-effort, additive.

## Tests
442/442 green; build clean (5 bundles). New: `tests/metadata-*.test.mjs` (url-normalizer, anchor-capture, anchor-resolver, trust-graph, builders, ranker).

## Notes
- Rebased onto `main` after PR #21; only the 3 metadata commits remain.
- No IDB collision with the identity branch (that one keeps its registry in `chrome.storage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)