### PR TITLE
release: v0.5.0 — post-consolidation docs + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Sections per release: **Added** (new features), **Changed**
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-29
+
+This release consolidates three feature lines onto `main`: default-to-local
+signing + the consolidated Settings hub, the Phase 9a crowdsourced
+URL-metadata data model + NIP draft, and the Phase 9 social-media identity
+layer.
+
 ### Added
 
 - **Signing method is now an explicit user preference**
@@ -50,7 +57,46 @@ Sections per release: **Added** (new features), **Changed**
   through `Storage.relays.get()` and keeps `default_relays` in sync.
 - **12 new tests in `tests/signer.test.mjs`** covering all three
   signing branches, primaryIdentity round-trip, the `signing_method`
-  migration, and `Storage.relays.set()`. Total: 235 (up from 223).
+  migration, and `Storage.relays.set()`.
+- **Phase 9a — crowdsourced URL-metadata data model** (`src/shared/metadata/`).
+  The wire-format foundation for annotations, fact-checks, ratings,
+  topic-scoped trust, and helpfulness votes, conforming to
+  `docs/NIP_DRAFT.md`:
+  - NIP-73-conformant URL normalizer (`url-normalizer.js`);
+    `Utils.normalizeUrl` is now a thin wrapper over it.
+  - W3C Web Annotation selector capture + a confidence-scored
+    resolution cascade (`anchor-capture.js` / `anchor-resolver.js`).
+  - Builders for kinds 30050 (Annotation), 30051 (FactCheck), 30052
+    (Rating), 30053 (TopicTrust), 9803 (HelpfulnessVote) + the kind
+    30023 `responds-to` tag extension (`builders.js`).
+  - First-order trust graph (kind 3 + kind 30053) and a v1
+    binary-trust ranker (`trust-graph.js` / `ranker.js`).
+  - Feature flags gating the not-yet-surfaced kinds; IDB v2 metadata
+    stores in `archive-cache.js`. Data model only — no UI yet.
+  - `docs/NIP_DRAFT.md` — the authoritative wire-format spec
+    ("Web Content Annotations, Fact-Checks, and Topic Trust").
+- **Phase 9 — social-media identity layer** (`src/shared/identity/`).
+  Turns a captured author (commenter or post author) into a stable,
+  cross-capture identity and lets the user collapse cross-platform
+  accounts into one canonical person:
+  - Deterministic `accountPubkey` per `<platform>:<stableId>`
+    (`platform-account.js`) — an identifier-only key that never signs;
+    a `Storage.platformAccounts` registry in `chrome.storage`.
+  - Published comments and post authors now carry a stable `p`-tag
+    identity (kind 30041 / 30023), via `recordAccount` + the existing
+    `buildCommentEvent` socket and a new optional `authorAccountPubkey`
+    on `buildArticleEvent`.
+  - **YouTube comment capture** — parses the InnerTube
+    `/youtubei/v1/next` responses (reusing the Phase 8a api-interceptor;
+    both legacy `commentThreadRenderer` and modern `commentEntityPayload`
+    shapes), keyed on the commenter's channelId. Scroll the comments
+    into view before capturing (see `docs/CAPTURE_GUIDE.md`).
+  - **Manual account↔entity linking** in the sidepanel Entity Browser,
+    with alias-chain-aware `resolveAccountToEntity`. v1 is
+    local-index-only (no kind 32126 relay publish) and manual-link-only.
+- **Combined test suite: 519 passing** (up from 223 at v0.4.0), adding
+  `tests/metadata-*`, `tests/identity-*`, `tests/youtube-comments`, and
+  `tests/platform-account-event`.
 
 ### Changed
 
@@ -337,6 +383,8 @@ roadmap landed:
 - **Phase 7** — Archive reader: IndexedDB cache, paywall detection,
   relay-backed reconstruction.
 
-[Unreleased]: https://github.com/bryanmatthewsimonson/xray/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/bryanmatthewsimonson/xray/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/bryanmatthewsimonson/xray/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/bryanmatthewsimonson/xray/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/bryanmatthewsimonson/xray/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/bryanmatthewsimonson/xray/releases/tag/v0.2.0

--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ has already said about it.*
 
 ## Status
 
-Phases 0–8 of the roadmap are complete. The extension can capture across
-every shipped platform handler, publish events end-to-end, sync entity
-data across devices, and reconstruct paywalled content from cached or
-relay copies. The codebase is past the userscript-paradigm port and now
-operates as a pure WebExtension.
+Phases 0–8 of the roadmap are complete, plus the Phase 9a metadata data
+model and the Phase 9 identity layer (v0.5.0). The extension captures
+across every shipped platform handler, publishes events end-to-end, syncs
+entity data across devices, reconstructs paywalled content from cached or
+relay copies, and now carries the wire-format foundation for crowdsourced
+URL metadata (annotations / fact-checks / topic-trust — see
+[`docs/NIP_DRAFT.md`](docs/NIP_DRAFT.md)) plus a stable cross-platform
+identity layer (captured commenters and post authors become dedup-able
+identities; cross-platform accounts can be collapsed into one person).
+The codebase is past the userscript-paradigm port and operates as a pure
+WebExtension.
 
 The [**roadmap**](docs/ROADMAP.md) tracks per-phase scope. The
 [**engineering journal**](docs/JOURNAL.md) logs significant bugs, design
