### PR TITLE
Release v0.5.1 — inline-name extractor fix + CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Sections per release: **Added** (new features), **Changed**
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inline person/place names no longer vanish from article captures** on
+  sites that wrap them in `popup`-classed elements (e.g.
+  josephsmithpapers.org). Readability's `unlikelyCandidates` blocklist
+  matches the substring `popup` and was deleting the whole wrapper —
+  visible name included — leaving dangling punctuation. The extractor now
+  unwraps `aside.popup-wrapper` to its reference text before Readability
+  runs.
+
 ## [0.5.0] — 2026-05-29
 
 This release consolidates three feature lines onto `main`: default-to-local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Sections per release: **Added** (new features), **Changed**
   visible name included — leaving dangling punctuation. The extractor now
   unwraps `aside.popup-wrapper` to its reference text before Readability
   runs.
+- **Publishing no longer fails with `invalid: tag val was not a string`**
+  on pages whose JSON-LD carries a non-string `articleSection` (array) or
+  `inLanguage` (object). The kind-30023 builder now sanitizes every tag
+  value to a string — flattening arrays, extracting `name`/`@value` from
+  schema.org objects, and dropping anything unstringifiable — so a single
+  odd metadata field can't make relays reject the whole event.
 
 ## [0.5.0] — 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Sections per release: **Added** (new features), **Changed**
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-06-06
+
 ### Fixed
 
 - **Inline person/place names no longer vanish from article captures** on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,192 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+X-Ray is a Chrome/Firefox **MV3 WebExtension** (no framework, no
+TypeScript, no transpile) that captures web pages — articles, Substack
+posts, YouTube videos with transcripts, tweets, Facebook/Instagram/TikTok
+posts — as Markdown and publishes them to NOSTR. It ships its own NOSTR
+crypto (secp256k1 / BIP-340 / bech32 / NIP-44 v2) and signs locally by
+default. It was ported from the `nostr-article-capture` userscript; some
+modules still carry userscript-era idioms (see Conventions).
+
+## Commands
+
+```sh
+npm install            # required first — a fresh clone has no node_modules
+npm run build          # esbuild → dist/*.bundle.js (+ .map). No transpile step.
+npm run watch          # incremental rebuild
+npm test               # node --test tests/*.test.mjs  (519 tests, must be green)
+npm run lint           # web-ext lint --self-hosted (what CI gates on)
+npm run version:set X  # bump package.json + manifest.json in lockstep
+npm run clean          # rm -rf dist
+```
+
+- **Run a single test file:** `node --test tests/youtube.test.mjs`
+- **Tests fail with `ERR_MODULE_NOT_FOUND` (`@mozilla/readability`, etc.)
+  if you skipped `npm install`** — that's the #1 false alarm in a fresh
+  container, not a real regression.
+- Tests are `node --test` over `.mjs` files importing the ES modules in
+  `src/` directly. `fake-indexeddb` backs the archive-cache tests; there
+  is no browser/jsdom — anything touching `chrome.*` or the DOM is tested
+  against hand-built stubs in the test file.
+- **Loading the unpacked extension:** Chrome `chrome://extensions` →
+  Developer mode → Load unpacked → point at the repo root (`manifest.json`
+  is at the root by design). Firefox `about:debugging` → Load Temporary
+  Add-on → pick `manifest.json`. After any rebuild, click reload on the
+  extension card **and** reload the test tab — content scripts do not
+  re-inject on extension reload.
+
+## Build model (esbuild → dist/)
+
+`esbuild.config.mjs` produces six bundles from entry points. The manifest
+and HTML shells reference `dist/*.bundle.js`; **`src/` is never loaded
+directly except the two MAIN-world page scripts.** Entry points:
+
+- `src/content/index.js` → `content.bundle.js` (IIFE, isolated world, every tab)
+- `src/background/index.js` → `background.bundle.js` (**ESM** service worker, `conditions: ['worker','browser']`)
+- `src/options|sidepanel|reader/index.js` → matching IIFE bundles (loaded by their HTML shells)
+- `src/page/api-interceptor.js` → `api-interceptor.bundle.js` (IIFE; runs in the page MAIN world — **no shared imports allowed**, the file's IIFE is the whole module)
+
+`src/page/nip07-bridge.js` is loaded **unbundled** straight from `src/` as a
+MAIN-world content script (and is a `web_accessible_resource`). There is no
+popup surface — the toolbar click toggles the in-page FAB.
+
+## Architecture (the big picture)
+
+Four JS execution contexts, kept strictly separate, talking over
+`chrome.runtime`/`postMessage`. Understanding which context code runs in is
+the single most important thing here.
+
+1. **Content script** (`src/content/`, isolated world) — bootstraps on
+   every tab, owns the FAB and the capture pipeline (`ui.js` →
+   `openReader`). Runs the platform handlers and DOM extraction. Cannot
+   open WebSockets to relays on CSP-strict sites, so it delegates publish.
+2. **Background service worker** (`src/background/index.js`, ESM) — owns
+   the **relay WebSocket pool** (connections survive tab navigation and
+   aren't subject to page CSP — this is *why* the pool lives here, not in
+   the content script), context menus, toolbar/keyboard commands,
+   notifications, YouTube transcript fetch, and screenshot capture. MV3
+   SWs sleep/wake, so startup re-reads the debug pref and re-attaches a
+   `chrome.storage.onChanged` listener every wake.
+3. **Extension pages** (`src/options/`, `src/reader/`, `src/sidepanel/`) —
+   options is the single settings hub (Relays / Signing / Entities /
+   Keypair Registry / Migrate / Advanced); reader renders the captured
+   article + publish flow; sidepanel is the entity browser.
+4. **MAIN world page scripts** (`src/page/`) — `nip07-bridge.js` exposes
+   `window.nostr` to the extension via tagged `postMessage` envelopes;
+   `api-interceptor.js` hooks `fetch`/XHR on FB/IG/YouTube to capture
+   GraphQL responses (buffered through `shared/api-hook-buffer.js`).
+
+**Capture → publish handoff:** FAB click extracts the article, stashes it
+in `chrome.storage.session` under a UUID, opens the reader with `?id=<uuid>`.
+The reader's publish flow routes signing back through the **source tab**
+when NIP-07 is active, so the user's signer extension approves in-context.
+
+**Message bus:** everything is `chrome.runtime` messages typed `xray:*`
+(e.g. `xray:toggle`, `xray:capture:publish`, `xray:relay:publish`,
+`xray:relay:query`, `xray:sign`, `xray:youtube:fetch`,
+`xray:screenshot:capture`, `xray:flags:reload`). When adding a cross-context
+call, add an `xray:*` message rather than reaching across contexts directly.
+
+### Shared layer (`src/shared/`)
+
+Pure-ish modules imported by multiple bundles. Most export a single
+namespace object (`export const Storage = …`, `export const Signer = …`).
+
+- **`storage.js`** — `chrome.storage.local` wrapper; the **canonical source
+  of truth**. Preserves the userscript's outer API (`Storage.get/set/...`
+  plus `publications`/`people`/`organizations`/`preferences`/`keypairs`
+  sub-objects) so callers didn't change during the port. Values are
+  JSON-serialized for export/import compatibility. Note: the **primary
+  signing identity (Local mode) lives under a separate
+  `local_primary_identity` key**, deliberately *outside* the keypair
+  registry, so exporting entity keys never leaks the user's nsec.
+- **`signer.js`** — unified signing façade over Local / NIP-07 /
+  NSecBunker, dispatched on `preferences.signing_method`. NIP-07 only works
+  where a `nip07Client` is injected (`Signer.configure({ nip07Client })`),
+  i.e. the content script; other contexts pass a `signRequestForwarder`
+  that proxies to a tab.
+- **`crypto.js`** — real secp256k1 / BIP-340 Schnorr / bech32 / NIP-44 v2,
+  unit-tested against the BIP-340 vectors. Don't hand-roll alternatives.
+- **`event-builder.js`** — builds the NOSTR events (NIP-23 `30023`, claims
+  `30040`, comments `30041`, evidence `30043`, relationships `32125`) and
+  the archive-reader inverse. **Wire-format changes here have compatibility
+  consequences for anyone consuming X-Ray events — call them out
+  explicitly.**
+- **`content-detector.js` / `content-extractor.js`** — URL+DOM platform
+  detection; Readability + Turndown → Markdown.
+- **`platforms/`** — per-site handlers (`index.js` dispatches). They run in
+  the content script and **return plain data objects only — no DOM
+  mutation, no UI.** Add a new site by adding a handler here + a detector
+  case, not by special-casing the UI.
+- **`metadata/`** (Phase 9a) — wire-format foundation for crowdsourced URL
+  metadata (annotations / fact-checks / topic-trust; see
+  `docs/NIP_DRAFT.md`). Gated by **`metadata/feature-flags.js`**: defaults
+  in `FLAGS_DEFAULTS`, overridable via `chrome.storage.local` key
+  `xray:flags`. The service worker always *accepts* incoming events of
+  every kind; only publish paths and panel tabs are flag-gated.
+- **`identity/`** (Phase 9) — cross-platform identity layer: captured
+  commenters/authors become dedup-able identities, and cross-platform
+  accounts can be collapsed into one person.
+- Also: `nostr-client.js` (relay pool, used from background),
+  `archive-cache.js` (IndexedDB + paywall reconstruction),
+  `userscript-migration.js` (legacy JSON importer for Settings → Migrate).
+
+## Conventions
+
+- **Indentation: 4 spaces** in JS authored here; **2 spaces** in files
+  ported verbatim from the userscript (preserved so userscript diffs stay
+  readable). Match the file you're editing.
+- **`config.js` carries snake_case keys** (e.g. `min_content_length`) to
+  match the v4 userscript for drop-in module portability, with some
+  camelCase legacy aliases kept alongside. Don't "tidy" these casings.
+- **CSS prefixes:** `xr-*` for extension-chrome UI (options/reader/side
+  panel) and all *new* content-script UI. `nac-*` / `nmd-*` are legacy
+  userscript prefixes still in the FAB/capture CSS — **don't add new
+  `nac-*` classes**; a bulk rename to `xr-*` is a known cosmetic follow-up.
+- **Logging:** use `Utils.log` / `Utils.error` (no-ops when `CONFIG.debug`
+  is false). Don't add bare `console.log`.
+- **User-visible strings** use "X-Ray" (hyphenated). Avoid emoji in code
+  unless it's genuinely part of the UI.
+- **Version lockstep:** `package.json` and `manifest.json` versions MUST
+  agree — **CI rejects a mismatch.** Use `npm run version:set X`, which
+  edits both.
+- **Firefox floor is `gecko.strict_min_version: 128.0`** and is load-bearing
+  (`world: "MAIN"` content scripts, `scripting.executeScript({world:'MAIN'})`,
+  and `declarativeNetRequest` response-header rewriting all land in exactly
+  128). Don't lower it; don't bump it without a dependency that requires it.
+  `rules/csp-strip.json` strips CSP so the YouTube transcript fetch reaches
+  `/api/timedtext`.
+- **Private keys:** the keypair registry in `chrome.storage.local` holds
+  private keys — never paste its contents into issues/logs/commits. Raw
+  event JSON is fine (`pubkey` is public by definition).
+- **Commit messages:** imperative present tense; `fix:`/`feat:`/`chore:`/
+  `docs:`/`ci:` prefixes, scope in parens when useful
+  (`fix(youtube): …`). One concern per PR.
+
+## Project docs (read these for non-trivial work)
+
+- **`docs/ROADMAP.md`** — per-phase scope. Currently through Phase 9a
+  metadata data model + Phase 9 identity layer (v0.5.0).
+- **`docs/JOURNAL.md`** — chronological log of bugs, design decisions, and
+  external-platform changes. **Add a tight entry** when fixing a non-obvious
+  bug, making a second-guessable design choice, or working around a
+  third-party change. Skim it first when a capture target breaks.
+- **`docs/SMOKE_TEST.md`** — ~20-min manual checklist; run before any
+  release tag or after a cross-cutting refactor.
+- **`docs/CAPTURE_GUIDE.md`** — per-platform URL-shape/timing requirements
+  (FB/IG/TikTok are finicky).
+- **`docs/NIP_DRAFT.md`** — the crowdsourced-metadata wire format.
+- **`CONTRIBUTING.md`** — release process (git-tag-driven via
+  `.github/workflows/release.yml`) and the Firefox-floor rationale.
+
+## CI
+
+`.github/workflows/ci.yml` on push/PR to `main`: `node --check` every
+`src/**/*.js`, `npm run build`, `npm test` (if any tests exist), `web-ext
+lint --self-hosted`, `web-ext build`. A `v*` tag triggers `release.yml`
+(builds, packages, creates a GitHub Release with the `.zip`). Get all of
+build + test + lint green locally before pushing.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,39 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-06 — Relays reject events with non-string tag values
+
+**Tags:** bug, external
+
+**Symptom:** Publishing a josephsmithpapers.org capture failed on every
+relay with `invalid: tag val was not a string` (per-relay `{ok:0, fail:1}`).
+The event was otherwise well-formed and signed.
+
+**Root cause:** NOSTR requires every element of every tag to be a string,
+and relays reject the *whole* event if one isn't. `buildArticleEvent`
+pushes some tag values straight from the page's JSON-LD, where schema.org
+legitimately allows non-string shapes: `articleSection` can be an **array**
+(`["History","Religion"]`) and `inLanguage` an **object**
+(`{"@type":"Language","name":"en"}`). Those flowed into `['section', …]`
+and `['lang', …]` as a raw array/object → relay rejection. Most sites emit
+string scalars, so this never showed up in testing until a richly-marked-up
+scholarly site hit it.
+
+**Fix:** `EventBuilder.sanitizeTags()` runs over the article event's tags
+before it's returned. `coerceTagAtom()` turns each value into a string —
+primitives stringify, arrays flatten+join, schema.org objects yield their
+`name`/`@value`/`@id`, anything else becomes null and the tag is dropped
+(a valueless `["section"]` is meaningless). Empty positional markers (the
+`""` in `["p", pk, "", "author"]`) are preserved.
+
+**So-what:** Any tag value sourced from a third party's structured data is
+untrusted shape-wise. The sanitizer is a wire-level guarantee, not a
+per-field patch, so the next exotic JSON-LD field can't silently break
+publishing. Files: `src/shared/event-builder.js`,
+`tests/event-builder.test.mjs`.
+
+---
+
 ## 2026-06-06 — Readability eats inline names on josephsmithpapers.org
 
 **Tags:** bug, external

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,51 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-06 — Readability eats inline names on josephsmithpapers.org
+
+**Tags:** bug, external
+
+**Symptom:** Capturing a Joseph Smith Papers introduction
+(`/intro/introduction-to-administrative-records-volume-1`) produced prose
+with gaps where every person and place name should be — e.g. "organized a
+council in `[ ]`, Illinois" and "met in Nauvoo under `[ ]`'s leadership".
+The body text was otherwise complete (~56k chars captured), so it read as
+"missing full text" but was really *missing inline entities*.
+
+**Root cause:** JSP wraps each inline person/place name in an interactive
+glossary popup:
+
+```html
+<aside class="popup-wrapper">
+  <a class="reference staticPopup" title="Nauvoo, Illinois">Nauvoo</a>
+  <div class="popup-content">…hover blurb…</div>
+</aside>
+```
+
+Readability's `unlikelyCandidates` regex matches the literal substring
+**`popup`**, so during `_grabArticle` it removes the entire `<aside>` —
+visible name included — leaving the surrounding punctuation behind. Plain
+text occurrences of the same word survive because they aren't wrapped. The
+editorial footnote markers (`<aside>` → `a.editorial-note-static`) get
+eaten the same way.
+
+**Fix:** `ContentExtractor._unwrapInlinePopups()` runs on the detached
+document clone *before* Readability. It replaces each `aside.popup-wrapper`
+with its reference link's visible text (so "Nauvoo" becomes a bare text
+node Readability keeps) and drops editorial-note markers so footnote
+superscripts don't litter the prose. It operates on the clone, never the
+live page (so the user's interactive popups are untouched), and is
+best-effort — any failure falls through without blocking extraction.
+
+**So-what:** This is the same class as the YouTube `aria-hidden` timestamp
+drop (2026-04-19 entry): a third party's a11y/interaction markup colliding
+with an extraction heuristic that strips "chrome". The `popup` keyword in
+Readability's blocklist is the trap — any site that renders meaningful
+inline content inside a `popup`-classed element will lose it. Files:
+`src/shared/content-extractor.js`, `tests/content-popup-unwrap.test.mjs`.
+
+---
+
 ## 2026-04-24 — Facebook capture: full shake-down + scope-based DOM discipline
 
 **Tags:** bug, design, pattern

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X-Ray — NOSTR URL Metadata & Article Capture",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Capture articles as Markdown and publish to NOSTR — Chrome/Firefox MV3 extension.",
   "author": "Decentralized News Network",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xray-extension",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xray-extension",
-      "version": "0.3.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-extension",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "NOSTR-sourced URL metadata & article capture — Chrome/Firefox MV3 WebExtension.",
   "repository": "github:bryanmatthewsimonson/xray",

--- a/src/shared/content-extractor.js
+++ b/src/shared/content-extractor.js
@@ -98,7 +98,16 @@ export const ContentExtractor = {
 
       // Clone document for Readability
       const documentClone = document.cloneNode(true);
-      
+
+      // Unwrap inline glossary/footnote popups before Readability runs.
+      // Sites like josephsmithpapers.org wrap inline person/place names in
+      // <aside class="popup-wrapper">. Readability's `unlikelyCandidates`
+      // blocklist matches the literal substring "popup", so it deletes the
+      // whole <aside> — visible name included — leaving dangling
+      // punctuation ("organized a council in , Illinois"). See JOURNAL
+      // 2026-06-06.
+      ContentExtractor._unwrapInlinePopups(documentClone);
+
       // Readability is now bundled via npm import
       {
         const reader = new Readability(documentClone);
@@ -231,6 +240,46 @@ export const ContentExtractor = {
       console.error('[NAC] Article extraction failed:', e);
       return ContentExtractor.extractSimple();
     }
+  },
+
+  // Unwrap inline glossary/footnote popups so the visible reference text
+  // survives Readability. Targets the josephsmithpapers.org shape:
+  //
+  //   <aside class="popup-wrapper">
+  //     <a class="reference staticPopup" title="Nauvoo, Illinois">Nauvoo</a>
+  //     <div class="popup-content">…hover blurb…</div>
+  //   </aside>
+  //
+  // Readability's `unlikelyCandidates` regex matches "popup", so it strips
+  // the whole <aside> and the inline name vanishes. We replace each wrapper
+  // with its reference link's visible text (e.g. "Nauvoo"), and drop
+  // editorial-note markers (footnote superscripts) entirely so they don't
+  // litter the prose. Operates on the detached clone, never the live page.
+  // Best-effort: any failure here must not block extraction.
+  _unwrapInlinePopups: (root) => {
+    let unwrapped = 0;
+    try {
+      if (!root || typeof root.querySelectorAll !== 'function') return 0;
+      // A Document exposes createTextNode directly; an Element does not, so
+      // fall back to its ownerDocument.
+      const doc = (typeof root.createTextNode === 'function') ? root : root.ownerDocument;
+      const wrappers = root.querySelectorAll('aside.popup-wrapper');
+      Array.prototype.forEach.call(wrappers, (wrap) => {
+        // The first anchor in document order is the visible reference; the
+        // hover blurb's links live later inside .popup-content.
+        const ref = wrap.querySelector('a.reference, a.staticPopup');
+        const cls = (ref && ref.className) || '';
+        const label = ref ? (ref.textContent || '').trim() : '';
+        if (label && !/editorial-note/.test(cls)) {
+          wrap.replaceWith(doc.createTextNode(label));
+          unwrapped++;
+        } else {
+          // Footnote-number markers and empty wrappers: remove outright.
+          wrap.remove();
+        }
+      });
+    } catch (_) { /* never block extraction on a popup-unwrap failure */ }
+    return unwrapped;
   },
 
   // Simple fallback extraction

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -326,11 +326,54 @@ export const EventBuilder = {
       kind: 30023,
       pubkey: userPubkey || '',
       created_at: Math.floor(Date.now() / 1000),
-      tags,
+      // Guarantee every tag value is a string. Article metadata harvested
+      // from a page's JSON-LD can legitimately be an array (`articleSection`)
+      // or an object (`inLanguage: {"@type":"Language","name":"en"}`); a
+      // single non-string tag value makes relays reject the *entire* event
+      // with "invalid: tag val was not a string".
+      tags: EventBuilder.sanitizeTags(tags),
       content
     };
-    
+
     return event;
+  },
+
+  // Coerce a single tag atom to a string, or null if it can't be reduced
+  // to a meaningful one. Strings pass through; numbers/booleans stringify;
+  // arrays flatten (filtering empties) and join; schema.org-shaped objects
+  // yield their `name` / `@value` / `@id`; everything else is rejected.
+  coerceTagAtom: (value) => {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    if (value == null) return null;
+    if (Array.isArray(value)) {
+      const parts = value.map(EventBuilder.coerceTagAtom).filter((p) => p);
+      return parts.length ? parts.join(', ') : null;
+    }
+    if (typeof value === 'object') {
+      const candidate = value.name || value['@value'] || value['@id'];
+      return typeof candidate === 'string' ? candidate : null;
+    }
+    return null;
+  },
+
+  // Make a tag array NOSTR-valid: every element must be a string. The tag
+  // name (index 0) must be a non-empty string or the tag is dropped; if a
+  // tag's primary value (index 1) collapses to null the whole tag is
+  // dropped (publishing a `["section"]` with no value is meaningless);
+  // trailing positional slots (e.g. the empty marker in `["p", pk, "",
+  // "author"]`) are preserved as empty strings.
+  sanitizeTags: (tags) => {
+    const out = [];
+    for (const tag of (tags || [])) {
+      if (!Array.isArray(tag) || tag.length === 0) continue;
+      const name = tag[0];
+      if (typeof name !== 'string' || !name) continue;
+      const rest = tag.slice(1).map(EventBuilder.coerceTagAtom);
+      if (tag.length > 1 && rest[0] == null) continue;
+      out.push([name, ...rest.map((atom) => (atom == null ? '' : atom))]);
+    }
+    return out;
   },
 
   // Generate d-tag from URL (16 chars)

--- a/tests/content-popup-unwrap.test.mjs
+++ b/tests/content-popup-unwrap.test.mjs
@@ -1,0 +1,98 @@
+// Tests for ContentExtractor._unwrapInlinePopups — the josephsmithpapers.org
+// inline-name fix. There's no jsdom in this harness, so we exercise the
+// branch logic against hand-built DOM stubs (same approach as the platform
+// handler tests).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ContentExtractor } from '../src/shared/content-extractor.js';
+
+// Minimal stubs ----------------------------------------------------------
+
+function makeRef(className, textContent) {
+    return { className, textContent };
+}
+
+function makeWrapper(ref) {
+    return {
+        ref,
+        replaced: null,
+        removed: false,
+        querySelector() { return this.ref; },
+        replaceWith(node) { this.replaced = node; },
+        remove() { this.removed = true; }
+    };
+}
+
+function makeRoot(wrappers) {
+    return {
+        // A Document exposes createTextNode; mark text nodes so we can assert.
+        createTextNode(text) { return { nodeType: 3, text }; },
+        querySelectorAll(sel) {
+            assert.equal(sel, 'aside.popup-wrapper');
+            return wrappers;
+        }
+    };
+}
+
+// Tests ------------------------------------------------------------------
+
+test('entity reference is replaced with its visible text', () => {
+    const wrap = makeWrapper(makeRef('reference staticPopup', 'Nauvoo'));
+    const root = makeRoot([wrap]);
+
+    const count = ContentExtractor._unwrapInlinePopups(root);
+
+    assert.equal(count, 1);
+    assert.equal(wrap.removed, false);
+    assert.deepEqual(wrap.replaced, { nodeType: 3, text: 'Nauvoo' });
+});
+
+test('person reference text is trimmed', () => {
+    const wrap = makeWrapper(makeRef('reference staticPopup', '  Brigham Young\n\t'));
+    const root = makeRoot([wrap]);
+
+    ContentExtractor._unwrapInlinePopups(root);
+
+    assert.deepEqual(wrap.replaced, { nodeType: 3, text: 'Brigham Young' });
+});
+
+test('editorial-note footnote markers are dropped, not inlined', () => {
+    const wrap = makeWrapper(makeRef('editorial-note-static staticPopup', '1'));
+    const root = makeRoot([wrap]);
+
+    const count = ContentExtractor._unwrapInlinePopups(root);
+
+    assert.equal(count, 0);
+    assert.equal(wrap.removed, true);
+    assert.equal(wrap.replaced, null);
+});
+
+test('empty wrapper with no reference is removed', () => {
+    const wrap = makeWrapper(null);
+    const root = makeRoot([wrap]);
+
+    ContentExtractor._unwrapInlinePopups(root);
+
+    assert.equal(wrap.removed, true);
+    assert.equal(wrap.replaced, null);
+});
+
+test('handles a mix of entity and footnote wrappers in one pass', () => {
+    const name = makeWrapper(makeRef('reference staticPopup', 'Nauvoo'));
+    const note = makeWrapper(makeRef('editorial-note-static staticPopup', '1'));
+    const person = makeWrapper(makeRef('reference staticPopup', 'Brigham Young'));
+    const root = makeRoot([name, note, person]);
+
+    const count = ContentExtractor._unwrapInlinePopups(root);
+
+    assert.equal(count, 2);
+    assert.equal(name.replaced.text, 'Nauvoo');
+    assert.equal(person.replaced.text, 'Brigham Young');
+    assert.equal(note.removed, true);
+});
+
+test('never throws on a malformed root', () => {
+    assert.equal(ContentExtractor._unwrapInlinePopups(null), 0);
+    assert.equal(ContentExtractor._unwrapInlinePopups({}), 0);
+});

--- a/tests/event-builder.test.mjs
+++ b/tests/event-builder.test.mjs
@@ -123,3 +123,57 @@ test('buildRelayListEvent stamps created_at to a recent unix second', () => {
     assert.ok(ev.created_at >= before && ev.created_at <= after,
         `created_at ${ev.created_at} outside [${before}, ${after}]`);
 });
+
+// --- Tag sanitization: relays reject any non-string tag value with
+// "invalid: tag val was not a string". Article metadata harvested from a
+// page's JSON-LD can be an array (articleSection) or an object
+// (inLanguage), so buildArticleEvent must coerce before emitting. ---
+
+test('coerceTagAtom reduces JSON-LD shapes to strings or null', () => {
+    assert.equal(EventBuilder.coerceTagAtom('hi'), 'hi');
+    assert.equal(EventBuilder.coerceTagAtom(42), '42');
+    assert.equal(EventBuilder.coerceTagAtom(true), 'true');
+    assert.equal(EventBuilder.coerceTagAtom(['History', 'Religion']), 'History, Religion');
+    assert.equal(EventBuilder.coerceTagAtom({ '@type': 'Language', name: 'en' }), 'en');
+    assert.equal(EventBuilder.coerceTagAtom({ '@value': 'fr' }), 'fr');
+    assert.equal(EventBuilder.coerceTagAtom(null), null);
+    assert.equal(EventBuilder.coerceTagAtom({ shape: 'unknown' }), null);
+});
+
+test('sanitizeTags keeps valid tags untouched and drops valueless ones', () => {
+    const tags = [
+        ['d', 'abc'],
+        ['p', PUBKEY, '', 'author'],   // empty marker slot must survive
+        ['t', 'article']
+    ];
+    assert.deepEqual(EventBuilder.sanitizeTags(tags), tags);
+
+    // A section that collapsed to null (e.g. unstringifiable object) is dropped.
+    const dropped = EventBuilder.sanitizeTags([['section', { weird: true }], ['t', 'ok']]);
+    assert.deepEqual(dropped, [['t', 'ok']]);
+});
+
+test('buildArticleEvent stringifies array section and object language', async () => {
+    const article = {
+        url: 'https://www.josephsmithpapers.org/intro/x',
+        title: 'Intro',
+        domain: 'josephsmithpapers.org',
+        excerpt: 'An introduction.',
+        wordCount: 5000,
+        section: ['History', 'Religion'],                       // JSON-LD array
+        language: { '@type': 'Language', name: 'en' },          // JSON-LD object
+        keywords: ['council', 'nauvoo'],
+        structuredData: { type: 'Article' }
+    };
+    const ev = await EventBuilder.buildArticleEvent(article, [], PUBKEY, []);
+
+    // Nothing in the event may be a non-string tag value.
+    for (const t of ev.tags) {
+        for (const v of t) {
+            assert.equal(typeof v, 'string',
+                `tag ${JSON.stringify(t)} has non-string value ${JSON.stringify(v)}`);
+        }
+    }
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'section'), ['section', 'History, Religion']);
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'lang'), ['lang', 'en']);
+});


