### PR TITLE
Phase 10 — Claim redesign design note (thin, entity-centric claims)

### DIFF
--- a/docs/CLAIMS_REDESIGN.md
+++ b/docs/CLAIMS_REDESIGN.md
@@ -1,0 +1,147 @@
+# Claim redesign — thin, entity-centric claims (Phase 10)
+
+**Status:** design agreed 2026-06-09. Supersedes the Phase 5 structured-claim
+model for new work. Implemented in slices 10.1–10.5 (see the bottom of this
+doc and `ROADMAP.md` → Phase 10).
+
+This note records *why* the Phase 5 claim model is being reworked and the
+shape we're moving to, so the wire-format and UX decisions are on the record
+before the code lands.
+
+## Why rework the Phase 5 model
+
+The original claim (see `git log` of `src/shared/claim-model.js` and
+`src/reader/claim-extractor.js`) asked the user, per claim, for: text, a
+**type** (factual / causal / evaluative / predictive), a **crux** flag + a
+**confidence** 0–100 slider, an **attribution** (direct_quote / paraphrase /
+editorial / thesis), a **predicate** verb, a **subject** (entity-or-text),
+an **object** (entity-or-text), a **claimant** entity, and a **quote date**.
+Linking claims was a second modal restricted to the *same article*, and
+publish fanned out to three kinds (`30040` claim, `30043` evidence, `32125`
+relationship).
+
+Problems, measured against the goal (*lots of useful data about real people,
+organizations, and real-world stories*):
+
+1. **Friction fights data volume.** That intake form is analyst-grade; in
+   practice most fields stay blank or get guessed, which is worse than
+   absent — noisy, inconsistent data.
+2. **The S/P/O triple is the heaviest part with the weakest payoff.**
+   Forcing prose into subject–predicate–object rarely matches how claims
+   read, and the free-text `predicate` will never be query-consistent. The
+   valuable structured signal is simply **which real entities a claim is
+   about** — that's what makes "what does the network say about person P"
+   possible.
+3. **Ambiguous semantics → noisy data.** `confidence` on a "crux" reads as
+   *how true* to a slider but means *how central* in code. `type` /
+   `attribution` are real distinctions but applied inconsistently and rarely
+   queried.
+4. **Two overlapping systems.** Phase 5 claims (`30040`/`30043`/`32125`) and
+   the Phase 9a metadata layer (annotations `30050`, fact-checks `30051`,
+   ratings `30052`, topic-trust `30053`) both "anchor a structured assertion
+   to content," with different kinds and different anchoring (claims → `#r`
+   URL; metadata → W3C text-range selectors).
+5. **Same-article-only evidence links miss the point.** The value of linking
+   is *cross-source*; same-article linking is the low-value 80% of the
+   friction.
+
+## Decisions (agreed)
+
+- **Thin, entity-centric claim** as the core primitive. Key-claim flag is
+  enough; no confidence number, type, attribution, predicate, or S/P/O.
+- **Claims are the core** "structured assertion about entities." The metadata
+  layer's fact-checks/ratings are reframed as **responses to** a claim/URL
+  (NIP-draft `responds-to`) rather than a parallel system; claims and
+  annotations share the text-anchor mechanism.
+
+## Thin claim — data model
+
+```
+Claim {
+  id            // unchanged: claim_<sha256(source_url + '|' + norm(text))[:16]>
+  text          // required — the assertion (verbatim or paraphrased)
+  about[]       // entity ids the claim concerns  ← the queryable core
+  source_url    // required
+  anchor?       // W3C text-range selector (reuse Phase 9a anchor-capture)
+  source?       // who asserts it: null = "the article/author", else an entity
+                //   id or free text (a quoted person). Absorbs the old
+                //   `claimant` + `attribution`.
+  is_key?       // ⭐ single flag — replaces crux + the 0–100 confidence
+  context       // surrounding text (kept — cheap, helps anchor rehydration)
+  created, updated, publishedAt, publishedEventId
+}
+```
+
+**Dropped:** `type`, `confidence`, `attribution`, `predicate`, the
+`subject`/`object` split, `quote_date`.
+
+**Capture UX:** *select text → "it's about [P] [O]" → save.* Optional ⭐ for a
+key claim; optional "who said it" when the claim is a quoted source rather
+than the article itself.
+
+## Wire format (kind 30040)
+
+The valuable, queryable signal becomes first-class `p` tags pointing at the
+**same entity pubkeys used everywhere else** in X-Ray:
+
+```
+kind 30040
+  ["r", <source_url>]                     // queryable by #r
+  ["p", <entity_pubkey>, "", "about"]     // one per "about" entity ← the payoff
+  ["entity", <name>, "about"]             // human-readable mirror per entity
+  ["anchor", <selector-json>]?            // exact passage (shared with metadata)
+  ["p", <source_pubkey>, "", "source"]?   // who said it, if a quoted entity
+  ["key", "true"]?
+  ["client", "xray"]
+  content: <claim text>
+```
+
+"What does the network say about person P" is then a single query:
+`{ kinds:[30040], "#p":[P_pubkey] }` across relays — the Phase 10 payoff,
+falling out of the model instead of needing a manual S/P/O graph.
+
+## Compatibility
+
+- **Wire-format change** — flagged per the `event-builder.js` rule.
+- **Old stored claims** stay readable; a one-time storage migration folds
+  them to the thin shape: `is_crux`→`is_key`, `claimant`→`source`,
+  `subject_entity_ids` ∪ `object_entity_ids` → `about[]`; the rest is
+  dropped.
+- **Already-published `30040` events** keep their old tags. The "others'
+  claims" reader reads **both** vocabularies — old (`claim-text`, `subject`,
+  `object`, `predicate`, `crux`, `confidence`) and new (`content`, `#p about`,
+  `key`).
+
+## Claims as the core; metadata as responses
+
+- **Fact-checks / ratings** (`30051` / `30052`): reframe as responses that
+  *target a claim* (`e`/`a` reference to the `30040` + NIP-draft
+  `responds-to`) or a URL, instead of standing alone.
+- **Annotations** (`30050`): a passage note without entities is "a claim with
+  empty `about[]`." Unify the **anchor** mechanism (both use
+  `metadata/anchor-capture.js`); a claim is the entity-bearing form of the
+  same anchored-assertion shape.
+- **Same-article evidence links** (`30043`): retire. Cross-source
+  corroboration comes for free from entity `#p` aggregation + responds-to;
+  the bespoke same-article evidence modal goes away.
+
+## Implementation slices
+
+Each is one reviewable PR (the A–E cadence).
+
+- **10.1 — Thin model + gutted modal.** Rewrite `claim-model` fields
+  (+ back-compat read + one-time migration), strip the `claim-extractor`
+  modal to text + entity multi-picker + optional source + ⭐, update the
+  claims bar. **No wire change yet** — pure friction win, fully testable.
+- **10.2 — Lean `30040` + dual-read.** New tag set in
+  `EventBuilder.buildClaimEvent`; the others'-claims reader reads both old
+  and new vocabularies. (The wire-format-change PR.)
+- **10.3 — Shared anchor.** Wire `metadata/anchor-capture.js` into claim
+  creation → exact-passage anchoring (also replaces the brittle
+  first-text-occurrence rehydrate in `claim-extractor.js`).
+- **10.4 — Cross-source aggregation.** "What the network says about entity P"
+  — query `30040` by entity pubkey across relays; surface in the reader /
+  side panel. The payoff.
+- **10.5 — Metadata reframe.** Fact-checks / ratings as responses-to-claims;
+  reconcile annotations onto the shared anchor; retire `30043`. (Biggest;
+  last.)

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,33 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Claim redesign agreed: thin, entity-centric claims (Phase 10)
+
+**Tags:** design
+
+**Decision:** Rework the Phase 5 structured-claim model. The original asked
+for ~9 fields per claim (type / crux+confidence / attribution / predicate /
+subject / object / claimant / quote-date / text) plus a separate
+same-article evidence-link modal — analyst-grade friction that fights the
+goal of *volume* of useful entity data, with a brittle S/P/O graph and a
+`confidence` slider whose semantics are ambiguous (truth vs. centrality).
+
+Agreed shape: a **thin, entity-centric claim** — `text` + `about[]` (the
+entities it concerns) + `source_url`/`anchor`, an optional `source` ("who
+said it", absorbing attribution+claimant), and a single `is_key` ⭐ flag.
+Everything else is cut. The queryable value moves into `30040` `p`-tags on
+entity pubkeys, so "what the network says about person P" is one
+`{kinds:[30040], "#p":[P]}` query. **Claims become the core primitive**; the
+Phase 9a metadata fact-checks/ratings get reframed as *responses to* claims
+(shared text-anchor) rather than a parallel system; same-article evidence
+links (`30043`) retire in favor of cross-source entity aggregation.
+
+Full design + rationale + compat plan: `docs/CLAIMS_REDESIGN.md`. Ships in
+slices 10.1–10.5 (see ROADMAP). Wire-format change in 10.2 with dual-read of
+old/new tag vocab and a one-time storage migration of old claim records.
+
+---
+
 ## 2026-06-09 — Roadmap + docs refresh; Phase 10 teed up (Phase E)
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -768,11 +768,9 @@ with keypairs, claims `30040`, evidence links `30043`, relationships
 Scope is still being shaped, but the working themes:
 
 - **Usability of claim capture** — lower the friction from "I see an
-  assertion" to "it's a structured claim tied to real entities" (entity
-  auto-suggest, smarter S/P/O pickers, batch signing).
-- **Connecting claims across sources** — cross-article/cross-capture
-  evidence links and claim de-dup, so a story accretes evidence from many
-  pages instead of living in one capture.
+  assertion" to "it's a structured claim tied to real entities."
+- **Connecting claims across sources** — so a story accretes evidence from
+  many pages instead of living in one capture.
 - **Reading others' claims** — go beyond the point-in-time "others'
   claims" modal toward a browsable, trust-filtered view (leaning on the
   Phase 9a trust graph) of what the network says about a person / org /