@@ -232,7 +238,7 @@ produces `dist/*.bundle.js`, which the manifest loads).
 │           ├── instagram.js       og-meta + DOM scrape + GraphQL
 │           ├── tiktok.js          three SSR shapes + screenshot
 │           └── comment-extractor.js  generic WordPress / Disqus probe
-└── tests/                         node --test suite (235 passing)
+└── tests/                         node --test suite (519 passing)
 ```
 
 ## Permissions
@@ -253,7 +259,7 @@ produces `dist/*.bundle.js`, which the manifest loads).
 - **Build:** `npm install`, then `npm run build` to produce
   `dist/*.bundle.js` and `dist/*.bundle.js.map`. esbuild handles all
   bundling; no transpile step. `npm run watch` for incremental.
-- **Tests:** `npm test` runs `node --test tests/*.test.mjs`. **235
+- **Tests:** `npm test` runs `node --test tests/*.test.mjs`. **519
   tests** today, covering crypto, event-builder, every platform
   handler, entity sync, claim model, archive cache, the Signer
   façade, and the URL normalizer.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,6 +45,8 @@ Phase 5  ████████████████████  complete 
 Phase 6  ████████████████████  complete — entity sync via NIP-78 + NIP-44 v2
 Phase 7  ████████████████████  complete — archive reader (IDB cache + paywall detection + relay reconstruct)
 Phase 8  ████████████████████  complete — 8a infra + TikTok + Instagram + Facebook shipped
+Phase 9a ████████████████████  complete — URL-metadata data model (annotations / fact-checks / topic-trust) + NIP draft; data-model only, UI in 9b+
+Phase 9  ████████████████████  complete — identity layer: platform accounts + YouTube comments + manual account↔entity linking
 ```
 
 ---

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -14,7 +14,7 @@ git clone …
 cd xray
 npm install
 npm run build           # produces dist/*.bundle.js (5 bundles)
-npm test                # 235/235 should pass
+npm test                # 519/519 should pass
 ```
 
 ### Chrome / Chromium / Brave / Edge
@@ -88,7 +88,7 @@ For each platform handler:
 2. **Read console** filtered by `X-Ray` — look for the init
    sequence. With Local signing selected (the default):
    ```
-   [X-Ray] Starting X-Ray content script v0.4.0
+   [X-Ray] Starting X-Ray content script v0.5.0
    [X-Ray] LocalKeyManager initialized with N keys
    [X-Ray] UI initialized
    [X-Ray] Local signing identity ready: npub1…
@@ -187,7 +187,7 @@ clicking through every URL.
 | # | Test | Pass criteria |
 |---|---|---|
 | 0.1 | `npm run build` exits 0 with no errors | ✅ all five bundles emitted under `dist/` (content, background, options, sidepanel, reader) plus `api-interceptor` |
-| 0.2 | `npm test` exits 0 | ✅ 235/235 (or current-on-main count) passing |
+| 0.2 | `npm test` exits 0 | ✅ 519/519 (or current-on-main count) passing |
 | 0.3 | Reload extension after a build → no console errors in the SW log | ✅ the SW log under `chrome://extensions` → "Inspect views: service worker" is clean |
 | 0.4 | Click toolbar icon on a normal http page | ✅ FAB capture panel toggles open/closed (no popup window) |
 | 0.5 | Click toolbar icon on `chrome://newtab` | ✅ Options page opens (fallback, since content script can't run there) |

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X-Ray — NOSTR URL Metadata & Article Capture",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Capture articles as Markdown and publish to NOSTR — Chrome/Firefox MV3 extension.",
   "author": "Decentralized News Network",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-extension",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "NOSTR-sourced URL metadata & article capture — Chrome/Firefox MV3 WebExtension.",
   "repository": "github:bryanmatthewsimonson/xray",

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -3,7 +3,7 @@
 // content/ui.js, background/index.js (indirectly via the above).
 
 export const CONFIG = {
-    version: '0.2.0',
+    version: '0.5.0',
     // Off by default — users who want noise can flip
     // `preferences.debug` in the options page Advanced tab.
     debug: false,


### PR DESCRIPTION
Records the v0.5.0 release after consolidating PRs #21 (signing/UI) + #22 (Phase 9a metadata) + #23 (Phase 9 identity) onto main.

- **Version → 0.5.0** in package.json + manifest.json (lockstep) and `CONFIG.version` (was a stale 0.2.0).
- **CHANGELOG** — dated `[0.5.0]` section folding in metadata + identity alongside signing/UI; compare-link refs fixed.
- **README / ROADMAP** — Status + phase snapshot now cover Phase 9a + the identity layer; test count 235 → 519.
- **SMOKE_TEST** — init-log version + counts (519/519) refreshed.

No code changes beyond the `CONFIG.version` string. Suite **519/519**, build clean.

After this merges I'll delete the three merged feature branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)