### PR DESCRIPTION
## Release v0.5.1

Patch release. Two capture/publish bug fixes plus the new contributor/AI guidance doc.

### Fixed — inline names dropped from article captures
On sites that wrap inline person/place names in `popup`-classed elements (e.g. **josephsmithpapers.org**, `<aside class="popup-wrapper">`), Readability's `unlikelyCandidates` blocklist matches the substring `popup` and deletes the whole wrapper — taking the visible name with it and leaving dangling punctuation (`organized a council in , Illinois`). `ContentExtractor._unwrapInlinePopups()` now runs on the cloned DOM before Readability, replacing each `aside.popup-wrapper` with its reference link's visible text and dropping editorial-note footnote markers. Verified against the real JSP markup in a DOM harness.

### Fixed — publishing rejected with `invalid: tag val was not a string`
NOSTR relays reject the entire event if any tag element isn't a string. A page's JSON-LD can carry a non-string `articleSection` (array) or `inLanguage` (object), which flowed into the `section`/`lang` tags raw. The kind-30023 builder now runs `sanitizeTags()` / `coerceTagAtom()` to stringify every tag value — flattening arrays, pulling `name`/`@value` from schema.org objects, dropping anything unstringifiable — so one odd metadata field can't break publishing.

### Added — CLAUDE.md
Onboarding guidance for AI assistants / new contributors: build model, the four execution contexts, the shared layer, conventions, and CI.

### Release mechanics
- `package.json` / `manifest.json` / `package-lock.json` bumped to `0.5.1` (lockstep; also clears a pre-existing stale `0.3.0` lock root-version).
- `CHANGELOG.md` `[0.5.1]` section covers both fixes (the release workflow pulls it into the GitHub Release body).
- Tests: **528/528** green (9 new tests across the unwrap logic and tag sanitizer). `npm run build` clean.
- Note: the manual `docs/SMOKE_TEST.md` checklist was **not** run (no browser here); `release.yml` re-runs build + test + `web-ext lint` before publishing.

On merge, `main` is tagged `v0.5.1`, triggering `release.yml` to build, package, and publish the GitHub Release with the `.zip`.

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65