### PR TITLE
Phase 10.2 — Lean kind-30040 wire format + dual-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Changed
 
+- **Lean `kind 30040` claim wire format** (Phase 10.2; **wire-format
+  change**, back-compat preserved). Published claims now carry the entities
+  they're about as **`['p', <entity_pubkey>, '', 'about']` tags** (mirrored by
+  `['entity', <name>, 'about']`), the claim text as the event **content**, the
+  asserting source as `['source', …]` (+ a `p`-tag when it's an entity), and a
+  single `['key','true']` flag — replacing the old `claim-text` / `claim-type`
+  / `crux` / `confidence` / `attribution` / `subject` / `object` / `predicate`
+  / `claimant` tag soup. This makes *"what the network says about person P"* a
+  single `{ kinds:[30040], "#p":[P] }` query. **Reading is dual-vocabulary:**
+  the "others' claims" view renders both new and pre-redesign events, and
+  already-published claims keep their old tags. The transitional legacy-field
+  mirror from 10.1 is removed. Entity-relationship (`32125`) events derived
+  from claims now use `about` / `source` relationship types.
+
 - **Claims simplified to a thin, entity-centric model** (Phase 10.1; see
   [`docs/CLAIMS_REDESIGN.md`](docs/CLAIMS_REDESIGN.md)). A claim is now just
   *text + the entities it's about + an optional "who said it" + a single ⭐

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,38 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Lean kind-30040 wire format (Phase 10.2)
+
+**Tags:** design, wire-format
+
+**What changed:** `buildClaimEvent` now emits the thin shape directly. Claim
+text moves to the event **content** (was a `claim-text` tag); about-entities
+become **`['p', pubkey, '', 'about']`** + `['entity', name, 'about']`; the
+source is `['source', value]` (+ a `p`-tag with `source` marker when it's an
+entity); `['key','true']` replaces `crux`/`confidence`. Gone: `claim-type`,
+`attribution`, `predicate`, `subject`/`object`, `claimant`, `quote-date`. The
+`buildArticleEvent` embedded `['claim', …]` tags went thin too
+(`['claim', text]` / `['claim', text, 'key']`). The 10.1 transitional mirror
+in `claim-model.js` is removed; `normalizeClaim` stays (reads pre-redesign
+local records). The reader's publish flow (`collectClaimEntityIds`,
+`resolveRelationshipsToPublish`) now reads `about` + `source`, and the derived
+`32125` relationships use `about` / `source` relTypes (the relationship
+builder takes an arbitrary type, so no enum change).
+
+**Why this is the payoff:** about-entities tagged with the *same entity
+pubkeys used everywhere else* make "what the network says about person P" a
+single `{ kinds:[30040], "#p":[P] }` relay query (Phase 10.4 will surface it).
+
+**Compat:** wire-format change, back-compat preserved. Already-published
+30040s keep their old tags; `renderForeignClaim` is **dual-read** — it
+understands both the new vocab (`content`, `entity …about`, `source`, `key`)
+and the legacy one (`claim-text`, `subject`/`object`, `claimant`, `crux`), so
+others' claims published before the redesign still display. Tests:
+`tests/event-builder.test.mjs` gains two lean-format cases; the 10.1 mirror
+test was dropped. 523/523 green.
+
+---
+
 ## 2026-06-09 — Thin claims shipped: model + modal (Phase 10.1)
 
 **Tags:** design

