### PR TITLE
Phase 10.4 — "Claims about this entity" cross-source view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Sections per release: **Added** (new features), **Changed**
 
 ## [Unreleased]
 
+### Added
+
+- **"Claims about this entity" — cross-source aggregation** (Phase 10.4). The
+  side-panel entity browser's detail view gains a **Load from relays** action
+  that queries `kind 30040` across your configured relays by the entity's
+  pubkey (`{ kinds:[30040], "#p":[P] }`) and shows what the network has said
+  about that person / org / thing — grouped by author, each claim with its ⭐
+  key flag, source, and a link back to the article it came from. This is the
+  payoff of the entity-centric claim redesign: because claims `p`-tag the same
+  entity pubkeys X-Ray uses everywhere, "what the network says about P" is a
+  single relay query. (Per-*entity* axis — distinct from the reader's existing
+  per-*article* "Others' claims".) The panel routes the query through the
+  background service worker's relay pool (`xray:relay:query`); reading is
+  dual-vocabulary via a shared `parseClaimEvent`, so pre-redesign `30040`s
+  show too.
+
 ### Changed
 
 - **Claims record a precise text-anchor** (Phase 10.3). When you mark a

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,34 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Cross-source claim aggregation (Phase 10.4)
+
+**Tags:** design
+
+The payoff slice. Added a "Claims about this entity" section to the side
+panel's entity-detail view (`renderDetail`): a **Load from relays** button
+queries `kind 30040` by the entity's pubkey (`{kinds:[30040], "#p":[P]}`)
+and renders what the network says about that entity, grouped by author.
+
+**Placement (decided with maintainer):** side-panel entity detail, *not* the
+reader. The reader's existing "Others' claims" is per-**URL** (`#r`); this is
+per-**entity** (`#p`) across all articles — a different axis, and the panel is
+the entity-centric surface. The panel has no relay access of its own (by
+design — see its header comment), so the query routes through the background
+SW's `xray:relay:query` (same path the reader uses), with relays read from
+`preferences.default_relays` (mirroring the reader's `getConfiguredRelays`).
+
+**Shared parse:** added `parseClaimEvent(event)` to `claim-model.js` — a pure,
+dual-vocabulary (thin 10.2 + legacy) reader that turns a `30040` into a
+display object. Unit-tested both vocabularies. (The reader's
+`renderForeignClaim` still has its own inline parse; DRYing it onto
+`parseClaimEvent` is a low-value follow-up, left alone to avoid churn.)
+
+Querying is **on-demand** (a button), not auto-on-detail-open, so browsing
+entities doesn't fire a relay round-trip per click. 526/526 green.
+
+---
+
 ## 2026-06-09 — Precise claim anchoring (Phase 10.3)
 
 **Tags:** design

--- a/src/shared/claim-model.js
+++ b/src/shared/claim-model.js
@@ -68,6 +68,36 @@ export async function generateClaimId(sourceUrl, text) {
     return `claim_${hash.slice(0, 16)}`;
 }
 
+/**
+ * Parse a foreign kind-30040 event into a display-ready object. Dual-read:
+ * understands both the thin vocabulary (Phase 10.2 — content=text,
+ * `entity …about`, `source`, `key`) and the legacy one (`claim-text`,
+ * `subject`/`object`, `claimant`, `crux`). Pure; no DOM, no storage.
+ *
+ * @param {{tags?: Array, content?: string, pubkey?: string, created_at?: number, id?: string}} event
+ * @returns {{id, text, about: string[], source: string, isKey: boolean, url, title, pubkey, created_at}}
+ */
+export function parseClaimEvent(event) {
+    const tags = (event && event.tags) || [];
+    const first = (name) => { const t = tags.find((x) => x[0] === name); return t ? t[1] : ''; };
+    const valsOf = (name) => tags.filter((x) => x[0] === name).map((x) => x[1]);
+    // `entity` name tags carry their role in slot 2 ('about'); fall back to
+    // the legacy subject/object tags.
+    let about = tags.filter((x) => x[0] === 'entity' && x[2] === 'about').map((x) => x[1]);
+    if (about.length === 0) about = [...valsOf('subject'), ...valsOf('object')];
+    return {
+        id:         first('d') || (event && event.id) || '',
+        text:       first('claim-text') || (event && event.content) || '',
+        about,
+        source:     first('source') || first('claimant') || '',
+        isKey:      first('key') === 'true' || first('crux') === 'true',
+        url:        first('r') || '',
+        title:      first('title') || '',
+        pubkey:     (event && event.pubkey) || '',
+        created_at: (event && event.created_at) || 0
+    };
+}
+
 // ------------------------------------------------------------------
 // Validation
 // ------------------------------------------------------------------

--- a/src/sidepanel/index.css
+++ b/src/sidepanel/index.css
@@ -624,3 +624,57 @@ body.xr-side {
   margin-top: 4px;
   color: var(--xr-text);
 }
+
+/* Network claims about an entity (Phase 10.4) */
+.xr-side__net-loading,
+.xr-side__net-summary {
+  font-size: 11px;
+  color: var(--xr-text-dim);
+  margin-bottom: 8px;
+}
+.xr-side__net-author {
+  margin-bottom: 10px;
+}
+.xr-side__net-author-head {
+  font-size: 11px;
+  color: var(--xr-text-dim);
+  font-family: var(--xr-mono, monospace);
+  margin-bottom: 4px;
+}
+.xr-side__net-author-count {
+  opacity: 0.7;
+}
+.xr-side__net-claim {
+  border-left: 2px solid var(--xr-border, #444);
+  padding: 4px 0 4px 8px;
+  margin-bottom: 6px;
+}
+.xr-side__net-claim-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.xr-side__net-key {
+  font-size: 10px;
+  color: var(--xr-accent, #c8a2ff);
+}
+.xr-side__net-when {
+  font-size: 10px;
+  color: var(--xr-text-dim);
+}
+.xr-side__net-claim-text {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--xr-text);
+}
+.xr-side__net-source {
+  font-size: 11px;
+  color: var(--xr-text-dim);
+}
+.xr-side__net-src {
+  font-size: 10px;
+  color: var(--xr-text-dim);
+  text-decoration: none;
+}
+.xr-side__net-src:hover { text-decoration: underline; }

--- a/src/sidepanel/index.js
+++ b/src/sidepanel/index.js
@@ -16,6 +16,7 @@
 // see reader/index.js `resolveEntitiesToPublish`).
 
 import { EntityModel, ENTITY_TYPES, ENTITY_ICONS, installEntityStorageBridge } from '../shared/entity-model.js';
+import { parseClaimEvent } from '../shared/claim-model.js';
 import { accountsForEntity, listUnlinkedAccounts, linkAccountToEntity, unlinkAccount } from '../shared/identity/account-registry.js';
 import { LocalKeyManager } from '../shared/local-key-manager.js';
 import { Crypto } from '../shared/crypto.js';
@@ -245,6 +246,14 @@ function renderDetail(entity) {
         <button type="button" class="xr-side__ghost-btn" id="xr-link-account">Link an account…</button>
       </div>
 
+      <div class="xr-side__network-claims">
+        <h3>Claims about this entity</h3>
+        <p class="xr-side__hint">What the network has published about ${escapeHtml(entity.name)} — kind-30040 claims that reference this entity's key, across your configured relays.</p>
+        <div id="xr-network-claims">
+          <button type="button" class="xr-side__ghost-btn" id="xr-load-network-claims">Load from relays</button>
+        </div>
+      </div>
+
       <div class="xr-side__publish">
         <h3>Publish status</h3>
         <p class="xr-side__pub-line">${pubInfo}</p>
@@ -282,6 +291,10 @@ function renderDetail(entity) {
     renderLinkedAccounts(entity.id);
     $('#xr-link-account').addEventListener('click', () => openAccountPicker(entity));
 
+    // Network claims about this entity (Phase 10.4) — on-demand relay query.
+    const loadClaimsBtn = $('#xr-load-network-claims');
+    if (loadClaimsBtn) loadClaimsBtn.addEventListener('click', () => loadNetworkClaims(entity));
+
     // Keypair controls.
     $('#xr-copy-npub').addEventListener('click', () => {
         if (entity.keypair && entity.keypair.npub) copyToClipboard(entity.keypair.npub);
@@ -299,6 +312,103 @@ function renderDetail(entity) {
             revealBtn.onclick = () => copyToClipboard(entity.keypair.nsec);
         }
     });
+}
+
+// ------------------------------------------------------------------
+// Network claims about this entity (Phase 10.4)
+//
+// "What the network says about entity P" — query kind-30040 across the
+// configured relays by the entity's pubkey (#p). The panel has no relay
+// access, so it routes the query through the background SW (the same
+// `xray:relay:query` path the reader's per-URL "others' claims" uses).
+// ------------------------------------------------------------------
+
+/** Configured read relays, mirroring the reader's `getConfiguredRelays`. */
+function getQueryRelays() {
+    const FALLBACK = ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.nostr.band'];
+    return new Promise((resolve) => {
+        try {
+            chrome.storage.local.get(['preferences'], (res) => {
+                const raw = res && res.preferences;
+                let prefs = {};
+                try { prefs = typeof raw === 'string' ? JSON.parse(raw) : (raw || {}); }
+                catch (_) { prefs = {}; }
+                const relays = Array.isArray(prefs.default_relays) && prefs.default_relays.length > 0
+                    ? prefs.default_relays
+                    : FALLBACK;
+                resolve(relays);
+            });
+        } catch (_) { resolve(FALLBACK); }
+    });
+}
+
+async function loadNetworkClaims(entity) {
+    const host = $('#xr-network-claims');
+    if (!host) return;
+    const pubkey = entity.keypair && entity.keypair.pubkey;
+    if (!pubkey) {
+        host.innerHTML = `<div class="xr-side__canonical-none">This entity has no keypair, so the network can't reference it yet.</div>`;
+        return;
+    }
+    const relays = await getQueryRelays();
+    if (!relays.length) {
+        host.innerHTML = `<div class="xr-side__canonical-none">No relays configured — add some in Settings → Relays.</div>`;
+        return;
+    }
+    host.innerHTML = `<div class="xr-side__net-loading">Querying ${relays.length} relay${relays.length === 1 ? '' : 's'}…</div>`;
+    chrome.runtime.sendMessage({
+        type: 'xray:relay:query',
+        relays,
+        filter: { kinds: [30040], '#p': [pubkey], limit: 200 },
+        timeoutMs: 6000
+    }, (resp) => {
+        if (!resp || !resp.ok) {
+            host.innerHTML = `<div class="xr-side__canonical-none">Query failed: ${escapeHtml((resp && resp.error) || 'no response from service worker')}</div>`;
+            return;
+        }
+        host.innerHTML = renderNetworkClaims(resp.events, resp.byRelay);
+    });
+}
+
+/** Group kind-30040 events by author pubkey and render claim cards. */
+function renderNetworkClaims(events, byRelay) {
+    const relayCount = Object.keys(byRelay || {}).length;
+    const list = Array.isArray(events) ? events : [];
+    if (list.length === 0) {
+        return `<div class="xr-side__canonical-none">No claims about this entity found on ${relayCount} relay${relayCount === 1 ? '' : 's'} yet.</div>`;
+    }
+    const byAuthor = new Map();
+    for (const ev of list) {
+        if (!byAuthor.has(ev.pubkey)) byAuthor.set(ev.pubkey, []);
+        byAuthor.get(ev.pubkey).push(ev);
+    }
+    const summary = `<div class="xr-side__net-summary">${list.length} claim${list.length === 1 ? '' : 's'} from ${byAuthor.size} author${byAuthor.size === 1 ? '' : 's'} · ${relayCount} relay${relayCount === 1 ? '' : 's'}</div>`;
+    const cards = [...byAuthor.entries()].map(([pubkey, evs]) => {
+        evs.sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+        const rows = evs.map((ev) => renderNetworkClaimRow(parseClaimEvent(ev))).join('');
+        return `
+          <section class="xr-side__net-author">
+            <header class="xr-side__net-author-head">👤 ${escapeHtml(pubkey.slice(0, 12))}… <span class="xr-side__net-author-count">${evs.length}</span></header>
+            ${rows}
+          </section>`;
+    }).join('');
+    return summary + cards;
+}
+
+function renderNetworkClaimRow(c) {
+    const when = c.created_at ? fmtRelative(c.created_at) : '';
+    const key = c.isKey ? `<span class="xr-side__net-key">⭐ key</span>` : '';
+    const source = c.source ? `<div class="xr-side__net-source">Per <em>${escapeHtml(c.source)}</em></div>` : '';
+    const src = c.url
+        ? `<a class="xr-side__net-src" href="${escapeHtml(c.url)}" target="_blank" rel="noopener">${escapeHtml(c.title || c.url)}</a>`
+        : '';
+    return `
+      <article class="xr-side__net-claim">
+        <div class="xr-side__net-claim-top">${key}<span class="xr-side__net-when">${escapeHtml(when)}</span></div>
+        <div class="xr-side__net-claim-text">${escapeHtml(c.text)}</div>
+        ${source}
+        ${src}
+      </article>`;
 }
 
 /**

--- a/tests/claim-model.test.mjs
+++ b/tests/claim-model.test.mjs
@@ -28,7 +28,7 @@ globalThis.chrome = {
     }
 };
 
-const { ClaimModel, generateClaimId } = await import('../src/shared/claim-model.js');
+const { ClaimModel, generateClaimId, parseClaimEvent } = await import('../src/shared/claim-model.js');
 
 function resetState() { _stateStore.clear(); }
 
@@ -148,6 +148,45 @@ test('claim: legacy records normalize to thin fields on read', async () => {
     assert.deepEqual(got.about, [ENT_1, ENT_2], 'about backfilled from subject ∪ object');
     assert.equal(got.is_key, true, 'is_key backfilled from is_crux');
     assert.equal(got.source, ENT_1, 'source backfilled from claimant');
+});
+
+test('parseClaimEvent: reads the thin (10.2) vocabulary', () => {
+    const ev = {
+        id: 'evid', pubkey: 'a'.repeat(64), created_at: 100,
+        content: 'Jane runs Acme.',
+        tags: [
+            ['d', 'claim_1'], ['r', 'https://x.test/a'], ['title', 'A Title'],
+            ['p', 'b'.repeat(64), '', 'about'], ['entity', 'Jane Roe', 'about'],
+            ['entity', 'Acme Corp', 'about'],
+            ['source', 'Jane Roe'], ['key', 'true']
+        ]
+    };
+    const c = parseClaimEvent(ev);
+    assert.equal(c.id, 'claim_1');
+    assert.equal(c.text, 'Jane runs Acme.');
+    assert.deepEqual(c.about, ['Jane Roe', 'Acme Corp']);
+    assert.equal(c.source, 'Jane Roe');
+    assert.equal(c.isKey, true);
+    assert.equal(c.url, 'https://x.test/a');
+    assert.equal(c.title, 'A Title');
+    assert.equal(c.pubkey, 'a'.repeat(64));
+});
+
+test('parseClaimEvent: reads the legacy vocabulary', () => {
+    const ev = {
+        pubkey: 'c'.repeat(64), created_at: 50,
+        content: 'ignored body',
+        tags: [
+            ['claim-text', 'Old-style claim.'], ['claim-type', 'factual'],
+            ['subject', 'Old Subject'], ['object', 'Old Object'],
+            ['claimant', 'A Reporter'], ['crux', 'true']
+        ]
+    };
+    const c = parseClaimEvent(ev);
+    assert.equal(c.text, 'Old-style claim.', 'prefers claim-text tag over content');
+    assert.deepEqual(c.about, ['Old Subject', 'Old Object'], 'about backfilled from subject ∪ object');
+    assert.equal(c.source, 'A Reporter', 'source from claimant');
+    assert.equal(c.isKey, true, 'isKey from crux');
 });
 
 test('claim: delete + markPublished', async () => {


### PR DESCRIPTION
The payoff slice of the claim redesign ([design](docs/CLAIMS_REDESIGN.md)): **"what the network says about entity P"**, cross-source.

## What changed
- The side-panel entity browser's **detail view** gains a **"Claims about this entity"** section with a **Load from relays** button. It queries `kind 30040` across your configured relays by the entity's pubkey — `{ kinds:[30040], "#p":[P] }` — and renders the results grouped by author, each claim showing its ⭐ key flag, source, date, and a link back to the article it came from.
- **Why this falls out for free:** the 10.2 wire format `p`-tags about-entities with the *same entity pubkeys X-Ray uses everywhere*, so this aggregation is one relay filter — no extra index.
- **Placement** (per your call): side-panel entity detail, *not* the reader. This is the per-**entity** axis (across all articles); the reader's existing "Others' claims" is the per-**article** axis (`#r`).
- The panel has no relay access of its own, so the query routes through the background SW's `xray:relay:query` (the reader's path); relays come from `preferences.default_relays`.
- New shared **`parseClaimEvent(event)`** in `claim-model.js` — pure, **dual-vocabulary** (thin 10.2 + legacy), so pre-redesign `30040`s render too. Unit-tested both ways.
- Query is **on-demand** (button), so browsing entities doesn't fire a relay round-trip per click.

## Verification
- `npm run build` clean; **526/526 tests** (two new `parseClaimEvent` cases: thin + legacy vocab).
- **Wants a manual smoke** (no browser here): open the side panel → pick an entity that you've published claims about → **Load from relays** → confirm the claims show grouped by author with the article link; pick an entity with nothing on relays → confirm the empty state.

## Next
10.5 (last) — metadata reframe: fact-checks/ratings as responses-to-claims, reconcile annotations onto the shared anchor, retire `30043`. It's the biggest/most exploratory slice — good one to scope together first.

https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3969HLtgiZu725qqtdr65)_