@@ -781,8 +779,30 @@ Scope is still being shaped, but the working themes:
   real work: collapse duplicate captured authors into canonical people and
   attach their claims to that person.
 
-A dedicated Phase 10 issue will pin exit criteria before implementation
-starts; this section is the intent, not the spec.
+### Foundation: claim redesign (agreed 2026-06-09)
+
+The Phase 5 claim model is being reworked first — see
+[`docs/CLAIMS_REDESIGN.md`](CLAIMS_REDESIGN.md) for the full design and
+rationale. In short: replace the heavy structured claim (type / confidence /
+attribution / predicate / subject–predicate–object / quote-date) with a
+**thin, entity-centric claim** — *text + the entities it's about + a source
+anchor*, plus an optional "who said it" and a single ⭐ key-claim flag. The
+queryable value moves into `p`-tag links to entity pubkeys, so "what the
+network says about person P" is a single `{kinds:[30040], "#p":[P]}` query.
+**Claims become the core primitive**; the Phase 9a metadata layer's
+fact-checks / ratings are reframed as *responses to* claims, sharing the
+text-anchor mechanism, rather than a parallel system.
+
+Implemented in slices (one PR each):
+
+- **10.1** Thin model + gutted modal (no wire change).
+- **10.2** Lean `30040` tag set + dual-read of old/new vocab (wire change).
+- **10.3** Shared anchor (reuse `metadata/anchor-capture.js`).
+- **10.4** Cross-source aggregation — "what the network says about entity P".
+- **10.5** Metadata reframe — fact-checks/ratings as responses; retire `30043`.
+
+A dedicated Phase 10 issue will pin exit criteria; this section + the design
+note are the intent, not the final spec.
 
 ---
 


