### PR TITLE
Phase 10.1 — Thin, entity-centric claim model + modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Changed
 
+- **Claims simplified to a thin, entity-centric model** (Phase 10.1; see
+  [`docs/CLAIMS_REDESIGN.md`](docs/CLAIMS_REDESIGN.md)). A claim is now just
+  *text + the entities it's about + an optional "who said it" + a single ⭐
+  key-claim flag*. The old per-claim fields — type, the crux confidence
+  slider, attribution, predicate, the subject/predicate/object pickers, and
+  quote-date — are gone from the capture modal. Old stored claims normalize
+  to the new shape on read; no wire-format change yet (the thin fields are
+  mirrored onto the legacy fields the publisher still reads — slice 10.2
+  rewrites the `kind 30040` tag set).
+
 - **Docs refreshed for the post-parity state.** `ROADMAP.md` updated:
   status snapshot reflects all phases complete, the v0.5.x cleanup (A–E)
   recorded, the deferred backlog triaged (keep / defer / cut) against the

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,33 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Thin claims shipped: model + modal (Phase 10.1)
+
+**Tags:** design
+
+**What changed:** First slice of the claim redesign. `claim-model.js` is now
+thin — `text` + `about[]` (entity ids) + `source` (entity id / free text /
+null=article) + `is_key` + `anchor?`. The claim modal (`claim-extractor.js`)
+lost the type row, crux+confidence slider, attribution dropdown, predicate,
+the subject/object/claimant pickers, and the quote-date field; in their place
+it has a single **About** multi-entity picker, an optional **"who said it"**
+entity-or-text picker, and a ⭐ **Key claim** checkbox. The claims bar renders
+text + about-entities + source + ⭐ instead of the type/triple/attribution.
+
+**Compat / how it stays non-breaking:** This slice deliberately makes **no
+wire-format change** (that's 10.2). `ClaimModel.create/update` mirror the thin
+fields onto the legacy fields the unchanged `buildClaimEvent` + reader publish
+flow read (`subject_entity_ids`←`about`, `claimant_entity_id`←`source` when an
+entity, `is_crux`←`is_key`, `type='factual'`, `attribution='editorial'`).
+`normalizeClaim()` does the inverse for pre-10.1 records on read, so old
+claims render in the thin UI. Both the mirror and `normalizeClaim` go away in
+10.2 when the `kind 30040` builder reads the thin fields directly. Id
+derivation (`source_url|norm(text)`) is unchanged, so published-event ids stay
+stable. Tests: `tests/claim-model.test.mjs` rewritten (thin API + legacy
+normalization); 522/522 green.
+
+---
+
 ## 2026-06-09 — Claim redesign agreed: thin, entity-centric claims (Phase 10)
 
 **Tags:** design

--- a/src/reader/claim-extractor.js
+++ b/src/reader/claim-extractor.js
@@ -22,10 +22,8 @@
 
 import {
     ClaimModel,
-    CLAIM_TYPES,
     CLAIM_TYPE_LABELS,
     CLAIM_TYPE_ICONS,
-    CLAIM_ATTRIBUTIONS,
     CLAIM_ATTRIBUTION_LABELS
 } from '../shared/claim-model.js';
 import {
@@ -57,18 +55,10 @@ export function openClaimModal(opts) {
 
         const isEdit = !!initialClaim;
         const initial = initialClaim || {
-            text:                initialText,
-            type:                'factual',
-            is_crux:             false,
-            confidence:          null,
-            attribution:         'editorial',
-            predicate:           '',
-            subject_entity_ids:  [],
-            subject_text:        '',
-            object_entity_ids:   [],
-            object_text:         '',
-            claimant_entity_id:  null,
-            quote_date:          null,
+            text:    initialText,
+            about:   [],
+            source:  null,
+            is_key:  false,
             context
         };
 
@@ -96,21 +86,9 @@ export function openClaimModal(opts) {
 
 function buildModalHtml(initial, isEdit) {
     const title = isEdit ? 'Edit claim' : 'Add claim';
-
-    const typeRow = CLAIM_TYPES.map((t) => `
-      <button type="button" class="xr-claim-modal__type-btn ${t === initial.type ? 'xr-claim-modal__type-btn--active' : ''}"
-              data-type="${t}">
-        ${CLAIM_TYPE_ICONS[t]} ${escapeHtml(CLAIM_TYPE_LABELS[t])}
-      </button>
-    `).join('');
-
-    const attributionOptions = CLAIM_ATTRIBUTIONS.map((a) => `
-      <option value="${escapeHtml(a)}" ${a === initial.attribution ? 'selected' : ''}>
-        ${escapeHtml(CLAIM_ATTRIBUTION_LABELS[a])}
-      </option>
-    `).join('');
-
-    const confidenceValue = initial.confidence != null ? initial.confidence : 75;
+    // `source` is an entity id, free text, or null (= the article).
+    const sourceIsEntity = typeof initial.source === 'string' && /^entity_/.test(initial.source);
+    const sourceText = (initial.source && !sourceIsEntity) ? initial.source : '';
 
     return `
       <div class="xr-claim-modal__backdrop"></div>
@@ -131,53 +109,44 @@ function buildModalHtml(initial, isEdit) {
             ${isEdit ? '<small class="xr-claim-modal__hint">Text is immutable after creation. Delete + recreate to change it.</small>' : ''}
           </label>
 
-          <div class="xr-claim-modal__field">
-            <span class="xr-claim-modal__label">Type</span>
-            <div class="xr-claim-modal__type-row">${typeRow}</div>
-          </div>
+          ${buildAboutPicker(initial.about)}
+
+          ${buildEntityOrTextPicker('source', 'Who said it (optional — defaults to the article)',
+                                    sourceIsEntity ? [initial.source] : [], sourceText)}
 
           <div class="xr-claim-modal__field xr-claim-modal__field--inline">
             <label class="xr-claim-modal__checkbox">
-              <input type="checkbox" class="xr-claim-modal__crux" ${initial.is_crux ? 'checked' : ''} />
-              <span>Crux — the central claim</span>
+              <input type="checkbox" class="xr-claim-modal__key" ${initial.is_key ? 'checked' : ''} />
+              <span>⭐ Key claim — central to the piece</span>
             </label>
           </div>
-
-          <div class="xr-claim-modal__field xr-claim-modal__conf-wrap" ${initial.is_crux ? '' : 'hidden'}>
-            <span class="xr-claim-modal__label">Confidence</span>
-            <div class="xr-claim-modal__conf-row">
-              <input type="range" class="xr-claim-modal__conf" min="0" max="100" step="1" value="${confidenceValue}" />
-              <output class="xr-claim-modal__conf-out">${confidenceValue}%</output>
-            </div>
-          </div>
-
-          <label class="xr-claim-modal__field">
-            <span class="xr-claim-modal__label">Attribution</span>
-            <select class="xr-claim-modal__attribution">${attributionOptions}</select>
-          </label>
-
-          <label class="xr-claim-modal__field">
-            <span class="xr-claim-modal__label">Predicate <em>(the verb connecting subject and object)</em></span>
-            <input type="text" class="xr-claim-modal__predicate" spellcheck="false"
-                   placeholder="e.g. causes, said, is, threatens"
-                   value="${escapeHtml(initial.predicate || '')}" />
-          </label>
-
-          ${buildEntityOrTextPicker('subject', 'Subject',  initial.subject_entity_ids, initial.subject_text)}
-          ${buildEntityOrTextPicker('object',  'Object',   initial.object_entity_ids,  initial.object_text)}
-          ${buildEntitySinglePicker('claimant', 'Claimant (optional)', initial.claimant_entity_id)}
-
-          <label class="xr-claim-modal__field">
-            <span class="xr-claim-modal__label">Quote date <em>(optional — when the claim was originally made)</em></span>
-            <input type="date" class="xr-claim-modal__date"
-                   value="${escapeHtml(initial.quote_date || '')}" />
-          </label>
         </div>
 
         <footer class="xr-claim-modal__foot">
           <button type="button" class="xr-claim-modal__btn xr-claim-modal__btn--ghost" data-action="cancel">Cancel</button>
           <button type="button" class="xr-claim-modal__btn xr-claim-modal__btn--primary" data-action="save">${isEdit ? 'Save changes' : 'Save claim'}</button>
         </footer>
+      </div>
+    `;
+}
+
+/**
+ * "About" picker — a multi-select of the entities this claim concerns.
+ * Entity-only (the queryable core); if an entity isn't tagged yet the
+ * search shows a hint to tag it from the article body first.
+ */
+function buildAboutPicker(entityIds) {
+    return `
+      <div class="xr-claim-modal__field xr-claim-modal__picker" data-prefix="about">
+        <span class="xr-claim-modal__label">About <em>(the people / orgs / things this claim concerns)</em></span>
+        <div class="xr-claim-modal__picker-entity">
+          <div class="xr-claim-modal__picked" data-role="picked">
+            ${(entityIds || []).map((id) => `<span class="xr-claim-modal__pill" data-id="${escapeHtml(id)}">Loading…<button type="button" class="xr-claim-modal__pill-x">×</button></span>`).join('')}
+          </div>
+          <input type="text" class="xr-claim-modal__picker-search" data-role="search"
+                 placeholder="Search entities by name…" spellcheck="false" />
+          <div class="xr-claim-modal__picker-results" data-role="results" hidden></div>
+        </div>
       </div>
     `;
 }
@@ -217,22 +186,6 @@ function buildEntityOrTextPicker(prefix, label, entityIds, textValue) {
     `;
 }
 
-function buildEntitySinglePicker(prefix, label, entityId) {
-    return `
-      <div class="xr-claim-modal__field xr-claim-modal__picker xr-claim-modal__picker--single" data-prefix="${prefix}">
-        <span class="xr-claim-modal__label">${escapeHtml(label)}</span>
-        <div class="xr-claim-modal__picker-entity">
-          <div class="xr-claim-modal__picked" data-role="picked">
-            ${entityId ? `<span class="xr-claim-modal__pill" data-id="${escapeHtml(entityId)}">Loading…<button type="button" class="xr-claim-modal__pill-x">×</button></span>` : ''}
-          </div>
-          <input type="text" class="xr-claim-modal__picker-search" data-role="search"
-                 placeholder="Search entities by name…" spellcheck="false" />
-          <div class="xr-claim-modal__picker-results" data-role="results" hidden></div>
-        </div>
-      </div>
-    `;
-}
-
 // ------------------------------------------------------------------
 // Modal wiring
 // ------------------------------------------------------------------
@@ -248,38 +201,24 @@ function wireModal(modal, initial, isEdit, onSubmit) {
     document.addEventListener('keydown', escHandler);
     function escHandler(ev) { if (ev.key === 'Escape') { document.removeEventListener('keydown', escHandler); close(); } }
 
-    // Type picker
-    let currentType = initial.type;
-    modal.querySelectorAll('.xr-claim-modal__type-btn').forEach((btn) => {
-        btn.addEventListener('click', () => {
-            modal.querySelectorAll('.xr-claim-modal__type-btn').forEach((b) =>
-                b.classList.remove('xr-claim-modal__type-btn--active'));
-            btn.classList.add('xr-claim-modal__type-btn--active');
-            currentType = btn.dataset.type;
-        });
-    });
+    const keyCb = $('.xr-claim-modal__key');
 
-    // Crux toggle → show/hide confidence row
-    const cruxCb = $('.xr-claim-modal__crux');
-    const confWrap = $('.xr-claim-modal__conf-wrap');
-    cruxCb.addEventListener('change', () => { confWrap.hidden = !cruxCb.checked; });
-
-    // Confidence slider → live output
-    const confSl = $('.xr-claim-modal__conf');
-    const confOut = $('.xr-claim-modal__conf-out');
-    confSl.addEventListener('input', () => { confOut.textContent = confSl.value + '%'; });
-
-    // Entity pickers. Each picker has either single-select or multi-select
-    // semantics depending on the field: claimant is single, subject + object
-    // are multi (multiple entity IDs supported by the event-builder).
+    // Pickers: `about` is a multi-select of entities (no text mode);
+    // `source` is single, entity-or-text ("who said it").
+    const sourceIsEntity = typeof initial.source === 'string' && /^entity_/.test(initial.source);
     const pickerState = {
-        subject:  { mode: (initial.subject_entity_ids?.length ? 'entity' : 'text'), ids: (initial.subject_entity_ids || []).slice(), text: initial.subject_text || '' },
-        object:   { mode: (initial.object_entity_ids?.length  ? 'entity' : 'text'), ids: (initial.object_entity_ids  || []).slice(), text: initial.object_text || '' },
-        claimant: { mode: 'entity', ids: initial.claimant_entity_id ? [initial.claimant_entity_id] : [], text: '' }
+        about:  { mode: 'entity', ids: (initial.about || []).slice(), text: '' },
+        source: {
+            mode: sourceIsEntity ? 'entity' : 'text',
+            ids:  sourceIsEntity ? [initial.source] : [],
+            text: (initial.source && !sourceIsEntity) ? initial.source : ''
+        }
     };
 
     modal.querySelectorAll('.xr-claim-modal__picker').forEach((picker) => {
-        wirePicker(picker, pickerState[picker.dataset.prefix], picker.dataset.prefix, picker.classList.contains('xr-claim-modal__picker--single'));
+        const prefix = picker.dataset.prefix;
+        // `source` is single-select; `about` is multi.
+        wirePicker(picker, pickerState[prefix], prefix, prefix === 'source');
     });
 
     // Hydrate entity pills async so the user sees real names instead of "Loading…".
@@ -289,23 +228,22 @@ function wireModal(modal, initial, isEdit, onSubmit) {
     modal.querySelector('[data-action="save"]').addEventListener('click', async () => {
         const text = $('.xr-claim-modal__text').value.trim();
         if (!text) { showModalError(modal, 'Claim text is required'); return; }
-        const isCrux = cruxCb.checked;
-        const confidence = isCrux ? Number(confSl.value) : null;
+
+        // `source`: an entity id (entity mode), free text (text mode), or
+        // null (= the article).
+        let source = null;
+        if (pickerState.source.mode === 'entity' && pickerState.source.ids[0]) {
+            source = pickerState.source.ids[0];
+        } else if (pickerState.source.mode === 'text' && pickerState.source.text.trim()) {
+            source = pickerState.source.text.trim();
+        }
 
         const record = {
             text,
-            type: currentType,
-            is_crux: isCrux,
-            confidence,
-            attribution: $('.xr-claim-modal__attribution').value,
-            predicate:   $('.xr-claim-modal__predicate').value.trim(),
-            subject_entity_ids: pickerState.subject.mode === 'entity' ? pickerState.subject.ids : [],
-            subject_text:       pickerState.subject.mode === 'text'   ? pickerState.subject.text.trim() : '',
-            object_entity_ids:  pickerState.object.mode  === 'entity' ? pickerState.object.ids  : [],
-            object_text:        pickerState.object.mode  === 'text'   ? pickerState.object.text.trim()  : '',
-            claimant_entity_id: pickerState.claimant.ids[0] || null,
-            quote_date:         $('.xr-claim-modal__date').value || null,
-            context:            initial.context || ''
+            about:   pickerState.about.ids.slice(),
+            source,
+            is_key:  keyCb.checked,
+            context: initial.context || ''
         };
 
         document.removeEventListener('keydown', escHandler);
@@ -567,26 +505,24 @@ export async function renderClaimsBar(claims) {
           </section>`;
     }
 
-    // Resolve entity display for each claim's subject/object/claimant
+    // Resolve entity display for each claim's `about` set + its `source`
     // plus its evidence links in parallel so the bar renders quickly
     // for typical ~dozen-claim cases.
     const rows = await Promise.all(claims.map(async (c) => {
-        const [subject, object, claimant, links] = await Promise.all([
-            describeParty(c.subject_entity_ids, c.subject_text),
-            describeParty(c.object_entity_ids,  c.object_text),
-            c.claimant_entity_id ? describeEntity(c.claimant_entity_id) : null,
+        const [about, source, links] = await Promise.all([
+            describeParty(c.about, ''),
+            describeSource(c.source),
             EvidenceLinker.getForClaim(c.id)
         ]);
-        const typeIcon = CLAIM_TYPE_ICONS[c.type] || '📋';
-        const crux = c.is_crux
-            ? `<span class="xr-claims__crux" title="Crux of the article — confidence ${c.confidence ?? '—'}%">★ crux${c.confidence != null ? ` · ${c.confidence}%` : ''}</span>`
+        const key = c.is_key
+            ? `<span class="xr-claims__crux" title="Key claim — central to the piece">⭐ key</span>`
             : '';
-        const triple = (subject || object || c.predicate)
-            ? `<div class="xr-claims__triple"><em>${escapeHtml(subject || '—')}</em> <strong>${escapeHtml(c.predicate || '—')}</strong> <em>${escapeHtml(object || '—')}</em></div>`
+        const aboutLine = about
+            ? `<div class="xr-claims__triple">About <em>${escapeHtml(about)}</em></div>`
             : '';
-        const claimantLine = claimant
-            ? `<div class="xr-claims__claimant">Attributed to <em>${escapeHtml(claimant)}</em> · ${escapeHtml(CLAIM_ATTRIBUTION_LABELS[c.attribution] || c.attribution)}</div>`
-            : `<div class="xr-claims__claimant">${escapeHtml(CLAIM_ATTRIBUTION_LABELS[c.attribution] || c.attribution)}</div>`;
+        const sourceLine = source
+            ? `<div class="xr-claims__claimant">Per <em>${escapeHtml(source)}</em></div>`
+            : '';
         const pubDot = c.publishedAt
             ? `<span class="xr-claims__pub" title="Published ${new Date(c.publishedAt * 1000).toLocaleString()}">🌐</span>`
             : '';
@@ -613,10 +549,9 @@ export async function renderClaimsBar(claims) {
               }</div>`
             : '';
         return `
-          <article class="xr-claims__item xr-claims__item--${c.type} ${c.is_crux ? 'xr-claims__item--crux' : ''}" data-id="${escapeHtml(c.id)}">
+          <article class="xr-claims__item ${c.is_key ? 'xr-claims__item--crux' : ''}" data-id="${escapeHtml(c.id)}">
             <div class="xr-claims__row-top">
-              <span class="xr-claims__type">${typeIcon} ${escapeHtml(CLAIM_TYPE_LABELS[c.type] || c.type)}</span>
-              ${crux}
+              ${key}
               ${pubDot}
               <div class="xr-claims__row-actions">
                 <button type="button" class="xr-claims__btn" data-action="link" title="Link to another claim">🔗</button>
@@ -625,8 +560,8 @@ export async function renderClaimsBar(claims) {
               </div>
             </div>
             <div class="xr-claims__text">${escapeHtml(c.text)}</div>
-            ${triple}
-            ${claimantLine}
+            ${aboutLine}
+            ${sourceLine}
             ${linksBlock}
           </article>`;
     }));
@@ -656,6 +591,14 @@ async function describeEntity(id) {
     const e = await EntityModel.get(id);
     if (!e) return '(missing entity)';
     return `${ENTITY_ICONS[e.type] || '🔷'} ${e.name}`;
+}
+
+// `source` is an entity id, free text, or null (= the article — render
+// nothing). Resolves entity ids to their display name.
+async function describeSource(source) {
+    if (!source) return '';
+    if (/^entity_/.test(source)) return await describeEntity(source);
+    return String(source);
 }
 
 // ------------------------------------------------------------------

--- a/src/shared/claim-model.js
+++ b/src/shared/claim-model.js
@@ -1,34 +1,36 @@
-// Claim model — Phase 5 C1 of the v4.2 parity push (issue #16).
+// Claim model — thin, entity-centric claim (Phase 10.1).
 //
-// A "claim" is a structured factual assertion the user has extracted
-// from an article. Each claim has:
+// See docs/CLAIMS_REDESIGN.md. A claim is now just:
 //
-//   - a stable hash-based id           (derived from source URL + text)
-//   - a classification type            (factual / causal / evaluative / predictive)
-//   - optional "crux" flag + confidence (0–100) — this is the central
-//     claim the whole piece hinges on
-//   - a claimant, subject, object triple — each either a specific
-//     entity (by id, from Phase 4's `EntityModel`) or free text
-//   - a predicate — the relationship verb
-//   - an attribution — direct_quote / paraphrase / editorial / thesis
-//   - an optional quote_date — when the claim was ORIGINALLY made (may
-//     predate the article reporting it)
-//   - the surrounding context text — becomes the kind-30040 event body
+//   - text       — the assertion (required; immutable after creation)
+//   - about[]    — the entity ids the claim concerns (the queryable core)
+//   - source     — who asserts it: null = "the article/author", else an
+//                  entity id or free-text name (absorbs the old
+//                  attribution + claimant)
+//   - is_key     — a single ⭐ flag (replaces crux + the 0–100 confidence)
+//   - anchor     — optional W3C text-range selector (wired in slice 10.3)
+//   - source_url + context — unchanged
 //
-// Storage:
-//   Storage.get('article_claims', {})  — keyed by claim id. Same
-//     pattern as entities.
+// The old structured fields (type / confidence / attribution / predicate /
+// subject / object / claimant / quote_date) are gone from the capture UX.
 //
-// Publication (Phase 5 C3): the reader's publish flow will emit a
-// kind-30040 event per claim via `event-builder.buildClaimEvent()`,
-// already built in Phase 2 and consuming this exact shape.
+// TRANSITIONAL MIRROR: until slice 10.2 rewrites `buildClaimEvent` to read
+// the thin fields directly, `create`/`update` also populate the legacy
+// fields the unchanged event-builder + reader publish flow read:
+//   subject_entity_ids ← about, claimant_entity_id ← source (when an
+//   entity), is_crux ← is_key, type ← 'factual', attribution ← 'editorial'.
+// `normalizeClaim` does the inverse for records written before this slice,
+// so old claims render in the thin UI. Both go away in 10.2.
+//
+// Storage: Storage.get('article_claims', {}) keyed by claim id (unchanged).
 
 import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
 import { Utils } from './utils.js';
 
 // ------------------------------------------------------------------
-// Enums
+// Enums — retained for rendering legacy + foreign (others') claims that
+// still carry a type/attribution. The thin model does not require them.
 // ------------------------------------------------------------------
 
 export const CLAIM_TYPES = ['factual', 'causal', 'evaluative', 'predictive'];
@@ -57,16 +59,9 @@ export const CLAIM_ATTRIBUTION_LABELS = {
 };
 
 // ------------------------------------------------------------------
-// ID derivation
+// ID derivation (unchanged — keeps published-event ids stable)
 // ------------------------------------------------------------------
 
-/**
- * Collapse whitespace + casefold the claim text for id derivation.
- * Two capture sessions that extract the same claim from the same URL —
- * even with minor whitespace differences — get the same id. Explicit
- * variant claims live at different URLs or have substantively different
- * text.
- */
 function normalizeClaimText(text) {
     return String(text || '').trim().replace(/\s+/g, ' ').toLowerCase();
 }
@@ -81,32 +76,11 @@ export async function generateClaimId(sourceUrl, text) {
 // Validation
 // ------------------------------------------------------------------
 
-function assertValidType(type) {
-    if (!CLAIM_TYPES.includes(type)) {
-        throw new Error(`Invalid claim type: ${type} (expected one of ${CLAIM_TYPES.join(', ')})`);
-    }
-}
-
-function assertValidAttribution(attribution) {
-    if (!CLAIM_ATTRIBUTIONS.includes(attribution)) {
-        throw new Error(`Invalid attribution: ${attribution} (expected one of ${CLAIM_ATTRIBUTIONS.join(', ')})`);
-    }
-}
-
 function assertValidText(text) {
     const trimmed = String(text || '').trim();
     if (!trimmed) throw new Error('Claim text is required');
     if (trimmed.length > 2000) throw new Error('Claim text too long (max 2000 chars)');
     return trimmed;
-}
-
-function assertValidConfidence(confidence) {
-    if (confidence == null) return null;
-    const n = Number(confidence);
-    if (!Number.isFinite(n) || n < 0 || n > 100) {
-        throw new Error(`Invalid confidence: ${confidence} (expected 0..100)`);
-    }
-    return Math.round(n);
 }
 
 function assertValidUrl(url) {
@@ -115,96 +89,119 @@ function assertValidUrl(url) {
     return trimmed;
 }
 
+function isEntityId(s) {
+    return typeof s === 'string' && /^entity_/.test(s);
+}
+
+function cleanAbout(about) {
+    if (!Array.isArray(about)) return [];
+    // Keep unique, non-empty entity ids only.
+    return [...new Set(about.filter((id) => typeof id === 'string' && id))];
+}
+
+// Derive the transitional legacy mirror from the thin fields, so the
+// (as-yet-unchanged) event-builder + publish flow keep working.
+function legacyMirror(about, source, isKey) {
+    return {
+        subject_entity_ids: about.slice(),
+        object_entity_ids:  [],
+        subject_text:       '',
+        object_text:        '',
+        claimant_entity_id: isEntityId(source) ? source : null,
+        predicate:          '',
+        is_crux:            isKey,
+        confidence:         null,
+        type:               'factual',
+        attribution:        'editorial',
+        quote_date:         null
+    };
+}
+
+// Backfill thin fields for records written before slice 10.1, so old
+// claims render in the thin UI. Non-destructive (read-time only).
+function normalizeClaim(record) {
+    if (!record) return record;
+    if ('about' in record && 'is_key' in record && 'source' in record) return record;
+    const about = cleanAbout(
+        Array.isArray(record.about)
+            ? record.about
+            : [...(record.subject_entity_ids || []), ...(record.object_entity_ids || [])]
+    );
+    const source = ('source' in record)
+        ? record.source
+        : (record.claimant_entity_id || null);
+    const isKey = ('is_key' in record) ? record.is_key === true : record.is_crux === true;
+    return { ...record, about, source, is_key: isKey };
+}
+
 // ------------------------------------------------------------------
 // CRUD
 // ------------------------------------------------------------------
 
 export const ClaimModel = {
-    /**
-     * Fetch a single claim by id, or null if not found.
-     */
     get: async (id) => {
         if (!id) return null;
         const all = await Storage.get('article_claims', {});
-        return all[id] || null;
+        return all[id] ? normalizeClaim(all[id]) : null;
     },
 
-    /**
-     * All claims, keyed by id.
-     */
     getAll: async () => {
-        return await Storage.get('article_claims', {});
+        const all = await Storage.get('article_claims', {});
+        const out = {};
+        for (const [id, rec] of Object.entries(all)) out[id] = normalizeClaim(rec);
+        return out;
     },
 
     /**
-     * All claims whose `source_url` exactly matches the given URL.
-     * Used by the reader's claims-bar to show the list of claims for
-     * the currently-open article.
+     * All claims for a URL, key claims first then by creation time.
      */
     getBySourceUrl: async (url) => {
         if (!url) return [];
         const all = await Storage.get('article_claims', {});
         const out = [];
         for (const claim of Object.values(all)) {
-            if (claim.source_url === url) out.push(claim);
+            if (claim.source_url === url) out.push(normalizeClaim(claim));
         }
-        out.sort((a, b) => (b.is_crux ? 1 : 0) - (a.is_crux ? 1 : 0)   // cruxes first
-                          || (a.created || 0) - (b.created || 0));     // then by creation
+        out.sort((a, b) => (b.is_key ? 1 : 0) - (a.is_key ? 1 : 0)   // key claims first
+                          || (a.created || 0) - (b.created || 0));   // then by creation
         return out;
     },
 
     /**
-     * Create a new claim. Generates a hash-based id from
-     * `source_url + text`, so the same claim on the same article is
-     * idempotent — second `create()` with identical text + URL returns
-     * the existing record without surprise.
-     *
-     * Required fields: `text`, `type`, `source_url`.
-     * Optional:        `is_crux`, `confidence` (0-100), `attribution`
-     *                  (default 'editorial'), `claimant_entity_id`,
-     *                  `subject_entity_ids` | `subject_text`,
-     *                  `object_entity_ids` | `object_text`,
-     *                  `predicate`, `quote_date`, `context`.
+     * Create a thin claim. Required: `text`, `source_url`.
+     * Optional: `about` (entity id[]), `source` (entity id | free text |
+     * null), `is_key` (bool), `anchor`, `context`. Idempotent on
+     * (source_url, normalized text).
      */
     create: async (fields) => {
         const text = assertValidText(fields.text);
-        const type = fields.type;
-        assertValidType(type);
         const sourceUrl = assertValidUrl(fields.source_url);
-        const attribution = fields.attribution || 'editorial';
-        assertValidAttribution(attribution);
-        const confidence = assertValidConfidence(fields.confidence);
 
         const id = await generateClaimId(sourceUrl, text);
         const all = await Storage.get('article_claims', {});
-        if (all[id]) {
-            // Idempotent create if the URL + normalized text already
-            // produced this id — return the existing record. If the
-            // caller wanted to update, they should call `update()`.
-            return all[id];
-        }
+        if (all[id]) return normalizeClaim(all[id]);   // idempotent
+
+        const about = cleanAbout(fields.about);
+        const source = fields.source != null && String(fields.source).trim() !== ''
+            ? (isEntityId(fields.source) ? fields.source : String(fields.source).trim())
+            : null;
+        const isKey = fields.is_key === true;
 
         const now = Math.floor(Date.now() / 1000);
         const record = {
             id,
             text,
-            type,
-            is_crux:             fields.is_crux === true,
-            confidence:          confidence,
-            claimant_entity_id:  fields.claimant_entity_id || null,
-            subject_entity_ids:  Array.isArray(fields.subject_entity_ids) ? fields.subject_entity_ids.slice() : [],
-            subject_text:        fields.subject_text || '',
-            object_entity_ids:   Array.isArray(fields.object_entity_ids)  ? fields.object_entity_ids.slice()  : [],
-            object_text:         fields.object_text || '',
-            predicate:           fields.predicate   || '',
-            attribution,
-            quote_date:          fields.quote_date  || null,
-            source_url:          sourceUrl,
-            context:             fields.context     || '',
-            created:             now,
-            updated:             now,
-            publishedAt:         null,
-            publishedEventId:    null
+            about,
+            source,
+            is_key:           isKey,
+            anchor:           fields.anchor || null,
+            source_url:       sourceUrl,
+            context:          fields.context || '',
+            ...legacyMirror(about, source, isKey),   // transitional — removed in 10.2
+            created:          now,
+            updated:          now,
+            publishedAt:      null,
+            publishedEventId: null
         };
 
         all[id] = record;
@@ -214,32 +211,27 @@ export const ClaimModel = {
     },
 
     /**
-     * Patch a claim. Id, source_url, and text are IMMUTABLE — they
-     * derive the id together, so changing them would orphan any
-     * already-published kind-30040 event. If you need to change the
-     * text, delete the old claim and create a new one.
+     * Patch a claim. id / source_url / text are IMMUTABLE (they derive
+     * the id). Patchable: about, source, is_key, anchor, context.
      */
     update: async (id, updates) => {
         const all = await Storage.get('article_claims', {});
         const record = all[id];
         if (!record) throw new Error(`Claim not found: ${id}`);
 
-        const patched = { ...record };
-        if (updates.type != null) { assertValidType(updates.type); patched.type = updates.type; }
-        if (updates.attribution != null) {
-            assertValidAttribution(updates.attribution);
-            patched.attribution = updates.attribution;
+        const patched = normalizeClaim({ ...record });
+        if ('about' in updates)   patched.about   = cleanAbout(updates.about);
+        if ('source' in updates) {
+            patched.source = updates.source != null && String(updates.source).trim() !== ''
+                ? (isEntityId(updates.source) ? updates.source : String(updates.source).trim())
+                : null;
         }
-        if ('is_crux' in updates)            patched.is_crux           = updates.is_crux === true;
-        if ('confidence' in updates)         patched.confidence        = assertValidConfidence(updates.confidence);
-        if ('claimant_entity_id' in updates) patched.claimant_entity_id = updates.claimant_entity_id || null;
-        if ('subject_entity_ids' in updates) patched.subject_entity_ids = Array.isArray(updates.subject_entity_ids) ? updates.subject_entity_ids.slice() : [];
-        if ('subject_text' in updates)       patched.subject_text       = updates.subject_text || '';
-        if ('object_entity_ids' in updates)  patched.object_entity_ids  = Array.isArray(updates.object_entity_ids)  ? updates.object_entity_ids.slice()  : [];
-        if ('object_text' in updates)        patched.object_text        = updates.object_text || '';
-        if ('predicate' in updates)          patched.predicate          = updates.predicate || '';
-        if ('quote_date' in updates)         patched.quote_date         = updates.quote_date || null;
-        if ('context' in updates)            patched.context            = updates.context || '';
+        if ('is_key' in updates)  patched.is_key  = updates.is_key === true;
+        if ('anchor' in updates)  patched.anchor  = updates.anchor || null;
+        if ('context' in updates) patched.context = updates.context || '';
+
+        // Re-derive the transitional legacy mirror from the patched thin fields.
+        Object.assign(patched, legacyMirror(patched.about, patched.source, patched.is_key));
 
         patched.updated = Math.floor(Date.now() / 1000);
         all[id] = patched;
@@ -247,11 +239,6 @@ export const ClaimModel = {
         return patched;
     },
 
-    /**
-     * Delete a claim. Any evidence links that reference it should be
-     * orphan-cleaned in Phase 5 C4's `EvidenceLinker.deleteForClaim`;
-     * not our concern here.
-     */
     delete: async (id) => {
         const all = await Storage.get('article_claims', {});
         if (!all[id]) return false;
@@ -261,10 +248,8 @@ export const ClaimModel = {
     },
 
     /**
-     * Record a successful kind-30040 publish so `resolveClaimsToPublish`
-     * on the reader side can skip unchanged claims. Matches
-     * `EntityModel.markPublished` semantics: does NOT bump `updated`,
-     * so the user's edits after a publish correctly re-emit next time.
+     * Record a successful kind-30040 publish. Does NOT bump `updated`,
+     * so edits after a publish correctly re-emit next time.
      */
     markPublished: async (id, eventId) => {
         const all = await Storage.get('article_claims', {});
@@ -274,6 +259,6 @@ export const ClaimModel = {
         if (eventId) record.publishedEventId = eventId;
         all[id] = record;
         await Storage.set('article_claims', all);
-        return record;
+        return normalizeClaim(record);
     }
 };

--- a/tests/claim-model.test.mjs
+++ b/tests/claim-model.test.mjs
@@ -1,4 +1,4 @@
-// Claim model tests — Phase 5 C1 (issue #16).
+// Claim model tests — thin model (Phase 10.1).
 //
 // Same chrome.storage.local shim pattern as entity-model.test.mjs.
 
@@ -28,17 +28,18 @@ globalThis.chrome = {
     }
 };
 
-const { ClaimModel, CLAIM_TYPES, CLAIM_ATTRIBUTIONS, generateClaimId } =
-    await import('../src/shared/claim-model.js');
+const { ClaimModel, generateClaimId } = await import('../src/shared/claim-model.js');
 
 function resetState() { _stateStore.clear(); }
 
 const URL_A = 'https://example.com/article-a';
 const URL_B = 'https://example.com/article-b';
+const ENT_1 = 'entity_aaaaaaaaaaaaaaaa';
+const ENT_2 = 'entity_bbbbbbbbbbbbbbbb';
 
 // ---------------------------------------------------------------------
 
-test('claim: deterministic id generation', async () => {
+test('claim: deterministic id generation (stable across the redesign)', async () => {
     const a = await generateClaimId(URL_A, 'The sky is blue.');
     const b = await generateClaimId(URL_A, '  the   sky   is   BLUE.  ');
     const c = await generateClaimId(URL_A, 'The sky is green.');
@@ -49,134 +50,128 @@ test('claim: deterministic id generation', async () => {
     assert.match(a, /^claim_[0-9a-f]{16}$/);
 });
 
-test('claim: create + get round-trip', async () => {
+test('claim: thin create + get round-trip', async () => {
     resetState();
     const claim = await ClaimModel.create({
         text: 'Democracy is under threat.',
-        type: 'evaluative',
         source_url: URL_A,
-        is_crux: true,
-        confidence: 75,
-        attribution: 'thesis',
-        predicate: 'is threatened by',
-        subject_text: 'Democracy',
-        object_text: 'Authoritarianism'
+        about: [ENT_1, ENT_2],
+        source: ENT_1,
+        is_key: true
     });
     assert.match(claim.id, /^claim_[0-9a-f]{16}$/);
-    assert.equal(claim.type, 'evaluative');
-    assert.equal(claim.is_crux, true);
-    assert.equal(claim.confidence, 75);
-    assert.equal(claim.attribution, 'thesis');
+    assert.deepEqual(claim.about, [ENT_1, ENT_2]);
+    assert.equal(claim.source, ENT_1);
+    assert.equal(claim.is_key, true);
 
     const fetched = await ClaimModel.get(claim.id);
     assert.deepEqual(fetched, claim);
 });
 
-test('claim: create is idempotent on same (url, normalized-text)', async () => {
-    resetState();
-    const a = await ClaimModel.create({
-        text: 'Same claim.',
-        type: 'factual',
-        source_url: URL_A
-    });
-    const b = await ClaimModel.create({
-        text: 'SAME   claim.',   // whitespace + case
-        type: 'factual',
-        source_url: URL_A
-    });
-    assert.equal(a.id, b.id, 'idempotent create must collide on the same id');
-});
-
-test('claim: rejects invalid type / attribution / empty text / bad confidence', async () => {
-    resetState();
-    await assert.rejects(() => ClaimModel.create({ text: 'X', type: 'bogus',    source_url: URL_A }), /Invalid claim type/);
-    await assert.rejects(() => ClaimModel.create({ text: '',  type: 'factual',  source_url: URL_A }), /text is required/);
-    await assert.rejects(() => ClaimModel.create({ text: 'X', type: 'factual',  source_url: ''     }), /source_url is required/);
-    await assert.rejects(() => ClaimModel.create({
-        text: 'X', type: 'factual', source_url: URL_A, attribution: 'bogus'
-    }), /Invalid attribution/);
-    await assert.rejects(() => ClaimModel.create({
-        text: 'X', type: 'factual', source_url: URL_A, confidence: 150
-    }), /Invalid confidence/);
-    await assert.rejects(() => ClaimModel.create({
-        text: 'X', type: 'factual', source_url: URL_A, confidence: -5
-    }), /Invalid confidence/);
-});
-
-test('claim: confidence gets rounded; null is preserved', async () => {
-    resetState();
-    const a = await ClaimModel.create({ text: 'A', type: 'factual', source_url: URL_A, confidence: 87.4 });
-    assert.equal(a.confidence, 87);
-    const b = await ClaimModel.create({ text: 'B', type: 'factual', source_url: URL_A, confidence: null });
-    assert.equal(b.confidence, null);
-});
-
-test('claim: update patches mutable fields but refuses immutable ones', async () => {
+test('claim: about dedups + drops empties; defaults are sane', async () => {
     resetState();
     const claim = await ClaimModel.create({
-        text: 'Original.', type: 'factual', source_url: URL_A
+        text: 'A.', source_url: URL_A, about: [ENT_1, ENT_1, '', null, ENT_2]
     });
-    const originalId = claim.id;
-    const originalText = claim.text;
+    assert.deepEqual(claim.about, [ENT_1, ENT_2]);
+    assert.equal(claim.source, null);   // no source → "the article"
+    assert.equal(claim.is_key, false);
+    assert.deepEqual(claim.anchor, null);
+});
+
+test('claim: source can be free text (a quoted name) or null', async () => {
+    resetState();
+    const quoted = await ClaimModel.create({ text: 'A.', source_url: URL_A, source: '  Jane Roe  ' });
+    assert.equal(quoted.source, 'Jane Roe');
+    const article = await ClaimModel.create({ text: 'B.', source_url: URL_A, source: '' });
+    assert.equal(article.source, null);
+});
+
+test('claim: legacy mirror keeps the (unchanged) event-builder path fed', async () => {
+    resetState();
+    const claim = await ClaimModel.create({
+        text: 'Mirror.', source_url: URL_A, about: [ENT_1], source: ENT_2, is_key: true
+    });
+    // Until slice 10.2, the thin fields are mirrored onto the legacy fields
+    // buildClaimEvent still reads.
+    assert.deepEqual(claim.subject_entity_ids, [ENT_1]);
+    assert.equal(claim.claimant_entity_id, ENT_2);
+    assert.equal(claim.is_crux, true);
+    assert.equal(claim.type, 'factual');
+});
+
+test('claim: create is idempotent on same (url, normalized-text)', async () => {
+    resetState();
+    const a = await ClaimModel.create({ text: 'Same claim.',  source_url: URL_A });
+    const b = await ClaimModel.create({ text: 'SAME   claim.', source_url: URL_A });
+    assert.equal(a.id, b.id);
+});
+
+test('claim: rejects empty text / missing url', async () => {
+    resetState();
+    await assert.rejects(() => ClaimModel.create({ text: '',  source_url: URL_A }), /text is required/);
+    await assert.rejects(() => ClaimModel.create({ text: 'X', source_url: ''     }), /source_url is required/);
+});
+
+test('claim: update patches thin fields, refuses immutable ones', async () => {
+    resetState();
+    const claim = await ClaimModel.create({ text: 'Original.', source_url: URL_A, about: [ENT_1] });
     const updated = await ClaimModel.update(claim.id, {
-        type: 'causal',
-        is_crux: true,
-        confidence: 50,
-        predicate: 'causes',
-        subject_text: 'A',
-        object_text: 'B',
-        // text + source_url + id are immutable — Updater ignores them.
-        text: 'CHANGED',
-        source_url: URL_B,
-        id: 'claim_fake'
+        about: [ENT_2],
+        source: 'A spokesperson',
+        is_key: true,
+        // immutable — ignored:
+        text: 'CHANGED', source_url: URL_B, id: 'claim_fake'
     });
-    assert.equal(updated.id, originalId,     'id stays stable');
-    assert.equal(updated.text, originalText, 'text stays stable');
-    assert.equal(updated.source_url, URL_A,  'source_url stays stable');
-    assert.equal(updated.type, 'causal');
-    assert.equal(updated.is_crux, true);
-    assert.equal(updated.confidence, 50);
-    assert.equal(updated.predicate, 'causes');
+    assert.equal(updated.id, claim.id);
+    assert.equal(updated.text, 'Original.');
+    assert.equal(updated.source_url, URL_A);
+    assert.deepEqual(updated.about, [ENT_2]);
+    assert.equal(updated.source, 'A spokesperson');
+    assert.equal(updated.is_key, true);
+    assert.deepEqual(updated.subject_entity_ids, [ENT_2], 'mirror re-derived on update');
     assert.ok(updated.updated >= claim.updated);
 });
 
-test('claim: getBySourceUrl filters and sorts cruxes first', async () => {
+test('claim: getBySourceUrl filters and sorts key claims first', async () => {
     resetState();
-    const earlyNonCrux = await ClaimModel.create({ text: 'Early non-crux.', type: 'factual', source_url: URL_A });
-    const lateCrux     = await ClaimModel.create({ text: 'Late crux.',     type: 'evaluative', source_url: URL_A, is_crux: true });
-    await ClaimModel.create({ text: 'Different article.', type: 'factual', source_url: URL_B });
+    const earlyNonKey = await ClaimModel.create({ text: 'Early non-key.', source_url: URL_A });
+    const lateKey     = await ClaimModel.create({ text: 'Late key.',      source_url: URL_A, is_key: true });
+    await ClaimModel.create({ text: 'Different article.', source_url: URL_B });
 
     const forA = await ClaimModel.getBySourceUrl(URL_A);
     assert.equal(forA.length, 2);
-    assert.equal(forA[0].id, lateCrux.id,      'crux sorts first regardless of creation order');
-    assert.equal(forA[1].id, earlyNonCrux.id);
-
-    const forB = await ClaimModel.getBySourceUrl(URL_B);
-    assert.equal(forB.length, 1);
+    assert.equal(forA[0].id, lateKey.id, 'key claim sorts first regardless of creation order');
+    assert.equal(forA[1].id, earlyNonKey.id);
 });
 
-test('claim: delete removes record; no cascade on evidence links (C4 handles those)', async () => {
+test('claim: legacy records normalize to thin fields on read', async () => {
     resetState();
-    const claim = await ClaimModel.create({ text: 'Deletable.', type: 'factual', source_url: URL_A });
-    assert.ok(await ClaimModel.get(claim.id));
-    const ok = await ClaimModel.delete(claim.id);
-    assert.equal(ok, true);
-    assert.equal(await ClaimModel.get(claim.id), null);
-    const notFound = await ClaimModel.delete(claim.id);
-    assert.equal(notFound, false);
+    // Simulate a pre-10.1 record written straight into storage.
+    const legacyId = await generateClaimId(URL_A, 'Legacy claim.');
+    _stateStore.set('article_claims', {
+        [legacyId]: {
+            id: legacyId, text: 'Legacy claim.', source_url: URL_A,
+            type: 'causal', is_crux: true, confidence: 80, attribution: 'paraphrase',
+            subject_entity_ids: [ENT_1], object_entity_ids: [ENT_2],
+            claimant_entity_id: ENT_1, predicate: 'causes',
+            created: 1, updated: 1, publishedAt: null, publishedEventId: null
+        }
+    });
+    const got = await ClaimModel.get(legacyId);
+    assert.deepEqual(got.about, [ENT_1, ENT_2], 'about backfilled from subject ∪ object');
+    assert.equal(got.is_key, true, 'is_key backfilled from is_crux');
+    assert.equal(got.source, ENT_1, 'source backfilled from claimant');
 });
 
-test('claim: markPublished records publishedAt without bumping updated', async () => {
+test('claim: delete + markPublished', async () => {
     resetState();
-    const claim = await ClaimModel.create({ text: 'Publishable.', type: 'factual', source_url: URL_A });
-    const updatedBefore = claim.updated;
-    const marked = await ClaimModel.markPublished(claim.id, 'eventid' + '0'.repeat(57));
+    const claim = await ClaimModel.create({ text: 'Publishable.', source_url: URL_A });
+    const marked = await ClaimModel.markPublished(claim.id, 'e'.repeat(64));
     assert.ok(marked.publishedAt > 0);
-    assert.ok(marked.publishedEventId && marked.publishedEventId.length === 64);
-    assert.equal(marked.updated, updatedBefore, 'publish must not bump updated');
-});
+    assert.equal(marked.updated, claim.updated, 'publish must not bump updated');
 
-test('claim: type + attribution enums are exhaustive', () => {
-    assert.deepEqual(CLAIM_TYPES.slice().sort(), ['causal', 'evaluative', 'factual', 'predictive']);
-    assert.deepEqual(CLAIM_ATTRIBUTIONS.slice().sort(), ['direct_quote', 'editorial', 'paraphrase', 'thesis']);
+    assert.equal(await ClaimModel.delete(claim.id), true);
+    assert.equal(await ClaimModel.get(claim.id), null);
+    assert.equal(await ClaimModel.delete(claim.id), false);
 });


### PR DESCRIPTION
First implementation slice of the claim redesign ([design note](docs/CLAIMS_REDESIGN.md), merged in #31). **Thin model + gutted modal — no wire-format change yet.**

## What changed
- **`claim-model.js`** is now thin: `text` + `about[]` (entity ids) + `source` (entity id / free text / `null`=the article) + `is_key` + `anchor?`. Dropped `type`, `confidence`, `attribution`, `predicate`, the `subject`/`object` split, and `quote_date`.
- **The claim modal** (`claim-extractor.js`) loses the type row, crux+confidence slider, attribution dropdown, predicate, the subject/object/claimant pickers, and quote-date. In their place: a single **About** multi-entity picker, an optional **"who said it"** entity-or-text picker, and a ⭐ **Key claim** checkbox. The claims bar renders *text + about-entities + source + ⭐*.

## Why no wire change yet (per the design's slice boundary)
`create`/`update` **mirror** the thin fields onto the legacy fields the *unchanged* `buildClaimEvent` + reader publish flow still read (`subject_entity_ids`←`about`, `claimant_entity_id`←`source` when an entity, `is_crux`←`is_key`, `type='factual'`, `attribution='editorial'`). `normalizeClaim()` backfills the thin fields for pre-10.1 records on read, so **old claims render in the new UI**. Both the mirror and the normalizer are removed in **10.2**, which rewrites the `kind 30040` tag set to the lean `#p about` form. Id derivation (`source_url|norm(text)`) is unchanged → published-event ids stay stable.

## Verification
- `npm run build` clean; **522/522 tests**. `tests/claim-model.test.mjs` rewritten for the thin API + a legacy-record normalization test.
- **Needs a manual UI smoke** (no browser here): capture → select text → "Add as claim" → the modal shows only About / who-said-it / ⭐; save; the claims bar shows the entities; edit/delete still work; publish still emits a `30040` (via the mirror).

## Next
10.2 — lean `30040` tag set (`#p about`) + dual-read of old/new vocab in "others' claims", and remove the mirror.

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65)_