### PR TITLE
Phase C — Unify the NOSTR client tag to 'xray'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Changed
 
+- **NOSTR `client` tag unified to `'xray'`** across all event builders
+  (article 30023, entity-sync 30078, relationship 32125, evidence 30043
+  previously emitted `'nostr-article-capture'`; comment 30041 and
+  platform-account 32126 already used `'xray'`). The entity-sync NIP-32
+  label namespace likewise moves to `xray/entity-sync`. **Wire-format
+  change, back-compat preserved:** entity-sync *reads* still accept the
+  legacy `nac/entity-sync` label, so entities synced before the rename
+  still pull; already-published events keep their old `client` value.
 - **Settings consolidated.** The Advanced tab is reorganized into a
   **Reader** group (archive banner sensitivity, promoted out of the
   engine-tuning pile) and a **Power user** group (debug logging + the

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,33 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Unify the NOSTR `client` tag to `xray` (Phase C)
+
+**Tags:** design, external
+
+**What changed:** The `['client', …]` tag was inconsistent — the article,
+entity-sync, relationship, and evidence builders emitted
+`'nostr-article-capture'` (the old userscript name) while the comment and
+platform-account builders already emitted `'xray'`. Unified all to
+`'xray'`. The entity-sync NIP-32 label namespace likewise moved from
+`nac/entity-sync` to `xray/entity-sync`. Also retitled the entity kind-0
+`about` field ("entity created by X-Ray").
+
+**Compatibility:** The `client` tag is informational — no consumer filters
+on it for correctness, and already-published events keep their old value,
+so unifying is cosmetic on the wire. The **sync label is a read filter**,
+though: changing it naively would orphan entities synced under the old
+label. So the write path emits `xray/entity-sync` while the *read* path
+(`entity-sync.js` pull/clear filters) queries **both** the new label and
+the legacy `nac/entity-sync` (`SYNC_LABELS_READ`). The write label lives
+in `EventBuilder.buildEntitySyncEvent`; the read constants live in
+`entity-sync.js` — keep them in lockstep.
+
+**Left intentionally:** the line-1 port-attribution comments in
+`event-builder.js` / `crypto.js` (historical, not wire data).
+
+---
+
 ## 2026-06-09 — Settings consolidation (Phase B of the cleanup)
 
 **Tags:** design

--- a/src/shared/entity-sync.js
+++ b/src/shared/entity-sync.js
@@ -23,7 +23,7 @@
 //       publish(relays, event)
 //
 //   Device B (Pull):
-//     events = queryRelays({ kinds:[30078], authors:[userPubkey], '#L':['nac/entity-sync'] })
+//     events = queryRelays({ kinds:[30078], authors:[userPubkey], '#L':['xray/entity-sync'] })
 //     for event in events:
 //       payload = nip44Decrypt(event.content, conversationKey)
 //       record  = JSON.parse(payload)
@@ -45,7 +45,13 @@ import { EntityModel } from './entity-model.js';
 import { LocalKeyManager } from './local-key-manager.js';
 
 const SCHEMA_VERSION = 1;
-const SYNC_LABEL     = 'nac/entity-sync';   // NIP-32 L/l tags for namespacing
+// NIP-32 L/l namespace for our sync events. Writes use the current label;
+// reads also accept the legacy `nac/entity-sync` so entities synced before
+// the rename still pull. (The write label lives in
+// EventBuilder.buildEntitySyncEvent — keep the two in lockstep.)
+const SYNC_LABEL        = 'xray/entity-sync';
+const SYNC_LABEL_LEGACY = 'nac/entity-sync';
+const SYNC_LABELS_READ  = [SYNC_LABEL, SYNC_LABEL_LEGACY];
 
 // ------------------------------------------------------------------
 // Encryption helpers
@@ -221,7 +227,7 @@ export async function pullEntities({ userPrivkey, relays, timeoutMs = 8000 }) {
 
     const { events, byRelay } = await NostrClient.queryRelays(
         relays,
-        { kinds: [30078], authors: [userPubkey], '#L': [SYNC_LABEL], limit: 500 },
+        { kinds: [30078], authors: [userPubkey], '#L': SYNC_LABELS_READ, limit: 500 },
         timeoutMs
     );
 
@@ -411,7 +417,7 @@ export async function clearRemote({ userPrivkey, relays }) {
     // Query our own kind-30078 events to find the ids to delete.
     const { events } = await NostrClient.queryRelays(
         relays,
-        { kinds: [30078], authors: [userPubkey], '#L': [SYNC_LABEL], limit: 500 },
+        { kinds: [30078], authors: [userPubkey], '#L': SYNC_LABELS_READ, limit: 500 },
         5000
     );
 

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -104,7 +104,7 @@ export const EventBuilder = {
       ['title', article.title || 'Untitled'],
       ['published_at', String(article.publishedAt || Math.floor(Date.now() / 1000))],
       ['r', article.url],
-      ['client', 'nostr-article-capture']
+      ['client', 'xray']
     ];
     
     if (article.excerpt) {
@@ -395,7 +395,7 @@ export const EventBuilder = {
       tags,
       content: JSON.stringify({
         name: entity.name,
-        about: `${entity.type} entity created by nostr-article-capture`,
+        about: `${entity.type} entity created by X-Ray`,
         nip05: entity.nip05 || undefined
       })
     };
@@ -471,10 +471,10 @@ export const EventBuilder = {
       created_at: Math.floor(Date.now() / 1000),
       tags: [
         ['d', entityId],
-        ['client', 'nostr-article-capture'],
+        ['client', 'xray'],
         ['entity-type', entityType],
-        ['L', 'nac/entity-sync'],
-        ['l', 'v1', 'nac/entity-sync']
+        ['L', 'xray/entity-sync'],
+        ['l', 'v1', 'xray/entity-sync']
       ],
       content: encryptedContent
     };
@@ -511,7 +511,7 @@ export const EventBuilder = {
         ['entity-name', entity.name],
         ['entity-type', entity.type],
         ['relationship', relationshipType],
-        ['client', 'nostr-article-capture'],
+        ['client', 'xray'],
         ...(claimId ? [['claim-ref', claimId]] : [])
       ],
       content: ''
@@ -651,7 +651,7 @@ export const EventBuilder = {
       ['source-claim', link.source_claim_id],
       ['target-claim', link.target_claim_id],
       ['relationship', link.relationship],
-      ['client', 'nostr-article-capture']
+      ['client', 'xray']
     ];
 
     if (sourceClaim?.source_url) tags.push(['r', sourceClaim.source_url]);

--- a/tests/event-builder.test.mjs
+++ b/tests/event-builder.test.mjs
@@ -21,7 +21,7 @@ const { EventBuilder } = await import('../src/shared/event-builder.js');
 
 const PUBKEY = '4ba5145ddce7322c3422096997fdf9d5cf9198312d7567b0dda275e580654a9f';
 
-test('buildEntitySyncEvent has the d/L/l tags the userscript pull filter expects', () => {
+test('buildEntitySyncEvent has the d/L/l tags the pull filter expects', () => {
     const ev = EventBuilder.buildEntitySyncEvent('entity_abc', 'CIPHERTEXT', 'person', PUBKEY);
     assert.equal(ev.kind, 30078);
     assert.equal(ev.pubkey, PUBKEY);
@@ -31,8 +31,8 @@ test('buildEntitySyncEvent has the d/L/l tags the userscript pull filter expects
     const lTag = ev.tags.find((t) => t[0] === 'l');
     const tTag = ev.tags.find((t) => t[0] === 'entity-type');
     assert.deepEqual(dTag, ['d', 'entity_abc']);
-    assert.deepEqual(LTag, ['L', 'nac/entity-sync']);
-    assert.deepEqual(lTag, ['l', 'v1', 'nac/entity-sync']);
+    assert.deepEqual(LTag, ['L', 'xray/entity-sync']);
+    assert.deepEqual(lTag, ['l', 'v1', 'xray/entity-sync']);
     assert.deepEqual(tTag, ['entity-type', 'person']);
 });
 


### PR DESCRIPTION
Phase C of the staged cleanup (follows #27). Agreed decision: **unify the NOSTR `client` tag to `'xray'` (incl. the sync label).**

## What changed
- **`['client', 'xray']`** everywhere. The article (30023), entity-sync (30078), relationship (32125), and evidence (30043) builders previously emitted `'nostr-article-capture'`; comment (30041) and platform-account (32126) already used `'xray'`. Now consistent.
- **Entity-sync NIP-32 label** `nac/entity-sync` → **`xray/entity-sync`**.
- Entity kind-0 `about` field retitled ("entity created by X-Ray").

## Compatibility (wire-format change)
- The `client` tag is **informational** — nothing filters on it for correctness, and already-published events keep their old value. Cosmetic on the wire.
- The **sync label is a read filter**, so a naive rename would orphan entities synced under the old label. The write path emits the new `xray/entity-sync`; the **read path queries both** the new and legacy labels (`SYNC_LABELS_READ` in `entity-sync.js`), so previously-synced entities still pull. Write label (`buildEntitySyncEvent`) and read constants (`entity-sync.js`) must stay in lockstep — noted in code + JOURNAL.

## Kept intentionally
- Line-1 port-attribution comments in `event-builder.js` / `crypto.js` (historical, not wire data).

## Verification
- `npm run build` clean; **521/521 tests** (updated the entity-sync L/l assertion to the new label).
- Docs: CHANGELOG `[Unreleased]`, JOURNAL.

## Next
D (UI token unification + `nac-` marker rename) · E (roadmap + docs/smoke-test refresh).

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65)_