### PR DESCRIPTION
Records the agreed **Phase 10 claim redesign** before any code lands. Docs-only.

## What's here
- **`docs/CLAIMS_REDESIGN.md`** — the full design: why the Phase 5 model is being reworked, the **thin entity-centric claim** schema, the lean `kind 30040` wire format, the compatibility/migration plan, the "claims are the core / metadata as responses" reconciliation, and the 10.1–10.5 implementation slices.
- **ROADMAP** Phase 10 section expanded to summarize the redesign and link the note.
- **JOURNAL** entry recording the decision.

## The shape (agreed with maintainer)
A claim collapses to **text + `about[]` (entities it concerns) + source anchor**, plus an optional "who said it" (`source`) and a single ⭐ `is_key` flag. Cut: `type`, `confidence`, `attribution`, `predicate`, the subject/predicate/object split, `quote_date`. The queryable value moves into `30040` `p`-tags on entity pubkeys, so *"what the network says about person P"* = `{ kinds:[30040], "#p":[P] }`. Fact-checks/ratings get reframed as responses to claims; same-article evidence links (`30043`) retire in favor of cross-source entity aggregation.

## Next
**10.1 — thin model + gutted modal** (no wire change yet) starts immediately after this lands. Then 10.2 (lean `30040` + dual-read), 10.3 (shared anchor), 10.4 (cross-source aggregation), 10.5 (metadata reframe).

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65)_