--- a/src/reader/claim-extractor.js
+++ b/src/reader/claim-extractor.js
@@ -22,9 +22,7 @@
 
 import {
     ClaimModel,
-    CLAIM_TYPE_LABELS,
-    CLAIM_TYPE_ICONS,
-    CLAIM_ATTRIBUTION_LABELS
+    CLAIM_TYPE_ICONS
 } from '../shared/claim-model.js';
 import {
     EvidenceLinker,
@@ -724,46 +722,48 @@ function renderOthersClaims(events, byRelay) {
     return summary + authorCards;
 }
 
+// Render one foreign (others') kind-30040. Dual-read: understands both the
+// thin vocabulary (Phase 10.2 — content=text, `entity …about`, `source`,
+// `key`) and the legacy one (`claim-text`, `subject`/`object`, `claimant`,
+// `crux`) so claims published before the redesign still display.
 function renderForeignClaim(event) {
     const tags = event.tags || [];
     const firstOf = (name) => {
         const t = tags.find((x) => x[0] === name);
         return t ? t[1] : '';
     };
-    const allOf = (name) => tags.filter((x) => x[0] === name).map((x) => x[1]);
+    // `entity` name tags carry their role in slot 2 ('about'); fall back to
+    // the legacy subject/object tags.
+    const entityNames = (role) => tags.filter((x) => x[0] === 'entity' && x[2] === role).map((x) => x[1]);
 
-    const text        = firstOf('claim-text') || (event.content || '').slice(0, 200);
-    const type        = firstOf('claim-type') || 'factual';
-    const typeIcon    = CLAIM_TYPE_ICONS[type] || '📋';
-    const typeLabel   = CLAIM_TYPE_LABELS[type] || type;
-    const attribution = firstOf('attribution');
-    const isCrux      = firstOf('crux') === 'true';
-    const confidence  = firstOf('confidence');
-    const predicate   = firstOf('predicate');
-    const subjects    = allOf('subject');
-    const objects     = allOf('object');
-    const claimant    = firstOf('claimant');
-    const triple = (subjects.length || objects.length || predicate)
-        ? `<div class="xr-claims__triple"><em>${escapeHtml(subjects.join(', ') || '—')}</em> <strong>${escapeHtml(predicate || '—')}</strong> <em>${escapeHtml(objects.join(', ') || '—')}</em></div>`
-        : '';
-    const cruxLine = isCrux
-        ? `<span class="xr-claims__crux">★ crux${confidence ? ` · ${escapeHtml(confidence)}%` : ''}</span>`
-        : '';
-    const when = event.created_at
-        ? new Date(event.created_at * 1000).toLocaleDateString()
-        : '';
+    // Text: thin events put it in content; legacy used a claim-text tag.
+    const text    = firstOf('claim-text') || (event.content || '');
+    const isKey   = firstOf('key') === 'true' || firstOf('crux') === 'true';
+    const about   = entityNames('about');
+    if (about.length === 0) {                       // legacy fallback
+        for (const n of [...tagVals(tags, 'subject'), ...tagVals(tags, 'object')]) about.push(n);
+    }
+    const source  = firstOf('source') || firstOf('claimant');
+    const when    = event.created_at ? new Date(event.created_at * 1000).toLocaleDateString() : '';
+
+    const keyLine    = isKey ? `<span class="xr-claims__crux">⭐ key</span>` : '';
+    const aboutLine  = about.length ? `<div class="xr-claims__triple">About <em>${escapeHtml(about.join(', '))}</em></div>` : '';
+    const sourceLine = source    ? `<div class="xr-claims__claimant">Per <em>${escapeHtml(source)}</em></div>` : '';
 
     return `
-      <article class="xr-claims__item xr-claims__item--${escapeHtml(type)} ${isCrux ? 'xr-claims__item--crux' : ''}">
+      <article class="xr-claims__item ${isKey ? 'xr-claims__item--crux' : ''}">
         <div class="xr-claims__row-top">
-          <span class="xr-claims__type">${typeIcon} ${escapeHtml(typeLabel)}</span>
-          ${cruxLine}
+          ${keyLine}
           <span class="xr-others-modal__when">${escapeHtml(when)}</span>
         </div>
         <div class="xr-claims__text">${escapeHtml(text)}</div>
-        ${triple}
-        <div class="xr-claims__claimant">${claimant ? `Attributed to <em>${escapeHtml(claimant)}</em> · ` : ''}${escapeHtml(CLAIM_ATTRIBUTION_LABELS[attribution] || attribution || 'editorial')}</div>
+        ${aboutLine}
+        ${sourceLine}
       </article>`;
+}
+
+function tagVals(tags, name) {
+    return tags.filter((x) => x[0] === name).map((x) => x[1]);
 }
 
 // ------------------------------------------------------------------
@@ -848,10 +848,9 @@ function approxLength(raw, startRaw, normalizedLen) {
 
 function wrapRangeWithClaimMark(range, claim) {
     const mark = document.createElement('span');
-    mark.className = `xr-claim xr-claim--${claim.type}${claim.is_crux ? ' xr-claim--crux' : ''}`;
+    mark.className = `xr-claim${claim.is_key ? ' xr-claim--crux' : ''}`;
     mark.setAttribute('data-claim-id', claim.id);
-    mark.setAttribute('data-claim-type', claim.type);
-    mark.setAttribute('title', `${CLAIM_TYPE_LABELS[claim.type] || 'claim'}${claim.is_crux ? ' (crux)' : ''}: ${claim.text.slice(0, 180)}`);
+    mark.setAttribute('title', `${claim.is_key ? '⭐ key claim' : 'Claim'}: ${claim.text.slice(0, 180)}`);
     try { range.surroundContents(mark); }
     catch (_) {
         const frag = range.extractContents();

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1852,17 +1852,16 @@ async function resolveClaimsToPublish(articleUrl) {
 }
 
 /**
- * Collect every entity id referenced by a claim as claimant, subject,
- * or object. Used to ensure claim-referenced entities have their
+ * Collect every entity id a claim references — its `about` set plus an
+ * entity `source`. Used to ensure claim-referenced entities have their
  * kind-0 on the network before the claim's kind-30040 lands (claim
  * events p-tag these pubkeys; dangling references are rude).
  */
 function collectClaimEntityIds(claims) {
     const ids = new Set();
     for (const c of claims || []) {
-        if (c.claimant_entity_id) ids.add(c.claimant_entity_id);
-        for (const id of c.subject_entity_ids || []) ids.add(id);
-        for (const id of c.object_entity_ids  || []) ids.add(id);
+        for (const id of c.about || []) ids.add(id);
+        if (c.source && /^entity_/.test(c.source)) ids.add(c.source);
     }
     return ids;
 }
@@ -1905,9 +1904,8 @@ async function resolveRelationshipsToPublish(claims, articleUrl) {
     const out = [];
     for (const c of claims || []) {
         const triples = [];
-        if (c.claimant_entity_id) triples.push([c.claimant_entity_id, 'claimant']);
-        for (const id of c.subject_entity_ids || []) triples.push([id, 'subject']);
-        for (const id of c.object_entity_ids  || []) triples.push([id, 'object']);
+        for (const id of c.about || []) triples.push([id, 'about']);
+        if (c.source && /^entity_/.test(c.source)) triples.push([c.source, 'source']);
         for (const [entityId, relType] of triples) {
             const key = `${entityId}:${articleUrl}:${relType}`;
             if (seen.has(key)) continue;

--- a/src/shared/claim-model.js
+++ b/src/shared/claim-model.js
@@ -14,13 +14,9 @@
 // The old structured fields (type / confidence / attribution / predicate /
 // subject / object / claimant / quote_date) are gone from the capture UX.
 //
-// TRANSITIONAL MIRROR: until slice 10.2 rewrites `buildClaimEvent` to read
-// the thin fields directly, `create`/`update` also populate the legacy
-// fields the unchanged event-builder + reader publish flow read:
-//   subject_entity_ids ← about, claimant_entity_id ← source (when an
-//   entity), is_crux ← is_key, type ← 'factual', attribution ← 'editorial'.
-// `normalizeClaim` does the inverse for records written before this slice,
-// so old claims render in the thin UI. Both go away in 10.2.
+// `normalizeClaim` backfills the thin fields for records written before the
+// redesign (which carried subject/object/claimant/crux), so old claims still
+// render and publish under the new model.
 //
 // Storage: Storage.get('article_claims', {}) keyed by claim id (unchanged).
 
@@ -97,24 +93,6 @@ function cleanAbout(about) {
     if (!Array.isArray(about)) return [];
     // Keep unique, non-empty entity ids only.
     return [...new Set(about.filter((id) => typeof id === 'string' && id))];
-}
-
-// Derive the transitional legacy mirror from the thin fields, so the
-// (as-yet-unchanged) event-builder + publish flow keep working.
-function legacyMirror(about, source, isKey) {
-    return {
-        subject_entity_ids: about.slice(),
-        object_entity_ids:  [],
-        subject_text:       '',
-        object_text:        '',
-        claimant_entity_id: isEntityId(source) ? source : null,
-        predicate:          '',
-        is_crux:            isKey,
-        confidence:         null,
-        type:               'factual',
-        attribution:        'editorial',
-        quote_date:         null
-    };
 }
 
 // Backfill thin fields for records written before slice 10.1, so old
@@ -197,7 +175,6 @@ export const ClaimModel = {
             anchor:           fields.anchor || null,
             source_url:       sourceUrl,
             context:          fields.context || '',
-            ...legacyMirror(about, source, isKey),   // transitional — removed in 10.2
             created:          now,
             updated:          now,
             publishedAt:      null,
@@ -229,9 +206,6 @@ export const ClaimModel = {
         if ('is_key' in updates)  patched.is_key  = updates.is_key === true;
         if ('anchor' in updates)  patched.anchor  = updates.anchor || null;
         if ('context' in updates) patched.context = updates.context || '';
-
-        // Re-derive the transitional legacy mirror from the patched thin fields.
-        Object.assign(patched, legacyMirror(patched.about, patched.source, patched.is_key));
 
         patched.updated = Math.floor(Date.now() / 1000);
         all[id] = patched;

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -179,14 +179,10 @@ export const EventBuilder = {
       tags.push(['icon', article.publicationIcon]);
     }
     
-    // Add claim tags
+    // Add claim tags (thin — Phase 10.2)
     if (Array.isArray(claims)) {
       for (const claim of claims) {
-        if (claim.is_crux) {
-          tags.push(['claim', claim.text, claim.type, 'crux']);
-        } else {
-          tags.push(['claim', claim.text, claim.type]);
-        }
+        tags.push(claim.is_key ? ['claim', claim.text, 'key'] : ['claim', claim.text]);
       }
     }
 
@@ -401,65 +397,60 @@ export const EventBuilder = {
     };
   },
 
-  // Build kind 30040 claim event
+  // Build kind 30040 claim event — thin, entity-centric (Phase 10.2).
+  //
+  // Wire format (see docs/CLAIMS_REDESIGN.md):
+  //   ['d', id], ['r', sourceUrl], ['title', articleTitle]
+  //   per about-entity:  ['p', pubkey, '', 'about'] + ['entity', name, 'about']
+  //   source (who said it):
+  //     entity    → ['p', pubkey, '', 'source'] + ['source', name]
+  //     free text → ['source', text]
+  //     null      → (the article — no tag)
+  //   ['key', 'true']?   ['anchor', <selector-json>]?   ['client', 'xray']
+  //   content = claim text
+  //
+  // "What the network says about entity P" is then a single relay query:
+  //   { kinds:[30040], "#p":[P_pubkey] }
   buildClaimEvent: (claim, articleUrl, articleTitle, userPubkey, entities) => {
+    const dict = entities || {};
     const tags = [
       ['d', claim.id],
       ['r', articleUrl],
-      ['claim-text', claim.text],
-      ['claim-type', claim.type],
-      ['title', articleTitle],
     ];
-    if (claim.is_crux) tags.push(['crux', 'true']);
-    if (claim.confidence != null) tags.push(['confidence', String(claim.confidence)]);
-    // Attribution tag
-    tags.push(['attribution', claim.attribution || 'editorial']);
-    // Claimant entity
-    if (claim.claimant_entity_id && entities) {
-      const claimant = entities[claim.claimant_entity_id];
-      if (claimant && claimant.keypair) {
-        tags.push(['p', claimant.keypair.pubkey, '', 'claimant']);
-        tags.push(['claimant', claimant.name]);
+    if (articleTitle) tags.push(['title', articleTitle]);
+
+    // About entities — the queryable core.
+    for (const eid of (Array.isArray(claim.about) ? claim.about : [])) {
+      const ent = dict[eid];
+      if (ent && ent.keypair) {
+        tags.push(['p', ent.keypair.pubkey, '', 'about']);
+        tags.push(['entity', ent.name, 'about']);
       }
     }
-    // Subject entities or freetext
-    if (Array.isArray(claim.subject_entity_ids) && claim.subject_entity_ids.length > 0 && entities) {
-      for (const sid of claim.subject_entity_ids) {
-        const subject = entities[sid];
-        if (subject && subject.keypair) {
-          tags.push(['p', subject.keypair.pubkey, '', 'subject']);
-          tags.push(['subject', subject.name]);
+
+    // Source — an entity id, free text, or null (= the article).
+    if (claim.source) {
+      if (/^entity_/.test(claim.source)) {
+        const s = dict[claim.source];
+        if (s && s.keypair) {
+          tags.push(['p', s.keypair.pubkey, '', 'source']);
+          tags.push(['source', s.name]);
         }
+      } else {
+        tags.push(['source', claim.source]);
       }
-    } else if (claim.subject_text) {
-      tags.push(['subject', claim.subject_text]);
     }
-    // Object entities or freetext
-    if (Array.isArray(claim.object_entity_ids) && claim.object_entity_ids.length > 0 && entities) {
-      for (const oid of claim.object_entity_ids) {
-        const obj = entities[oid];
-        if (obj && obj.keypair) {
-          tags.push(['p', obj.keypair.pubkey, '', 'object']);
-          tags.push(['object', obj.name]);
-        }
-      }
-    } else if (claim.object_text) {
-      tags.push(['object', claim.object_text]);
-    }
-    // Predicate
-    if (claim.predicate) {
-      tags.push(['predicate', claim.predicate]);
-    }
-    // Quote date
-    if (claim.quote_date) {
-      tags.push(['quote-date', claim.quote_date]);
-    }
+
+    if (claim.is_key) tags.push(['key', 'true']);
+    if (claim.anchor) tags.push(['anchor', JSON.stringify(claim.anchor)]);
+    tags.push(['client', 'xray']);
+
     return {
       kind: 30040,
       pubkey: userPubkey,
       created_at: Math.floor(Date.now() / 1000),
-      tags,
-      content: claim.context || ''
+      tags: EventBuilder.sanitizeTags(tags),
+      content: claim.text || ''
     };
   },
 

--- a/tests/claim-model.test.mjs
+++ b/tests/claim-model.test.mjs
@@ -87,19 +87,6 @@ test('claim: source can be free text (a quoted name) or null', async () => {
     assert.equal(article.source, null);
 });
 
-test('claim: legacy mirror keeps the (unchanged) event-builder path fed', async () => {
-    resetState();
-    const claim = await ClaimModel.create({
-        text: 'Mirror.', source_url: URL_A, about: [ENT_1], source: ENT_2, is_key: true
-    });
-    // Until slice 10.2, the thin fields are mirrored onto the legacy fields
-    // buildClaimEvent still reads.
-    assert.deepEqual(claim.subject_entity_ids, [ENT_1]);
-    assert.equal(claim.claimant_entity_id, ENT_2);
-    assert.equal(claim.is_crux, true);
-    assert.equal(claim.type, 'factual');
-});
-
 test('claim: create is idempotent on same (url, normalized-text)', async () => {
     resetState();
     const a = await ClaimModel.create({ text: 'Same claim.',  source_url: URL_A });
@@ -129,7 +116,6 @@ test('claim: update patches thin fields, refuses immutable ones', async () => {
     assert.deepEqual(updated.about, [ENT_2]);
     assert.equal(updated.source, 'A spokesperson');
     assert.equal(updated.is_key, true);
-    assert.deepEqual(updated.subject_entity_ids, [ENT_2], 'mirror re-derived on update');
     assert.ok(updated.updated >= claim.updated);
 });
 

--- a/tests/event-builder.test.mjs
+++ b/tests/event-builder.test.mjs
@@ -36,6 +36,53 @@ test('buildEntitySyncEvent has the d/L/l tags the pull filter expects', () => {
     assert.deepEqual(tTag, ['entity-type', 'person']);
 });
 
+test('buildClaimEvent (thin) — about p-tags, source, key; text in content', () => {
+    const entities = {
+        entity_p: { id: 'entity_p', name: 'Jane Roe',  type: 'person',       keypair: { pubkey: 'a'.repeat(64) } },
+        entity_o: { id: 'entity_o', name: 'Acme Corp', type: 'organization', keypair: { pubkey: 'b'.repeat(64) } }
+    };
+    const claim = {
+        id: 'claim_0123456789abcdef',
+        text: 'Jane Roe runs Acme Corp.',
+        about: ['entity_p', 'entity_o'],
+        source: 'entity_p',
+        is_key: true
+    };
+    const ev = EventBuilder.buildClaimEvent(claim, 'https://x.test/a', 'A Title', PUBKEY, entities);
+
+    assert.equal(ev.kind, 30040);
+    assert.equal(ev.content, 'Jane Roe runs Acme Corp.', 'claim text is the content');
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'd'), ['d', 'claim_0123456789abcdef']);
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'r'), ['r', 'https://x.test/a']);
+
+    // About entities → p-tag (queryable) + human-readable entity name.
+    const aboutPs = ev.tags.filter((t) => t[0] === 'p' && t[3] === 'about').map((t) => t[1]);
+    assert.deepEqual(aboutPs.sort(), ['a'.repeat(64), 'b'.repeat(64)]);
+    const aboutNames = ev.tags.filter((t) => t[0] === 'entity' && t[2] === 'about').map((t) => t[1]);
+    assert.deepEqual(aboutNames.sort(), ['Acme Corp', 'Jane Roe']);
+
+    // Source entity → p-tag(source) + source name.
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'p' && t[3] === 'source'), ['p', 'a'.repeat(64), '', 'source']);
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'source'), ['source', 'Jane Roe']);
+
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'key'), ['key', 'true']);
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'client'), ['client', 'xray']);
+
+    // No legacy structured tags.
+    for (const dead of ['claim-text', 'claim-type', 'crux', 'confidence', 'attribution', 'subject', 'object', 'predicate', 'claimant']) {
+        assert.equal(ev.tags.find((t) => t[0] === dead), undefined, `no legacy ${dead} tag`);
+    }
+});
+
+test('buildClaimEvent (thin) — free-text source, no source p-tag, no key when absent', () => {
+    const claim = { id: 'claim_x', text: 'A.', about: [], source: 'An unnamed official', is_key: false };
+    const ev = EventBuilder.buildClaimEvent(claim, 'https://x.test/a', '', PUBKEY, {});
+    assert.deepEqual(ev.tags.find((t) => t[0] === 'source'), ['source', 'An unnamed official']);
+    assert.equal(ev.tags.find((t) => t[0] === 'p' && t[3] === 'source'), undefined, 'free-text source gets no p-tag');
+    assert.equal(ev.tags.find((t) => t[0] === 'key'), undefined, 'no key tag when not a key claim');
+    assert.equal(ev.tags.find((t) => t[0] === 'title'), undefined, 'empty title omitted');
+});
+
 test('buildRelayListEvent emits one r-tag per relay, kind 10002', () => {
     const relays = [
         'wss://relay.damus.io',


### PR DESCRIPTION
Second slice of the claim redesign ([design](docs/CLAIMS_REDESIGN.md)). Turns the thin model from 10.1 into a **lean `kind 30040` wire format** and removes the transitional mirror. **Wire-format change — back-compat preserved.**

## New `30040` shape
```
['d', id]  ['r', sourceUrl]  ['title', title]
['p', <entity_pubkey>, '', 'about']  +  ['entity', <name>, 'about']   per about-entity
['p', <pubkey>, '', 'source']  +  ['source', <name>]                  (entity source)
['source', <text>]                                                    (free-text source)
['key', 'true']?   ['anchor', <json>]?   ['client', 'xray']
content = claim text
```
Gone: `claim-text`, `claim-type`, `crux`, `confidence`, `attribution`, `subject`, `object`, `predicate`, `claimant`, `quote-date`. The embedded `['claim', …]` tags in the `30023` article event went thin too.

**The payoff:** about-entities use the *same entity pubkeys used everywhere else*, so *"what the network says about person P"* becomes a single `{ kinds:[30040], "#p":[P] }` query (surfaced in 10.4).

## Compatibility
- **Already-published claims keep their old tags.** `renderForeignClaim` is **dual-read** — understands both the new vocab (`content` / `entity …about` / `source` / `key`) and the legacy one (`claim-text` / `subject` / `object` / `claimant` / `crux`), so others' claims published before the redesign still display.
- The 10.1 transitional mirror is removed from `claim-model.js`; `normalizeClaim` stays to read pre-redesign **local** records.
- Reader publish flow (`collectClaimEntityIds`, `resolveRelationshipsToPublish`) now reads `about` + `source`; derived `32125` relationships use `about` / `source` relTypes.

## Verification
- `npm run build` clean; **523/523 tests**. `tests/event-builder.test.mjs` gains two lean-format cases (entity `about` p-tags + name mirror, entity vs free-text source, `key`, content=text, and assertions that no legacy tags leak); the 10.1 mirror test was dropped.
- **Wants a manual smoke** (no browser here): publish a claim → inspect the `30040` (about `p`-tags + content=text + `key`); open **"Others' claims"** and confirm both a freshly-published claim *and* (if you have one) a pre-redesign claim render.

## Next
10.3 — wire `metadata/anchor-capture.js` into claim creation (exact-passage anchoring, replacing the first-text-occurrence rehydrate).

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65)_