### PR TITLE
Phase D — Rename the last nac-* markers to xr-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Changed
 
+- **Legacy `nac-*` CSS prefix fully eliminated.** The last `nac-*` tokens —
+  the capture→Markdown markers in `content-extractor.js` (`nac-tweet-embed`,
+  `nac-facebook-post`, `nac-inline-img`, …) — were renamed to `xr-*`. These
+  are internal class names on cloned nodes the Turndown rules match; the
+  rename is a pure no-behavior-change string swap (producer/consumer pairs
+  stay matched). The whole codebase now uses the `xr-*` prefix.
+
 - **NOSTR `client` tag unified to `'xray'`** across all event builders
   (article 30023, entity-sync 30078, relationship 32125, evidence 30043
   previously emitted `'nostr-article-capture'`; comment 30041 and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,13 +147,12 @@ namespace object (`export const Storage = …`, `export const Signer = …`).
 - **`config.js` carries snake_case keys** (e.g. `min_content_length`) to
   match the v4 userscript for drop-in module portability, with some
   camelCase legacy aliases kept alongside. Don't "tidy" these casings.
-- **CSS prefixes:** `xr-*` for extension-chrome UI (options/reader/side
-  panel) and all content-script UI. The FAB/panel `nac-*` CSS is gone; the
-  only `nac-*` left is a handful of **capture-pipeline markers** in
-  `content-extractor.js` (`nac-tweet-embed`, `nac-facebook-post`,
-  `nac-inline-img`, …) — class names on cloned nodes that the Turndown
-  rules match to build Markdown, not UI. **Don't add new `nac-*` classes**;
-  renaming those remaining markers to `xr-*` is a known follow-up.
+- **CSS prefixes:** everything is `xr-*` now — extension-chrome UI
+  (options/reader/side panel), content-script UI, and the capture-pipeline
+  markers in `content-extractor.js` (`xr-tweet-embed`, `xr-fb-*`,
+  `xr-inline-img`, … — class names on cloned nodes the Turndown rules match
+  to build Markdown, not UI). The legacy `nac-*` / `nmd-*` prefixes are
+  fully gone; don't reintroduce them.
 - **Logging:** use `Utils.log` / `Utils.error` (no-ops when `CONFIG.debug`
   is false). Don't add bare `console.log`.
 - **User-visible strings** use "X-Ray" (hyphenated). Avoid emoji in code

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,37 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Eliminate the last `nac-*` markers (Phase D)
+
+**Tags:** design
+
+**What changed:** Renamed the remaining `nac-*` class names — the
+capture→Markdown markers in `content-extractor.js` (`nac-tweet-embed`,
+`nac-inline-img`, `nac-facebook-post`/`nac-fb-*`,
+`nac-instagram-post`/`nac-ig-*`) — to `xr-*`. The codebase is now
+100% `xr-*` (the FAB/panel `nac-*` CSS went in Phase A; this clears the
+internal markers). Pure string rename, no behavior change: these are class
+names on cloned DOM nodes the Turndown rules match, and producer/consumer
+pairs were renamed in lockstep within the one file.
+
+**Tracing notes (for whoever touches these next):** `xr-tweet-embed` and
+`xr-inline-img` have live producer+consumer pairs. `xr-inline-img` is
+otherwise **vestigial** — Phase A deleted the content.css rule that styled
+it, and `htmlToMarkdown`'s image rule keys on width, not the class. The
+`xr-facebook-post` / `xr-instagram-post` Turndown rules have **no producer
+anywhere in src** — they're dead code from an earlier HTML-embed
+architecture (FB/IG handlers now return data objects). Left both in place
+(renamed) rather than deleted to keep Phase D a zero-risk rename; removing
+the dead rules + vestigial class is a safe future cleanup.
+
+**Deferred (needs browser QA):** the deeper CSS *token/color* unification
+the audit flagged — reconciling the minor success/warning/danger value
+divergence across reader/options/sidepanel and the couple of hardcoded
+`#363636`s — is a visual change I can't verify headless, so it's left as a
+documented follow-up rather than shipped blind.
+
+---
+
 ## 2026-06-09 — Unify the NOSTR `client` tag to `xray` (Phase C)
 
 **Tags:** design, external

--- a/src/shared/content-extractor.js
+++ b/src/shared/content-extractor.js
@@ -50,7 +50,7 @@ export const ContentExtractor = {
           const naturalHeight = img.naturalHeight || parseInt(img.getAttribute('height')) || img.offsetHeight;
           // Only tag small images (< 100px) to prevent enlargement in reader view
           if (naturalWidth > 0 && naturalWidth < 100) {
-              img.classList.add('nac-inline-img');
+              img.classList.add('xr-inline-img');
               img.setAttribute('width', naturalWidth);
               img.setAttribute('height', naturalHeight || naturalWidth);
           }
@@ -77,7 +77,7 @@ export const ContentExtractor = {
 
           // Replace complex tweet HTML with clean blockquote
           const cleanTweet = document.createElement('blockquote');
-          cleanTweet.className = 'nac-tweet-embed';
+          cleanTweet.className = 'xr-tweet-embed';
           cleanTweet.setAttribute('data-tweet-url', tweetUrl);
           cleanTweet.innerHTML = `<p>${tweetText}</p>` +
               (authorName ? `<footer>— ${authorName}</footer>` : '') +
@@ -88,7 +88,7 @@ export const ContentExtractor = {
 
       // Also handle Twitter avatar/profile images - constrain their size
       document.querySelectorAll('img[src*="pbs.twimg.com/profile_images"], img[src*="twimg.com/profile"]').forEach(img => {
-          img.classList.add('nac-inline-img');
+          img.classList.add('xr-inline-img');
           img.style.width = '48px';
           img.style.height = '48px';
           img.style.borderRadius = '50%';
@@ -563,7 +563,7 @@ export const ContentExtractor = {
           filter: function(node) {
             return (node.nodeName === 'BLOCKQUOTE' &&
                     (node.classList.contains('twitter-tweet') ||
-                     node.classList.contains('nac-tweet-embed') ||
+                     node.classList.contains('xr-tweet-embed') ||
                      node.getAttribute('data-tweet-url')));
           },
           replacement: function(content, node) {
@@ -597,12 +597,12 @@ export const ContentExtractor = {
         // Handle Facebook post blocks
         turndown.addRule('facebookPost', {
           filter: function(node) {
-            return node.nodeName === 'DIV' && node.classList.contains('nac-facebook-post');
+            return node.nodeName === 'DIV' && node.classList.contains('xr-facebook-post');
           },
           replacement: function(content, node) {
-            const authorName = node.querySelector('.nac-fb-author-name')?.textContent?.trim() || '';
-            const timestamp = node.querySelector('.nac-fb-timestamp')?.textContent?.trim() || '';
-            const postText = node.querySelector('.nac-fb-text')?.textContent?.trim() || '';
+            const authorName = node.querySelector('.xr-fb-author-name')?.textContent?.trim() || '';
+            const timestamp = node.querySelector('.xr-fb-timestamp')?.textContent?.trim() || '';
+            const postText = node.querySelector('.xr-fb-text')?.textContent?.trim() || '';
 
             let md = '> 📘 **Facebook Post';
             if (authorName) md += ` by ${authorName}`;
@@ -620,14 +620,14 @@ export const ContentExtractor = {
             }
 
             // Include images
-            const images = node.querySelectorAll('.nac-fb-image');
+            const images = node.querySelectorAll('.xr-fb-image');
             images.forEach(img => {
               const src = img.getAttribute('src') || '';
               if (src) md += `> \n> ![Post image](${src})\n`;
             });
 
             // Include shared links
-            const links = node.querySelectorAll('.nac-fb-link');
+            const links = node.querySelectorAll('.xr-fb-link');
             links.forEach(link => {
               const href = link.getAttribute('href') || '';
               const text = link.textContent?.trim() || href;
@@ -641,12 +641,12 @@ export const ContentExtractor = {
         // Handle Instagram post blocks
         turndown.addRule('instagramPost', {
           filter: function(node) {
-            return node.nodeName === 'DIV' && node.classList.contains('nac-instagram-post');
+            return node.nodeName === 'DIV' && node.classList.contains('xr-instagram-post');
           },
           replacement: function(content, node) {
-            const authorName = node.querySelector('.nac-ig-author-name')?.textContent?.trim() || '';
-            const timestamp = node.querySelector('.nac-ig-timestamp')?.textContent?.trim() || '';
-            const captionEl = node.querySelector('.nac-ig-caption');
+            const authorName = node.querySelector('.xr-ig-author-name')?.textContent?.trim() || '';
+            const timestamp = node.querySelector('.xr-ig-timestamp')?.textContent?.trim() || '';
+            const captionEl = node.querySelector('.xr-ig-caption');
             let caption = captionEl?.textContent?.trim() || '';
 
             let md = '> 📷 **Instagram Post';
@@ -654,7 +654,7 @@ export const ContentExtractor = {
             md += '**\n> \n';
 
             // Include images
-            const images = node.querySelectorAll('.nac-ig-image');
+            const images = node.querySelectorAll('.xr-ig-image');
             images.forEach(img => {
               const src = img.getAttribute('src') || '';
               if (src) md += `> ![Instagram media](${src})\n> \n`;


### PR DESCRIPTION
Phase D of the staged cleanup (follows #28). **Final legacy-prefix elimination.**

## What changed
Renamed the last `nac-*` tokens in the codebase — the capture→Markdown markers in `content-extractor.js` (`nac-tweet-embed`, `nac-inline-img`, `nac-facebook-post`/`nac-fb-*`, `nac-instagram-post`/`nac-ig-*`) — to `xr-*`. Combined with Phase A (which deleted the FAB/panel `nac-*` CSS), the codebase is now **100% `xr-*`**.

This is a **pure no-behavior-change string swap**: these are class names on cloned DOM nodes the Turndown rules match to build Markdown (not UI), and producer/consumer pairs were renamed in lockstep within the one file.

## Tracing notes (verified before renaming)
- `xr-tweet-embed` and `xr-inline-img`: live producer+consumer pairs. (`xr-inline-img` is otherwise **vestigial** — Phase A deleted the CSS that styled it, and the img Turndown rule keys on width, not the class.)
- `xr-facebook-post` / `xr-instagram-post` Turndown rules: **no producer anywhere in `src`** — dead code from an earlier HTML-embed architecture (FB/IG handlers now return data objects). Left in place (renamed) to keep this a zero-risk rename; deleting the dead rules + vestigial class is a safe future cleanup.

## Deferred (intentionally)
The audit's deeper CSS **token/color** unification — reconciling the minor success/warning/danger value divergence across reader/options/sidepanel and a couple of hardcoded `#363636`s — is a **visual** change I can't verify headless, so it's documented as a follow-up rather than shipped blind. (Phase A already removed the biggest source of palette fragmentation by deleting content.css's `--nac-` palette.)

## Verification
- `npm run build` clean; **521/521 tests**.
- Docs: CLAUDE.md (CSS-prefix note now says the codebase is all `xr-*`), CHANGELOG, JOURNAL (with the tracing notes above).

## Next
E — roadmap rewrite + docs/smoke-test refresh + claim-tracking groundwork.

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65)_