### PR TITLE
Phase 11.1 — Taxonomy + assessment model + cross-source claim links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Assessment data layer** (Phase 11.1; local-only, no UI yet — see
+  `docs/ASSESSMENTS_DESIGN.md`). New `assessment-model.js` +
+  `assessment-taxonomy.js`: register a personal judgment on any claim —
+  yours or a foreign one referenced by its `30040:<pubkey>:<d>` coordinate —
+  with a graded stance (−2..+2), typed issue labels (`misleading`,
+  `fallacy/strawman`, `flip-flop`, … under the `xray/assessment` namespace,
+  each optionally anchored + noted), a markdown rationale, and a
+  `suggested_by` provenance field (`'user' | 'llm:<model>'`). One assessment
+  per claim, idempotent across the publish boundary via canonical claim refs
+  (`claim-ref.js`). Records live under the new `claim_assessments` storage
+  key; the kind-30054 wire mapping lands in slice 11.2 and publishing stays
+  flag-gated.
+- **`case` entity type** (🗂️) for modeling a real-world story under
+  assessment ("John Dehlin excommunication") — the side-panel entity detail
+  becomes the case dashboard in later Phase 11 slices.
+
 - **"Claims about this entity" — cross-source aggregation** (Phase 10.4). The
   side-panel entity browser's detail view gains a **Load from relays** action
   that queries `kind 30040` across your configured relays by the entity's
@@ -27,6 +43,27 @@ Sections per release: **Added** (new features), **Changed**
   show too.
 
 ### Changed
+
+- **Claim links are cross-source and re-typed** (Phase 11.1). The link
+  vocabulary is now `contradicts / supports / updates / duplicates`
+  (`contextualizes` is read-only legacy: old records still render; new links
+  can't use it). Endpoints accept local claim ids **or** foreign claim
+  coordinates, and symmetric relationships (`contradicts`, `duplicates`)
+  derive one id regardless of creation direction. Links now carry
+  `suggested_by` + per-endpoint `{url, text}` snapshots.
+
+- **Evidence-link (kind `30043`) publishing is switched off** (Phase 11.1;
+  **behavior change**). The reader's batch publish no longer emits kind-30043
+  events — the kind is retired per the agreed Phase 11 design; cross-source
+  links will publish as the new kind `30055` behind the `assessmentPublishing`
+  flag in a later slice. Local link records are unaffected, and
+  already-published 30043s stay on relays (NIP-09 cleanup remains a later
+  phase).
+
+- **Claims record their publishing pubkey** (`ClaimModel.markPublished`
+  gains `publishedPubkey` + an append-only `publishedPubkeys` history) so a
+  published claim's addressable coordinate stays recoverable even if the
+  signing identity later changes.
 
 - **Claims record a precise text-anchor** (Phase 10.3). When you mark a
   claim, X-Ray now captures a W3C-Web-Annotation selector (exact text +

--- a/docs/ASSESSMENTS_DESIGN.md
+++ b/docs/ASSESSMENTS_DESIGN.md
@@ -155,10 +155,13 @@ source for model validation, UI chips, and the NIP draft), namespace
 - **Rhetorical:** `loaded-language`, `unfalsifiable`, `ambiguous`,
   `euphemism`
 - **Provenance:** `undisclosed-interest`
-- **Escape hatch:** any other value is accepted as a custom label, stored
-  and published verbatim under the same namespace, rendered with a "custom"
-  affordance in the UI. (Standard labels aggregate; custom ones still ride
-  the same rails.)
+- **Escape hatch:** any other value matching the label token grammar —
+  lowercase `a-z0-9-`, at most one `family/value` namespace segment,
+  ≤ 64 chars — is accepted as a custom label, stored and published verbatim
+  under the same namespace, rendered with a "custom" affordance in the UI.
+  (Standard labels aggregate; custom ones still ride the same rails. The
+  grammar keeps custom values wire-safe and aggregatable; 11.3's input
+  normalizes case/whitespace rather than rejecting.)
 
 The set is grouped + exported flat; the exhaustive-enum test idiom
 (`deepEqual(.slice().sort())`, as for `EVIDENCE_RELATIONSHIPS`) pins it.
@@ -426,7 +429,8 @@ tags in 30078 sync and 32125 relationship events), so deferring the type
 would mean the acceptance-case entities publish as `thing` and need a type
 migration + republish later — exactly the wire-vocabulary churn the compat
 rule exists to avoid. Adding it now is small and contained (`ENTITY_TYPES`,
-icon, tag map, the `event-builder.js` kind-0 type ternary, sidepanel filter
+icon, tag map, the `event-builder.js` `buildArticleEvent` (kind-30023)
+entity-tag ternaries, sidepanel filter
 chip) and gives the type filter, a cases-only "Export case" affordance, and
 a legible demo; entity-sync ingest already tolerates unknown type strings
 on older installs.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,56 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-09 — Phase 11.1: assessment data layer; legacy 30043 publish retired
+
+**Tags:** design, wire-format
+
+First Phase 11 slice (see `docs/ASSESSMENTS_DESIGN.md`, agreed same day).
+Model + taxonomy + tests only — no UI, no new wire kinds yet.
+
+**What landed:** `assessment-taxonomy.js` (label vocabulary under
+`xray/assessment`, stance −2..+2, relationship directionality),
+`claim-ref.js` (canonical claim refs: local id for ours, coordinate for
+foreign, with the collapse rule), `assessment-model.js`
+(one-assessment-per-claim under the `claim_assessments` key),
+evidence-linker repurposed cross-source (coordinate endpoints, new
+`contradicts/supports/updates/duplicates` enum, sorted endpoints for
+symmetric relationships, endpoint snapshots, `suggested_by`), the `case`
+entity type, and `ClaimModel.markPublished` recording `publishedPubkey`.
+
+**Behavior change (the wire-format-rule callout):** the reader's batch
+publish no longer emits kind-30043 evidence-link events —
+`resolveEvidenceLinksToPublish` returns `[]`. Rationale: the agreed design
+retires 30043 (its local-id tag vocabulary can't survive a public NIP, and
+a re-keyed d could never replace already-published events); gating the
+legacy path off *before* the model accepts coordinate refs guarantees no
+hybrid-vocabulary event can ever publish (a coordinate inside a
+`source-claim` tag would be malformed under both vocabularies). Local link
+records keep accumulating; the cross-source kind-30055 path arrives in 11.2
+and publishes behind `assessmentPublishing`. Already-published 30043s stay
+on relays per the standing NIP-09 posture.
+
+**Subtle invariant worth remembering:** assessment/link identity hashes the
+*canonical* ref, and `canonicalizeClaimRef` only collapses a coordinate to
+a local id when the coordinate's pubkey matches one of the claim's recorded
+publishing pubkeys (`publishedPubkeys`, append-only — a re-keyed republish
+must not orphan coordinates minted under the old identity). The d-tag alone
+is insufficient because claim ids hash (url|text), so two users capturing
+the same quote derive the same d under different pubkeys.
+
+**Drift-robust matching (review-forced):** canonicality is *time-dependent* —
+a stored coordinate becomes collapsible only once its claim records a
+publishedPubkey (e.g. claims published pre-11.1 gain it on their next
+republish). Matching only the query side would orphan such records under
+BOTH representations and let `create()` mint duplicates. So every matcher
+(`getByClaimRef`, `getForClaim`, `deleteForClaim`) canonicalizes the stored
+side too (via a one-storage-read snapshot canonicalizer,
+`makeClaimRefCanonicalizer`), and both `create()`s fall back to match-based
+dedupe when the id lookup misses. Pinned by the "drift" tests in
+`tests/assessment-model.test.mjs` / `tests/evidence-linker.test.mjs`.
+
+---
+
 ## 2026-06-09 — Phase 11 design: assessments & contradictions; 10.5 superseded
 
 **Tags:** design

--- a/src/reader/claim-extractor.js
+++ b/src/reader/claim-extractor.js
@@ -470,7 +470,7 @@ function buildLinkModalHtml(sourceClaim, candidates) {
           </div>
 
           <label class="xr-claim-modal__field">
-            <span class="xr-claim-modal__label">Note <em>(optional — becomes the kind-30043 content)</em></span>
+            <span class="xr-claim-modal__label">Note <em>(optional — stored with the link)</em></span>
             <textarea class="xr-link-modal__note" rows="2"
                       placeholder="Why does this link hold?"></textarea>
           </label>

--- a/src/reader/entity-tagger.js
+++ b/src/reader/entity-tagger.js
@@ -143,6 +143,8 @@ function openPopover({ x, y, initialText }) {
                 title="Place">${ENTITY_ICONS.place}</button>
         <button type="button" class="xr-tagger-popover__type-btn" data-type="thing"
                 title="Thing">${ENTITY_ICONS.thing}</button>
+        <button type="button" class="xr-tagger-popover__type-btn" data-type="case"
+                title="Case">${ENTITY_ICONS.case}</button>
       </div>
       <div class="xr-tagger-popover__handoff">
         <button type="button" class="xr-tagger-popover__claim-btn" title="Open the claim form with this selection">

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1391,9 +1391,10 @@ async function publish() {
     // published + unchanged claims).
     const relationshipsToPublish = await resolveRelationshipsToPublish(claimsToPublish, state.article.url);
 
-    // kind-30043 evidence links — any link touching two claims on this
-    // article whose gate is open.
-    const linksToPublish = await resolveEvidenceLinksToPublish(allArticleClaims);
+    // Claim links: the legacy kind-30043 publish path is retired
+    // (Phase 11.1) — this always resolves to [] until the kind-30055
+    // path lands behind the assessmentPublishing flag.
+    const linksToPublish = await resolveEvidenceLinksToPublish();
 
     const totalEvents = 1 + commentList.length + entitiesToPublish.length
                           + claimsToPublish.length + relationshipsToPublish.length
@@ -1659,7 +1660,9 @@ async function publish() {
                         // stable pointer. Re-fetch signed id from results
                         // array if relay echoed it.
                         const signedId = resp.signedEvent?.id || null;
-                        try { await ClaimModel.markPublished(claim.id, signedId); }
+                        // Record WHO signed too (Phase 11.1) — the claim's
+                        // addressable coordinate needs the publishing pubkey.
+                        try { await ClaimModel.markPublished(claim.id, signedId, userPubkey); }
                         catch (_) { /* best-effort */ }
                     } else {
                         claimResults.fail++;
@@ -1868,26 +1871,16 @@ function collectClaimEntityIds(claims) {
 }
 
 /**
- * Evidence links whose kind-30043 event still needs to publish.
- * Pulled from `EvidenceLinker.getAll()` filtered to links where both
- * endpoints are claims on the current article — cross-article links
- * are a future feature (C4 scope note: today we only create links
- * between claims on the same article via the modal UI).
- *
- * Same `updated > publishedAt` gate so edits to a link's note or
- * re-creations re-emit.
+ * Phase 11.1: the legacy kind-30043 evidence-link publish path is
+ * RETIRED (docs/ASSESSMENTS_DESIGN.md — "30043 retires"). Link records
+ * stay local-only until the cross-source kind-30055 publish path lands
+ * behind the `assessmentPublishing` flag (Phase 11 publish slice);
+ * already-published 30043s stay on relays per the standing NIP-09
+ * posture. Returning [] keeps the batch flow untouched — every count
+ * downstream guards on `> 0`.
  */
-async function resolveEvidenceLinksToPublish(claimsForThisArticle) {
-    if (!Array.isArray(claimsForThisArticle) || claimsForThisArticle.length === 0) return [];
-    const claimIds = new Set(claimsForThisArticle.map((c) => c.id));
-    const all = await EvidenceLinker.getAll();
-    const out = [];
-    for (const link of Object.values(all)) {
-        if (!claimIds.has(link.source_claim_id) || !claimIds.has(link.target_claim_id)) continue;
-        if (link.publishedAt && link.updated <= link.publishedAt) continue;
-        out.push(link);
-    }
-    return out;
+async function resolveEvidenceLinksToPublish() {
+    return [];
 }
 
 /**

--- a/src/shared/assessment-model.js
+++ b/src/shared/assessment-model.js
@@ -1,0 +1,324 @@
+// Assessment model — Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
+//
+// A personal judgment on a single claim — ours or a foreign one. Two
+// orthogonal axes:
+//
+//   - stance    — graded agree↔disagree, integer -2..+2, or null for
+//                 a label-only assessment
+//   - labels[]  — typed issues ({ label, anchor?, note?, suggested_by }),
+//                 at most one entry per label value (keeps the wire
+//                 round-trip lossless)
+//
+// plus a free-text markdown `rationale` and a `suggested_by`
+// provenance field ('user' | 'llm:<model>') — the manual-now /
+// LLM-ready seam: an LLM-suggestion pass can call this same API later.
+//
+// One assessment per claim: the id hashes the CANONICAL claim ref
+// (see claim-ref.js), so create() is idempotent across the publish
+// boundary — a claim assessed pre-publish (keyed by local id) and
+// re-encountered post-publish by coordinate keys identically.
+//
+// `claim_ref` carries url/text snapshots so assessments of foreign
+// claims render and export without a relay round-trip. The url is
+// stored normalized (metadata/url-normalizer) per the design's URL
+// rule.
+//
+// Storage: Storage.get('claim_assessments', {}) keyed by assessment
+// id — same single-key id→record map pattern as 'article_claims'.
+// Wire mapping (kind 30054) lands in slice 11.2; publishing is gated
+// behind the `assessmentPublishing` flag in a later slice.
+
+import { Storage } from './storage.js';
+import { Crypto } from './crypto.js';
+import { Utils } from './utils.js';
+import { ClaimModel } from './claim-model.js';
+import { normalize as normalizeUrl } from './metadata/url-normalizer.js';
+import {
+    isValidLabel, isValidStance, isValidSuggestedBy
+} from './assessment-taxonomy.js';
+import {
+    isLocalClaimId, parseClaimCoord, canonicalizeClaimRef,
+    makeClaimRefCanonicalizer
+} from './claim-ref.js';
+
+// ------------------------------------------------------------------
+// ID derivation
+// ------------------------------------------------------------------
+
+/**
+ * Deterministic id from the canonical claim ref. NOTE: this is the
+ * LOCAL id; the kind-30054 wire d-tag hashes the claim *coordinate*
+ * and is derived at publish time (slice 11.2) — local ids never hit
+ * the wire.
+ */
+export async function generateAssessmentId(canonicalRef) {
+    const hash = await Crypto.sha256(String(canonicalRef || ''));
+    return `assess_${hash.slice(0, 16)}`;
+}
+
+// ------------------------------------------------------------------
+// Validation
+// ------------------------------------------------------------------
+
+function assertValidStanceOrNull(stance) {
+    if (stance === null || stance === undefined) return null;
+    if (!isValidStance(stance)) {
+        throw new Error(`Invalid stance: ${stance} (expected integer -2..2 or null)`);
+    }
+    return stance;
+}
+
+function assertValidSuggestedBy(value, label) {
+    const v = value === undefined || value === null ? 'user' : value;
+    if (!isValidSuggestedBy(v)) {
+        throw new Error(`Invalid ${label}: ${v} (expected 'user' or 'llm:<model>')`);
+    }
+    return v;
+}
+
+function cleanLabels(labels) {
+    if (labels === undefined || labels === null) return [];
+    if (!Array.isArray(labels)) throw new Error('labels must be an array');
+    const seen = new Set();
+    const out = [];
+    for (const entry of labels) {
+        const rec = typeof entry === 'string' ? { label: entry } : (entry || {});
+        if (!isValidLabel(rec.label)) {
+            throw new Error(`Invalid label: ${rec.label}`);
+        }
+        if (seen.has(rec.label)) {
+            throw new Error(`Duplicate label: ${rec.label} (one entry per label value)`);
+        }
+        seen.add(rec.label);
+        out.push({
+            label:        rec.label,
+            anchor:       rec.anchor || null,
+            note:         rec.note || '',
+            suggested_by: assertValidSuggestedBy(rec.suggested_by, 'label suggested_by')
+        });
+    }
+    return out;
+}
+
+function assertHasJudgment(stance, labels) {
+    if (stance === null && labels.length === 0) {
+        throw new Error('Assessment needs a stance or at least one label');
+    }
+}
+
+/**
+ * Resolve the caller's claim_ref into the stored shape. For local
+ * claim ids the url/text snapshots come from the claim registry; for
+ * coordinates the caller must supply them (it always has the event in
+ * hand). Returns `{ canonicalRef, claim_ref }`.
+ */
+async function resolveClaimRef(input) {
+    const given = input || {};
+    const raw = given.claim_id || given.coord;
+    const canonicalRef = await canonicalizeClaimRef(raw, 'claim_ref');
+
+    if (isLocalClaimId(canonicalRef)) {
+        const claim = await ClaimModel.get(canonicalRef);
+        if (!claim) throw new Error(`Claim not found: ${canonicalRef}`);
+        return {
+            canonicalRef,
+            claim_ref: {
+                claim_id:      canonicalRef,
+                coord:         claim.publishedPubkey
+                                   ? `30040:${claim.publishedPubkey}:${canonicalRef}`
+                                   : null,
+                event_id:      given.event_id || null,
+                url:           normalizeUrl(claim.source_url),
+                text:          claim.text,
+                author_pubkey: claim.publishedPubkey || null
+            }
+        };
+    }
+
+    // Foreign claim — coordinate form. Snapshots required.
+    const coord = parseClaimCoord(canonicalRef);
+    const url  = String(given.url || '').trim();
+    const text = String(given.text || '').trim();
+    if (!url)  throw new Error('claim_ref.url is required for foreign claims');
+    if (!text) throw new Error('claim_ref.text is required for foreign claims');
+    return {
+        canonicalRef,
+        claim_ref: {
+            claim_id:      null,
+            coord:         canonicalRef,
+            event_id:      given.event_id || null,
+            url:           normalizeUrl(url),
+            text,
+            author_pubkey: coord.pubkey
+        }
+    };
+}
+
+/**
+ * The canonical key a stored record answers to. Canonicality is
+ * time-dependent (a stored coordinate becomes collapsible once its
+ * claim records a publishedPubkey), so the stored ref is run through
+ * the supplied canonicalizer rather than trusted verbatim — otherwise
+ * a drifted record would match NEITHER representation.
+ */
+function recordCanonicalRef(record, canon) {
+    const raw = (record && record.claim_ref &&
+                 (record.claim_ref.claim_id || record.claim_ref.coord)) || '';
+    return raw ? canon(raw) : '';
+}
+
+/** Match-based lookup over a storage snapshot (drift-robust). */
+async function findByCanonicalRef(all, canonicalRef) {
+    const canon = await makeClaimRefCanonicalizer();
+    const canonical = canon(canonicalRef);
+    for (const record of Object.values(all)) {
+        if (recordCanonicalRef(record, canon) === canonical) return record;
+    }
+    return null;
+}
+
+// ------------------------------------------------------------------
+// CRUD
+// ------------------------------------------------------------------
+
+const STORAGE_KEY = 'claim_assessments';
+
+export const AssessmentModel = {
+    get: async (id) => {
+        if (!id) return null;
+        const all = await Storage.get(STORAGE_KEY, {});
+        return all[id] || null;
+    },
+
+    getAll: async () => {
+        return await Storage.get(STORAGE_KEY, {});
+    },
+
+    /**
+     * The assessment for a claim, looked up by either representation
+     * (local id or coordinate) — BOTH the query ref and the stored
+     * refs are canonicalized before matching. Returns null when the
+     * claim is unassessed.
+     */
+    getByClaimRef: async (ref) => {
+        const canonical = await canonicalizeClaimRef(ref, 'claim ref');
+        const all = await Storage.get(STORAGE_KEY, {});
+        return await findByCanonicalRef(all, canonical);
+    },
+
+    /**
+     * Create an assessment. Required: `claim_ref` with one of
+     * `claim_id` (ours) or `coord` (foreign; plus url/text snapshots),
+     * and at least one of `stance` / `labels`. Idempotent on the
+     * canonical claim ref — one assessment per claim.
+     */
+    create: async (fields) => {
+        const given = fields || {};
+        const { canonicalRef, claim_ref } = await resolveClaimRef(given.claim_ref);
+
+        const id = await generateAssessmentId(canonicalRef);
+        const all = await Storage.get(STORAGE_KEY, {});
+        if (all[id]) return all[id];   // idempotent
+        // Match-based dedupe too: a record stored under a ref whose
+        // canonicality has since drifted derives a different id for
+        // the same logical claim — it must still win.
+        const drifted = await findByCanonicalRef(all, canonicalRef);
+        if (drifted) return drifted;
+
+        const stance = assertValidStanceOrNull(given.stance);
+        const labels = cleanLabels(given.labels);
+        assertHasJudgment(stance, labels);
+
+        const now = Math.floor(Date.now() / 1000);
+        const record = {
+            id,
+            claim_ref,
+            stance,
+            rationale:        String(given.rationale || ''),
+            labels,
+            suggested_by:     assertValidSuggestedBy(given.suggested_by, 'suggested_by'),
+            created:          now,
+            updated:          now,
+            publishedAt:      null,
+            publishedEventId: null
+        };
+
+        all[id] = record;
+        await Storage.set(STORAGE_KEY, all);
+        Utils.log('Created assessment:', id, canonicalRef);
+        return record;
+    },
+
+    /**
+     * Patch an assessment. `claim_ref` is IMMUTABLE (it derives the
+     * id) — use `backfillCoord` for the publish-time coordinate.
+     * Patchable: stance, labels, rationale, suggested_by. The
+     * stance-or-labels invariant is re-checked after the patch.
+     */
+    update: async (id, updates) => {
+        const all = await Storage.get(STORAGE_KEY, {});
+        const record = all[id];
+        if (!record) throw new Error(`Assessment not found: ${id}`);
+
+        const patched = { ...record };
+        if ('stance' in updates)       patched.stance = assertValidStanceOrNull(updates.stance);
+        if ('labels' in updates)       patched.labels = cleanLabels(updates.labels);
+        if ('rationale' in updates)    patched.rationale = String(updates.rationale || '');
+        if ('suggested_by' in updates) {
+            patched.suggested_by = assertValidSuggestedBy(updates.suggested_by, 'suggested_by');
+        }
+        assertHasJudgment(patched.stance, patched.labels);
+
+        patched.updated = Math.floor(Date.now() / 1000);
+        all[id] = patched;
+        await Storage.set(STORAGE_KEY, all);
+        return patched;
+    },
+
+    /**
+     * Record the claim's coordinate once it's known (our claim
+     * published). Enrichment, not an edit: does NOT bump `updated`.
+     * The coordinate's d must match the record's local claim id.
+     */
+    backfillCoord: async (id, coord) => {
+        const all = await Storage.get(STORAGE_KEY, {});
+        const record = all[id];
+        if (!record) return null;
+        const parsed = parseClaimCoord(coord);
+        if (!parsed) throw new Error(`Invalid coordinate: ${coord}`);
+        if (!record.claim_ref.claim_id || parsed.d !== record.claim_ref.claim_id) {
+            throw new Error('Coordinate does not match the assessed claim');
+        }
+        record.claim_ref = {
+            ...record.claim_ref,
+            coord:         coord,
+            author_pubkey: parsed.pubkey
+        };
+        all[id] = record;
+        await Storage.set(STORAGE_KEY, all);
+        return record;
+    },
+
+    delete: async (id) => {
+        const all = await Storage.get(STORAGE_KEY, {});
+        if (!all[id]) return false;
+        delete all[id];
+        await Storage.set(STORAGE_KEY, all);
+        return true;
+    },
+
+    /**
+     * Record a successful kind-30054 publish. Does NOT bump `updated`,
+     * so edits after a publish correctly re-emit next time.
+     */
+    markPublished: async (id, eventId) => {
+        const all = await Storage.get(STORAGE_KEY, {});
+        const record = all[id];
+        if (!record) return null;
+        record.publishedAt = Math.floor(Date.now() / 1000);
+        if (eventId) record.publishedEventId = eventId;
+        all[id] = record;
+        await Storage.set(STORAGE_KEY, all);
+        return record;
+    }
+};

--- a/src/shared/assessment-taxonomy.js
+++ b/src/shared/assessment-taxonomy.js
@@ -1,0 +1,113 @@
+// Assessment taxonomy — Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
+//
+// Single source of truth for the assessment label vocabulary, the
+// graded stance scale, and the claim-relationship directionality
+// rules. Model validation, UI chips, the wire builders (slice 11.2),
+// and the NIP draft all read from here — extending the vocabulary
+// means editing this file (and the exhaustive-enum tests that pin it).
+
+// NIP-32 namespace the labels publish under (`['L', <ns>]` +
+// `['l', <label>, <ns>]` on kind 30054, mirrored to kind 1985).
+export const ASSESSMENT_LABEL_NAMESPACE = 'xray/assessment';
+
+/**
+ * The standardized labels, grouped for the picker UI. Values are the
+ * exact strings that hit the wire — lowercase, hyphenated, with the
+ * fallacy family namespaced by a `fallacy/` prefix.
+ */
+export const ASSESSMENT_LABEL_GROUPS = Object.freeze({
+    factual: Object.freeze([
+        'false', 'unsupported', 'misleading', 'cherry-picked',
+        'missing-context', 'outdated'
+    ]),
+    consistency: Object.freeze([
+        'contradicts-prior-statement', 'flip-flop', 'moved-goalposts'
+    ]),
+    fallacy: Object.freeze([
+        'fallacy/strawman', 'fallacy/ad-hominem', 'fallacy/false-dilemma',
+        'fallacy/whataboutism', 'fallacy/circular', 'fallacy/slippery-slope',
+        'fallacy/appeal-to-authority', 'fallacy/appeal-to-consequences'
+    ]),
+    rhetorical: Object.freeze([
+        'loaded-language', 'unfalsifiable', 'ambiguous', 'euphemism'
+    ]),
+    provenance: Object.freeze([
+        'undisclosed-interest'
+    ])
+});
+
+/** Flat list of every standard label. */
+export const ASSESSMENT_LABELS = Object.freeze(
+    Object.values(ASSESSMENT_LABEL_GROUPS).flat()
+);
+
+export function isStandardLabel(label) {
+    return ASSESSMENT_LABELS.includes(label);
+}
+
+// Custom labels (the freeform escape hatch) ride the same rails as
+// standard ones: a lowercase token, optionally one `family/value`
+// namespace segment, ≤ 64 chars. Anything that passes here is stored
+// and published verbatim under the same namespace; the UI renders
+// non-standard values with a "custom" affordance.
+const LABEL_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)?$/;
+
+export function isValidLabel(label) {
+    return typeof label === 'string'
+        && label.length > 0
+        && label.length <= 64
+        && LABEL_RE.test(label);
+}
+
+// ------------------------------------------------------------------
+// Stance — graded agree↔disagree, discrete -2..+2 (or null when an
+// assessment is label-only).
+// ------------------------------------------------------------------
+
+export const STANCE_VALUES = Object.freeze([-2, -1, 0, 1, 2]);
+
+export const STANCE_LABELS = Object.freeze({
+    '-2': 'Strongly disagree',
+    '-1': 'Disagree',
+    '0':  'Unsure',
+    '1':  'Agree',
+    '2':  'Strongly agree'
+});
+
+export function isValidStance(value) {
+    return Number.isInteger(value) && value >= -2 && value <= 2;
+}
+
+// ------------------------------------------------------------------
+// Claim-relationship vocabulary (consumed by evidence-linker.js).
+// ------------------------------------------------------------------
+
+/**
+ * The Phase 11 typed-link vocabulary. `contradicts` and `duplicates`
+ * are SYMMETRIC — A↔B and B↔A state the same fact, so link ids sort
+ * the two endpoints before hashing and renderers treat the pair as
+ * direction-free. `supports` and `updates` are directional
+ * (source → target). The legacy `contextualizes` is read-only: old
+ * records still render, but new links can't use it.
+ */
+export const CLAIM_RELATIONSHIPS = Object.freeze([
+    'contradicts', 'supports', 'updates', 'duplicates'
+]);
+
+export const SYMMETRIC_RELATIONSHIPS = Object.freeze([
+    'contradicts', 'duplicates'
+]);
+
+export function isSymmetricRelationship(relationship) {
+    return SYMMETRIC_RELATIONSHIPS.includes(relationship);
+}
+
+// ------------------------------------------------------------------
+// Provenance — the manual-now / LLM-ready seam.
+// ------------------------------------------------------------------
+
+/** `suggested_by` values: 'user' or 'llm:<model>' (non-blank model). */
+export function isValidSuggestedBy(value) {
+    return value === 'user'
+        || (typeof value === 'string' && /^llm:\S.*$/.test(value));
+}

--- a/src/shared/claim-model.js
+++ b/src/shared/claim-model.js
@@ -254,13 +254,28 @@ export const ClaimModel = {
     /**
      * Record a successful kind-30040 publish. Does NOT bump `updated`,
      * so edits after a publish correctly re-emit next time.
+     *
+     * `publishedPubkey` (Phase 11.1) records WHO signed: the claim's
+     * addressable coordinate is `30040:<publishedPubkey>:<id>`, and
+     * without it the coordinate is unrecoverable if the signing
+     * identity later changes. claim-ref.js needs it to collapse
+     * coordinates of our own claims to their local ids. The full
+     * history is kept append-only in `publishedPubkeys` — coordinates
+     * minted under an OLD identity are live addressable events on
+     * relays and must keep collapsing after a re-keyed republish.
      */
-    markPublished: async (id, eventId) => {
+    markPublished: async (id, eventId, publishedPubkey) => {
         const all = await Storage.get('article_claims', {});
         const record = all[id];
         if (!record) return null;
         record.publishedAt = Math.floor(Date.now() / 1000);
         if (eventId) record.publishedEventId = eventId;
+        if (publishedPubkey) {
+            record.publishedPubkey = publishedPubkey;
+            const seen = Array.isArray(record.publishedPubkeys) ? record.publishedPubkeys : [];
+            if (!seen.includes(publishedPubkey)) seen.push(publishedPubkey);
+            record.publishedPubkeys = seen;
+        }
         all[id] = record;
         await Storage.set('article_claims', all);
         return normalizeClaim(record);

--- a/src/shared/claim-ref.js
+++ b/src/shared/claim-ref.js
@@ -1,0 +1,131 @@
+// Claim references — Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
+//
+// Everything in the assessment layer points at claims. A claim is
+// referenced in one of two forms:
+//
+//   - local claim id    `claim_<16 hex>`               — claims we authored
+//   - event coordinate  `30040:<author-pubkey>:<d>`    — claims on the wire
+//
+// The CANONICAL form is the local id for our own claims and the
+// coordinate for foreign ones. `canonicalizeClaimRef` collapses a
+// coordinate that points at one of our own *published* claims down to
+// its local id — the 30040 `d` tag IS the local claim id, and
+// `ClaimModel.markPublished` records the publishing pubkey — so the
+// same logical claim keys identically pre- and post-publish, and the
+// one-assessment-per-claim / one-link-per-pair invariants hold.
+//
+// The d-tag alone is NOT sufficient to recognize our own claims:
+// claim ids hash (source_url | normalized text), so two users who
+// capture the same quote from the same URL derive the same d under
+// different pubkeys. The pubkey must match a recorded publishedPubkey.
+
+import { ClaimModel } from './claim-model.js';
+
+export const CLAIM_KIND = 30040;
+
+const LOCAL_ID_RE = /^claim_[0-9a-f]{16}$/;
+const PUBKEY_RE   = /^[0-9a-f]{64}$/;
+
+export function isLocalClaimId(ref) {
+    return typeof ref === 'string' && LOCAL_ID_RE.test(ref);
+}
+
+/**
+ * Parse a `30040:<pubkey>:<d>` coordinate. The d-tag may itself
+ * contain colons (foreign clients pick arbitrary d values), so only
+ * the first two colons delimit. Returns `{ kind, pubkey, d }` or null.
+ */
+export function parseClaimCoord(ref) {
+    if (typeof ref !== 'string') return null;
+    const first = ref.indexOf(':');
+    if (first === -1) return null;
+    const second = ref.indexOf(':', first + 1);
+    if (second === -1) return null;
+    const kind   = ref.slice(0, first);
+    const pubkey = ref.slice(first + 1, second);
+    const d      = ref.slice(second + 1);
+    if (kind !== String(CLAIM_KIND)) return null;
+    if (!PUBKEY_RE.test(pubkey)) return null;
+    if (!d) return null;
+    return { kind: CLAIM_KIND, pubkey, d };
+}
+
+export function isClaimCoord(ref) {
+    return parseClaimCoord(ref) !== null;
+}
+
+export function buildClaimCoord(pubkey, d) {
+    if (!PUBKEY_RE.test(String(pubkey || ''))) {
+        throw new Error('buildClaimCoord: pubkey must be 64 hex chars');
+    }
+    if (!d) throw new Error('buildClaimCoord: d-tag value required');
+    return `${CLAIM_KIND}:${pubkey}:${d}`;
+}
+
+/**
+ * Validate a ref is one of the two accepted forms. Returns the
+ * trimmed ref; throws with a greppable message otherwise.
+ */
+export function assertValidClaimRef(ref, label = 'claim ref') {
+    const trimmed = String(ref || '').trim();
+    if (!trimmed) throw new Error(`${label} is required`);
+    if (!isLocalClaimId(trimmed) && !isClaimCoord(trimmed)) {
+        throw new Error(`${label} must be a claim id or a 30040 coordinate (got ${trimmed})`);
+    }
+    return trimmed;
+}
+
+/**
+ * Every pubkey a claim is known to have published under. Collapse
+ * matches ANY of them (design rule 1: a republish under a new signing
+ * identity must not turn old coordinates — live addressable events on
+ * relays — back into "foreign" refs).
+ */
+export function claimPublishedPubkeys(claim) {
+    if (!claim) return [];
+    const out = Array.isArray(claim.publishedPubkeys) ? [...claim.publishedPubkeys] : [];
+    if (claim.publishedPubkey && !out.includes(claim.publishedPubkey)) {
+        out.push(claim.publishedPubkey);
+    }
+    return out;
+}
+
+/**
+ * Collapse a ref to canonical form: local id for our own claims,
+ * coordinate for foreign ones. Async — reads the claim registry to
+ * check whether a coordinate points at one of our published claims.
+ */
+export async function canonicalizeClaimRef(ref, label = 'claim ref') {
+    const trimmed = assertValidClaimRef(ref, label);
+    if (isLocalClaimId(trimmed)) return trimmed;
+    const coord = parseClaimCoord(trimmed);
+    if (coord && LOCAL_ID_RE.test(coord.d)) {
+        const claim = await ClaimModel.get(coord.d);
+        if (claim && claimPublishedPubkeys(claim).includes(coord.pubkey)) return coord.d;
+    }
+    return trimmed;
+}
+
+/**
+ * Snapshot canonicalizer for matching MANY stored refs: one claim-
+ * registry read, then synchronous collapses. Canonicality is
+ * time-dependent (a coordinate becomes collapsible only once its
+ * claim records a publishedPubkey), so matchers MUST canonicalize the
+ * stored side at read time too — a record whose ref was canonical at
+ * write time may have drifted. Comparing canon(stored) === canon(query)
+ * keeps those records reachable and keeps idempotent-create finding
+ * them. Stored refs are pre-validated, so no assertion here.
+ */
+export async function makeClaimRefCanonicalizer() {
+    const claims = await ClaimModel.getAll();
+    return (ref) => {
+        const trimmed = String(ref || '').trim();
+        if (isLocalClaimId(trimmed)) return trimmed;
+        const coord = parseClaimCoord(trimmed);
+        if (coord && LOCAL_ID_RE.test(coord.d)) {
+            const claim = claims[coord.d];
+            if (claim && claimPublishedPubkeys(claim).includes(coord.pubkey)) return coord.d;
+        }
+        return trimmed;
+    };
+}

--- a/src/shared/entity-model.js
+++ b/src/shared/entity-model.js
@@ -33,7 +33,11 @@ import { Crypto } from './crypto.js';
 import { Utils } from './utils.js';
 import { LocalKeyManager } from './local-key-manager.js';
 
-export const ENTITY_TYPES = ['person', 'organization', 'place', 'thing'];
+// `case` (Phase 11.1) models a real-world story under assessment —
+// "John Dehlin excommunication", "Bricks & Minifigs scandal" — so the
+// side-panel entity detail can serve as the case dashboard
+// (docs/ASSESSMENTS_DESIGN.md).
+export const ENTITY_TYPES = ['person', 'organization', 'place', 'thing', 'case'];
 
 /**
  * Map entity type → tag name used in kind-30023 article events.
@@ -45,6 +49,7 @@ export function entityTypeToTag(type) {
         case 'organization': return 'org';
         case 'place':        return 'place';
         case 'thing':        return 'thing';
+        case 'case':         return 'case';
         default:             return 'thing';
     }
 }
@@ -58,7 +63,8 @@ export const ENTITY_ICONS = {
     person:       '👤',
     organization: '🏢',
     place:        '📍',
-    thing:        '🔷'
+    thing:        '🔷',
+    case:         '🗂️'
 };
 
 /**

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -154,8 +154,9 @@ export const EventBuilder = {
         tags.push(['p', entity.keypair.pubkey, '', entityRef.context]);
         taggedPubkeys.add(entity.keypair.pubkey);
         
-        // Add name tag for clients that don't resolve pubkeys
-        const tagType = entity.type === 'person' ? 'person' : entity.type === 'organization' ? 'org' : entity.type === 'thing' ? 'thing' : 'place';
+        // Add name tag for clients that don't resolve pubkeys.
+        // Keep in sync with entity-model.js entityTypeToTag.
+        const tagType = entity.type === 'person' ? 'person' : entity.type === 'organization' ? 'org' : entity.type === 'thing' ? 'thing' : entity.type === 'case' ? 'case' : 'place';
         tags.push([tagType, entity.name, entityRef.context]);
 
         // If this entity is an alias, also tag the canonical entity
@@ -164,7 +165,7 @@ export const EventBuilder = {
           if (canonical && canonical.keypair && !taggedPubkeys.has(canonical.keypair.pubkey)) {
             tags.push(['p', canonical.keypair.pubkey, '', entityRef.context]);
             taggedPubkeys.add(canonical.keypair.pubkey);
-            const canonTagType = canonical.type === 'person' ? 'person' : canonical.type === 'organization' ? 'org' : canonical.type === 'thing' ? 'thing' : 'place';
+            const canonTagType = canonical.type === 'person' ? 'person' : canonical.type === 'organization' ? 'org' : canonical.type === 'thing' ? 'thing' : canonical.type === 'case' ? 'case' : 'place';
             tags.push([canonTagType, canonical.name, entityRef.context]);
           }
         }

--- a/src/shared/evidence-linker.js
+++ b/src/shared/evidence-linker.js
@@ -1,42 +1,68 @@
-// Evidence linker — Phase 5 C4 of the v4.2 parity push (issue #16).
+// Claim linker — Phase 5 C4, repurposed cross-source in Phase 11.1
+// (docs/ASSESSMENTS_DESIGN.md).
 //
-// An "evidence link" connects two claims with a typed relationship —
-// the user is asserting that one claim relates to another in a
-// specific way:
+// A link connects two claims with a typed relationship:
 //
-//   - supports         (source supports target)
-//   - contradicts      (source contradicts target)
-//   - contextualizes   (source provides context for target)
+//   - contradicts   (SYMMETRIC — the Phase 11 core: ⚠ on both claims)
+//   - supports      (directional: source supports target)
+//   - updates       (directional: source updates/replaces target)
+//   - duplicates    (SYMMETRIC — same assertion, different capture)
 //
-// Links are directional. (A supports B) is a different link from
-// (B supports A); the model doesn't auto-mirror. Separately, we
-// allow multiple links between the same claim pair with different
-// relationship types — the user can state both "A supports B on
-// point X" and "A contextualizes B on point Y" — so the hash-based
-// id includes the relationship so the combinations don't collide.
+// The legacy `contextualizes` is read-only: pre-11.1 records still
+// load and render, but new links can't use it.
 //
-// Published as kind-30043 events. `event-builder.buildEvidenceLinkEvent`
-// has been stubbed since Phase 2 and consumes this exact shape.
+// Endpoints take CANONICAL claim refs (see claim-ref.js): a local
+// claim id for claims we authored, a `30040:<pubkey>:<d>` coordinate
+// for foreign ones — so links work against claims we didn't author.
+// Refs are canonicalized before hashing, and symmetric relationships
+// sort their endpoints first, so one logical link always derives one
+// id (A↔B contradicts === B↔A contradicts). Directional links remain
+// distinct per direction, and multiple relationship types between the
+// same pair coexist (the id includes the relationship).
+//
+// Each endpoint may carry a `{ url, text, author_pubkey }` snapshot so
+// links against foreign claims render and export without a relay
+// round-trip; for local endpoints the snapshot auto-fills from the
+// claim registry.
+//
+// Wire: the legacy kind-30043 publish path is RETIRED as of 11.1; the
+// cross-source kind-30055 builder lands in 11.2 and publishes behind
+// the `assessmentPublishing` flag in a later slice.
 
 import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
 import { Utils } from './utils.js';
+import { ClaimModel } from './claim-model.js';
+import { normalize as normalizeUrl } from './metadata/url-normalizer.js';
+import {
+    CLAIM_RELATIONSHIPS, isSymmetricRelationship, isValidSuggestedBy
+} from './assessment-taxonomy.js';
+import {
+    isLocalClaimId, parseClaimCoord, assertValidClaimRef,
+    canonicalizeClaimRef, makeClaimRefCanonicalizer
+} from './claim-ref.js';
 
 // ------------------------------------------------------------------
 // Enums
 // ------------------------------------------------------------------
 
-export const EVIDENCE_RELATIONSHIPS = ['supports', 'contradicts', 'contextualizes'];
+export const EVIDENCE_RELATIONSHIPS = CLAIM_RELATIONSHIPS;
 
+// Legacy `contextualizes` keeps label/icon entries so pre-11.1
+// records render; it is not offered for new links.
 export const EVIDENCE_RELATIONSHIP_LABELS = {
-    supports:       'Supports',
     contradicts:    'Contradicts',
+    supports:       'Supports',
+    updates:        'Updates',
+    duplicates:     'Duplicates',
     contextualizes: 'Contextualizes'
 };
 
 export const EVIDENCE_RELATIONSHIP_ICONS = {
-    supports:       '↗',
     contradicts:    '⚔',
+    supports:       '↗',
+    updates:        '↻',
+    duplicates:     '≡',
     contextualizes: '◇'
 };
 
@@ -45,33 +71,79 @@ export const EVIDENCE_RELATIONSHIP_ICONS = {
 // ------------------------------------------------------------------
 
 /**
- * Deterministic id from (source, target, relationship). Same triple
- * always produces the same id — so a second `create()` with identical
- * inputs is idempotent, matching the entity / claim pattern.
+ * Deterministic id from (source, target, relationship). Expects
+ * already-canonical refs (create() canonicalizes first). Symmetric
+ * relationships sort the endpoints so both directions derive the same
+ * id; the relationship is in the hash so different types between the
+ * same pair don't collide. NOTE: this is the LOCAL id; the kind-30055
+ * wire d-tag hashes coordinates only and is derived at publish time.
  */
-export async function generateEvidenceLinkId(sourceClaimId, targetClaimId, relationship) {
-    const key = `${String(sourceClaimId || '')}|${String(targetClaimId || '')}|${String(relationship || '')}`;
+export async function generateEvidenceLinkId(sourceRef, targetRef, relationship) {
+    let a = String(sourceRef || '');
+    let b = String(targetRef || '');
+    if (isSymmetricRelationship(relationship) && b < a) [a, b] = [b, a];
+    const key = `${a}|${b}|${String(relationship || '')}`;
     const hash = await Crypto.sha256(key);
     return `link_${hash.slice(0, 16)}`;
 }
 
 // ------------------------------------------------------------------
-// Validation
+// Validation + normalization
 // ------------------------------------------------------------------
 
 function assertValidRelationship(relationship) {
-    if (!EVIDENCE_RELATIONSHIPS.includes(relationship)) {
-        throw new Error(`Invalid relationship: ${relationship} (expected one of ${EVIDENCE_RELATIONSHIPS.join(', ')})`);
+    if (!CLAIM_RELATIONSHIPS.includes(relationship)) {
+        throw new Error(`Invalid relationship: ${relationship} (expected one of ${CLAIM_RELATIONSHIPS.join(', ')})`);
     }
 }
 
-function assertValidClaimId(id, label) {
-    const trimmed = String(id || '').trim();
-    if (!trimmed) throw new Error(`${label} is required`);
-    if (!/^claim_[0-9a-f]{16}$/.test(trimmed)) {
-        throw new Error(`${label} must be a claim id (got ${trimmed})`);
+function assertValidSuggestedBy(value) {
+    const v = value === undefined || value === null ? 'user' : value;
+    if (!isValidSuggestedBy(v)) {
+        throw new Error(`Invalid suggested_by: ${v} (expected 'user' or 'llm:<model>')`);
     }
-    return trimmed;
+    return v;
+}
+
+/**
+ * Endpoint snapshot: caller-supplied for foreign refs, auto-filled
+ * from the claim registry for local ones. Null when neither source
+ * has it (e.g. tests with fake ids) — renderers must tolerate that.
+ * A coordinate ref carries its author pubkey, so that backfills when
+ * the caller didn't supply one.
+ */
+async function resolveSnapshot(ref, given) {
+    if (given && (given.url || given.text)) {
+        const coord = parseClaimCoord(ref);
+        return {
+            url:           given.url ? normalizeUrl(String(given.url)) : '',
+            text:          String(given.text || ''),
+            author_pubkey: given.author_pubkey || (coord ? coord.pubkey : null)
+        };
+    }
+    if (isLocalClaimId(ref)) {
+        const claim = await ClaimModel.get(ref);
+        if (claim) {
+            return {
+                url:           normalizeUrl(claim.source_url),
+                text:          claim.text,
+                author_pubkey: claim.publishedPubkey || null
+            };
+        }
+    }
+    return null;
+}
+
+// Backfill fields for records written before 11.1, read-time only.
+function normalizeLink(record) {
+    if (!record) return record;
+    if ('suggested_by' in record) return record;
+    return {
+        ...record,
+        suggested_by:    'user',
+        source_snapshot: record.source_snapshot || null,
+        target_snapshot: record.target_snapshot || null
+    };
 }
 
 // ------------------------------------------------------------------
@@ -82,24 +154,33 @@ export const EvidenceLinker = {
     get: async (id) => {
         if (!id) return null;
         const all = await Storage.get('evidence_links', {});
-        return all[id] || null;
+        return all[id] ? normalizeLink(all[id]) : null;
     },
 
     getAll: async () => {
-        return await Storage.get('evidence_links', {});
+        const all = await Storage.get('evidence_links', {});
+        const out = {};
+        for (const [id, rec] of Object.entries(all)) out[id] = normalizeLink(rec);
+        return out;
     },
 
     /**
-     * Every link where `claimId` is either source OR target. Used by
-     * the reader's claim card to show outgoing + incoming links.
+     * Every link where `ref` is either endpoint. BOTH the query ref
+     * and the stored endpoints are canonicalized before matching —
+     * canonicality is time-dependent (a stored coordinate becomes
+     * collapsible once its claim records a publishedPubkey), so a
+     * drifted endpoint must still match. Used by the reader's claim
+     * card and the ⚠ badge logic.
      */
-    getForClaim: async (claimId) => {
-        if (!claimId) return [];
+    getForClaim: async (ref) => {
+        if (!ref) return [];
+        const canonical = await canonicalizeClaimRef(ref);
+        const canon = await makeClaimRefCanonicalizer();
         const all = await Storage.get('evidence_links', {});
         const out = [];
         for (const link of Object.values(all)) {
-            if (link.source_claim_id === claimId || link.target_claim_id === claimId) {
-                out.push(link);
+            if (canon(link.source_claim_id) === canonical || canon(link.target_claim_id) === canonical) {
+                out.push(normalizeLink(link));
             }
         }
         out.sort((a, b) => (a.created || 0) - (b.created || 0));
@@ -107,23 +188,50 @@ export const EvidenceLinker = {
     },
 
     /**
-     * Create a new evidence link. Idempotent on the
-     * (source, target, relationship) triple — second create with the
-     * same triple returns the existing record rather than surprising
-     * the caller.
+     * Create a link. Endpoints accept local claim ids or 30040
+     * coordinates; idempotent on the canonical (source, target,
+     * relationship) triple — for symmetric relationships, on the
+     * unordered pair.
      */
-    create: async ({ source_claim_id, target_claim_id, relationship, note }) => {
-        const source = assertValidClaimId(source_claim_id, 'source_claim_id');
-        const target = assertValidClaimId(target_claim_id, 'target_claim_id');
+    create: async ({ source_claim_id, target_claim_id, relationship, note, suggested_by,
+                     source_snapshot, target_snapshot }) => {
+        assertValidClaimRef(source_claim_id, 'source_claim_id');
+        assertValidClaimRef(target_claim_id, 'target_claim_id');
         assertValidRelationship(relationship);
+
+        let source = await canonicalizeClaimRef(source_claim_id, 'source_claim_id');
+        let target = await canonicalizeClaimRef(target_claim_id, 'target_claim_id');
+        let sourceSnap = source_snapshot || null;
+        let targetSnap = target_snapshot || null;
 
         if (source === target) {
             throw new Error('Cannot link a claim to itself');
         }
 
+        // Symmetric relationships store endpoints in sorted order so
+        // both creation directions land on the same record.
+        if (isSymmetricRelationship(relationship) && target < source) {
+            [source, target] = [target, source];
+            [sourceSnap, targetSnap] = [targetSnap, sourceSnap];
+        }
+
         const id = await generateEvidenceLinkId(source, target, relationship);
         const all = await Storage.get('evidence_links', {});
-        if (all[id]) return all[id];
+        if (all[id]) return normalizeLink(all[id]);
+        // Match-based dedupe too: an endpoint stored under a ref whose
+        // canonicality has since drifted derives a different id for the
+        // same logical pair — it must still win.
+        {
+            const canon = await makeClaimRefCanonicalizer();
+            let qa = canon(source), qb = canon(target);
+            if (isSymmetricRelationship(relationship) && qb < qa) [qa, qb] = [qb, qa];
+            for (const link of Object.values(all)) {
+                if (link.relationship !== relationship) continue;
+                let sa = canon(link.source_claim_id), sb = canon(link.target_claim_id);
+                if (isSymmetricRelationship(relationship) && sb < sa) [sa, sb] = [sb, sa];
+                if (sa === qa && sb === qb) return normalizeLink(link);
+            }
+        }
 
         const now = Math.floor(Date.now() / 1000);
         const record = {
@@ -131,15 +239,18 @@ export const EvidenceLinker = {
             source_claim_id: source,
             target_claim_id: target,
             relationship,
-            note: note || '',
-            created: now,
-            updated: now,
-            publishedAt: null,
+            note:            note || '',
+            suggested_by:    assertValidSuggestedBy(suggested_by),
+            source_snapshot: await resolveSnapshot(source, sourceSnap),
+            target_snapshot: await resolveSnapshot(target, targetSnap),
+            created:         now,
+            updated:         now,
+            publishedAt:     null,
             publishedEventId: null
         };
         all[id] = record;
         await Storage.set('evidence_links', all);
-        Utils.log('Created evidence link:', id, relationship);
+        Utils.log('Created claim link:', id, relationship);
         return record;
     },
 
@@ -152,7 +263,7 @@ export const EvidenceLinker = {
         const all = await Storage.get('evidence_links', {});
         const record = all[id];
         if (!record) throw new Error(`Evidence link not found: ${id}`);
-        const patched = { ...record };
+        const patched = normalizeLink({ ...record });
         if ('note' in updates) patched.note = updates.note || '';
         patched.updated = Math.floor(Date.now() / 1000);
         all[id] = patched;
@@ -169,15 +280,19 @@ export const EvidenceLinker = {
     },
 
     /**
-     * Delete every link that references `claimId`. Called by the
-     * reader's claim-delete flow so links aren't orphaned. Returns
-     * the number of links removed.
+     * Delete every link that references the claim (by either
+     * representation — stored endpoints are canonicalized too, so
+     * drifted refs still match). Called by the reader's claim-delete
+     * flow so links aren't orphaned. Returns the number removed.
      */
-    deleteForClaim: async (claimId) => {
+    deleteForClaim: async (ref) => {
+        if (!ref) return 0;
+        const canonical = await canonicalizeClaimRef(ref);
+        const canon = await makeClaimRefCanonicalizer();
         const all = await Storage.get('evidence_links', {});
         let removed = 0;
         for (const [id, link] of Object.entries(all)) {
-            if (link.source_claim_id === claimId || link.target_claim_id === claimId) {
+            if (canon(link.source_claim_id) === canonical || canon(link.target_claim_id) === canonical) {
                 delete all[id];
                 removed++;
             }
@@ -194,6 +309,6 @@ export const EvidenceLinker = {
         if (eventId) record.publishedEventId = eventId;
         all[id] = record;
         await Storage.set('evidence_links', all);
-        return record;
+        return normalizeLink(record);
     }
 };

--- a/src/sidepanel/index.css
+++ b/src/sidepanel/index.css
@@ -233,6 +233,7 @@ body.xr-side {
 .xr-side__type-badge--organization { border-color: color-mix(in srgb, #22d3ee 60%, transparent); }
 .xr-side__type-badge--place        { border-color: color-mix(in srgb, #34d399 60%, transparent); }
 .xr-side__type-badge--thing        { border-color: color-mix(in srgb, #a78bfa 60%, transparent); }
+.xr-side__type-badge--case         { border-color: color-mix(in srgb, #fb923c 60%, transparent); }
 
 /* ---------------- form fields ---------------- */
 

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -23,6 +23,7 @@
       <button class="xr-side__type-chip" data-type="organization" title="Organization">🏢</button>
       <button class="xr-side__type-chip" data-type="place"        title="Place">📍</button>
       <button class="xr-side__type-chip" data-type="thing"        title="Thing">🔷</button>
+      <button class="xr-side__type-chip" data-type="case"         title="Case">🗂️</button>
     </div>
     <input type="search" class="xr-side__search" id="xr-search"
            placeholder="Search by name…" spellcheck="false" />

--- a/src/sidepanel/index.js
+++ b/src/sidepanel/index.js
@@ -33,7 +33,7 @@ const USER_KEY_NAME = 'xray:user';
 
 const state = {
     view:          'list',     // 'list' | 'detail'
-    typeFilter:    '',         // '' | 'person' | 'organization' | 'place' | 'thing'
+    typeFilter:    '',         // '' | 'person' | 'organization' | 'place' | 'thing' | 'case'
     searchQuery:   '',
     selectedId:    null,
     entities:      {},         // cached getAll() result

--- a/tests/assessment-model.test.mjs
+++ b/tests/assessment-model.test.mjs
@@ -1,0 +1,285 @@
+// Assessment model tests — Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
+// Same chrome.storage.local shim pattern as entity-model.test.mjs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const { AssessmentModel, generateAssessmentId } = await import('../src/shared/assessment-model.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+const { buildClaimCoord } = await import('../src/shared/claim-ref.js');
+
+function resetState() { _stateStore.clear(); }
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+const URL_1 = 'https://example.com/video-1';
+
+async function seedClaim(text = 'The collection was worth $200,000.', url = URL_1) {
+    return await ClaimModel.create({ text, source_url: url });
+}
+
+// ---------------------------------------------------------------------
+
+test('assessment: deterministic id derivation', async () => {
+    const a = await generateAssessmentId('claim_aaaaaaaaaaaaaaaa');
+    const b = await generateAssessmentId('claim_bbbbbbbbbbbbbbbb');
+    assert.match(a, /^assess_[0-9a-f]{16}$/);
+    assert.notEqual(a, b, 'different refs derive different ids');
+    assert.equal(a, await generateAssessmentId('claim_aaaaaaaaaaaaaaaa'), 'stable');
+});
+
+test('assessment: create + get round-trip on an own claim', async () => {
+    resetState();
+    // utm params must be stripped from the snapshot url (the URL rule).
+    const claim = await seedClaim('Quote.', 'https://example.com/video-1?utm_source=feed');
+    const assessment = await AssessmentModel.create({
+        claim_ref: { claim_id: claim.id },
+        stance:    -1,
+        labels:    [{ label: 'misleading', note: 'closure framed as neutral' }],
+        rationale: 'Both sides confirm it was not mutual.'
+    });
+
+    assert.match(assessment.id, /^assess_[0-9a-f]{16}$/);
+    assert.equal(assessment.claim_ref.claim_id, claim.id);
+    assert.equal(assessment.claim_ref.coord, null, 'no coordinate before the claim publishes');
+    assert.equal(assessment.claim_ref.url, 'https://example.com/video-1', 'snapshot url normalized');
+    assert.equal(assessment.claim_ref.text, 'Quote.');
+    assert.equal(assessment.stance, -1);
+    assert.deepEqual(assessment.labels, [{
+        label: 'misleading', anchor: null, note: 'closure framed as neutral', suggested_by: 'user'
+    }]);
+    assert.equal(assessment.suggested_by, 'user');
+    assert.equal(assessment.publishedAt, null);
+
+    const fetched = await AssessmentModel.get(assessment.id);
+    assert.deepEqual(fetched, assessment);
+});
+
+test('assessment: own-claim refs must exist in the registry', async () => {
+    resetState();
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: { claim_id: 'claim_aaaaaaaaaaaaaaaa' }, stance: 1
+    }), /Claim not found/);
+});
+
+test('assessment: foreign claims by coordinate, with required snapshots', async () => {
+    resetState();
+    const coord = buildClaimCoord(PUBKEY_B, 'their-claim-d');
+    const assessment = await AssessmentModel.create({
+        claim_ref: {
+            coord,
+            event_id: 'f'.repeat(64),
+            url:  'https://example.com/their-video?fbclid=track',
+            text: 'We parted ways by mutual agreement.'
+        },
+        labels: ['euphemism', 'misleading']
+    });
+    assert.equal(assessment.claim_ref.claim_id, null);
+    assert.equal(assessment.claim_ref.coord, coord);
+    assert.equal(assessment.claim_ref.event_id, 'f'.repeat(64), 'event_id rides along');
+    assert.equal(assessment.claim_ref.author_pubkey, PUBKEY_B);
+    assert.equal(assessment.claim_ref.url, 'https://example.com/their-video', 'normalized');
+    assert.equal(assessment.stance, null, 'label-only assessment is valid');
+    assert.deepEqual(assessment.labels.map((l) => l.label), ['euphemism', 'misleading']);
+
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: { coord: buildClaimCoord(PUBKEY_B, 'other-d'), text: 'no url' }, stance: 0
+    }), /claim_ref\.url is required/);
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: { coord: buildClaimCoord(PUBKEY_B, 'other-d'), url: URL_1 }, stance: 0
+    }), /claim_ref\.text is required/);
+});
+
+test('assessment: idempotent create — one assessment per claim', async () => {
+    resetState();
+    const claim = await seedClaim();
+    const first = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, stance: 2 });
+    const second = await AssessmentModel.create({
+        claim_ref: { claim_id: claim.id }, stance: -2, rationale: 'ignored — record exists'
+    });
+    assert.equal(first.id, second.id);
+    assert.equal(second.stance, 2, 'idempotent create returns the EXISTING record');
+});
+
+test('assessment: identity survives the publish boundary (local id ↔ coordinate)', async () => {
+    resetState();
+    const claim = await seedClaim();
+    const prePublish = await AssessmentModel.create({
+        claim_ref: { claim_id: claim.id }, stance: 1
+    });
+
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64), PUBKEY_A);
+    const coord = buildClaimCoord(PUBKEY_A, claim.id);
+
+    // Re-encountering our own published claim by coordinate must hit
+    // the SAME record — the canonical-ref rule, not a second record.
+    const postPublish = await AssessmentModel.create({
+        claim_ref: { coord, url: URL_1, text: claim.text }, stance: -2
+    });
+    assert.equal(postPublish.id, prePublish.id, 'same record across the publish boundary');
+    assert.equal(postPublish.stance, 1, 'existing judgment wins');
+
+    const byCoord = await AssessmentModel.getByClaimRef(coord);
+    assert.equal(byCoord.id, prePublish.id);
+    const byId = await AssessmentModel.getByClaimRef(claim.id);
+    assert.equal(byId.id, prePublish.id);
+
+    // Same d under a different pubkey is a DIFFERENT (foreign) claim.
+    const foreign = await AssessmentModel.create({
+        claim_ref: { coord: buildClaimCoord(PUBKEY_B, claim.id), url: URL_1, text: claim.text },
+        stance: 0
+    });
+    assert.notEqual(foreign.id, prePublish.id);
+});
+
+test('assessment: drift — a coordinate-keyed record stays reachable once the claim gains publishedPubkey', async () => {
+    resetState();
+    const claim = await seedClaim('Drifting claim.', 'https://example.com/video-9');
+    // Published pre-11.1 style: publishedAt recorded, but no pubkey —
+    // the claim's own coordinate does NOT collapse, so an assessment
+    // created against it is keyed by the coordinate.
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64));
+    const coord = buildClaimCoord(PUBKEY_A, claim.id);
+    const a = await AssessmentModel.create({
+        claim_ref: { coord, url: 'https://example.com/video-9', text: claim.text }, stance: -1
+    });
+    assert.equal(a.claim_ref.coord, coord);
+    assert.equal(a.claim_ref.claim_id, null, 'stored as a foreign-style coordinate ref');
+
+    // The pubkey lands later (a republish) — the stored coordinate is
+    // now collapsible. Matching must canonicalize the STORED side too,
+    // or the record is orphaned by both representations.
+    await ClaimModel.markPublished(claim.id, 'f'.repeat(64), PUBKEY_A);
+    const byId    = await AssessmentModel.getByClaimRef(claim.id);
+    const byCoord = await AssessmentModel.getByClaimRef(coord);
+    assert.ok(byId, 'reachable by local id after drift');
+    assert.ok(byCoord, 'reachable by coordinate after drift');
+    assert.equal(byId.id, a.id);
+    assert.equal(byCoord.id, a.id);
+
+    // …and idempotent create must find the drifted record, not mint a
+    // second assessment for the same logical claim.
+    const again = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, stance: 2 });
+    assert.equal(again.id, a.id, 'one assessment per claim — even after drift');
+    assert.equal(again.stance, -1, 'existing judgment wins');
+    assert.equal(Object.keys(await AssessmentModel.getAll()).length, 1);
+});
+
+test('assessment: validation — stance range, judgment invariant, labels', async () => {
+    resetState();
+    const claim = await seedClaim();
+    const ref = { claim_id: claim.id };
+
+    await assert.rejects(() => AssessmentModel.create({ claim_ref: ref }),
+        /needs a stance or at least one label/);
+    for (const bad of [3, -3, 1.5, '1']) {
+        await assert.rejects(() => AssessmentModel.create({ claim_ref: ref, stance: bad }),
+            /Invalid stance/, `stance ${bad} rejected`);
+    }
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: ref, labels: ['misleading', 'misleading']
+    }), /Duplicate label/);
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: ref, labels: ['Has Space']
+    }), /Invalid label/);
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: ref, stance: 1, suggested_by: 'bot'
+    }), /Invalid suggested_by/);
+    await assert.rejects(() => AssessmentModel.create({
+        claim_ref: ref, stance: 1, labels: [{ label: 'misleading', suggested_by: 'robot' }]
+    }), /Invalid label suggested_by/);
+
+    // Custom labels and llm provenance ride the same rails.
+    const ok = await AssessmentModel.create({
+        claim_ref: ref,
+        stance: null,
+        labels: [{ label: 'pinky-promise', suggested_by: 'llm:claude-fable-5' }],
+        suggested_by: 'llm:claude-fable-5'
+    });
+    assert.equal(ok.labels[0].suggested_by, 'llm:claude-fable-5');
+});
+
+test('assessment: update patches judgment fields, never claim_ref', async () => {
+    resetState();
+    const claim = await seedClaim();
+    const a = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, stance: 0 });
+
+    const updated = await AssessmentModel.update(a.id, {
+        stance: 2,
+        labels: ['cherry-picked'],
+        rationale: 'On reflection, the quote is real but selective.',
+        claim_ref: { claim_id: 'claim_ffffffffffffffff' }   // must be IGNORED
+    });
+    assert.equal(updated.stance, 2);
+    assert.deepEqual(updated.labels.map((l) => l.label), ['cherry-picked']);
+    assert.equal(updated.claim_ref.claim_id, claim.id, 'claim_ref is immutable');
+    assert.ok(updated.updated >= a.updated);
+
+    await assert.rejects(() => AssessmentModel.update(a.id, { stance: null, labels: [] }),
+        /needs a stance or at least one label/);
+    await assert.rejects(() => AssessmentModel.update('assess_0000000000000000', { stance: 1 }),
+        /Assessment not found/);
+});
+
+test('assessment: backfillCoord records the coordinate without bumping updated', async () => {
+    resetState();
+    const claim = await seedClaim();
+    const a = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, stance: 1 });
+    const coord = buildClaimCoord(PUBKEY_A, claim.id);
+
+    const filled = await AssessmentModel.backfillCoord(a.id, coord);
+    assert.equal(filled.claim_ref.coord, coord);
+    assert.equal(filled.claim_ref.author_pubkey, PUBKEY_A);
+    assert.equal(filled.updated, a.updated, 'backfill is enrichment, not an edit');
+    assert.equal(filled.claim_ref.claim_id, claim.id, 'canonical key unchanged');
+
+    await assert.rejects(() => AssessmentModel.backfillCoord(a.id, buildClaimCoord(PUBKEY_A, 'claim_0000000000000000')),
+        /does not match the assessed claim/);
+    await assert.rejects(() => AssessmentModel.backfillCoord(a.id, 'garbage'),
+        /Invalid coordinate/);
+    assert.equal(await AssessmentModel.backfillCoord('assess_0000000000000000', coord), null);
+});
+
+test('assessment: markPublished records publishedAt without bumping updated', async () => {
+    resetState();
+    const claim = await seedClaim();
+    const a = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, stance: 1 });
+    const marked = await AssessmentModel.markPublished(a.id, 'e'.repeat(64));
+    assert.ok(marked.publishedAt > 0);
+    assert.equal(marked.publishedEventId, 'e'.repeat(64));
+    assert.equal(marked.updated, a.updated, 'publish must not bump updated');
+});
+
+test('assessment: getByClaimRef returns null for unassessed claims; delete works', async () => {
+    resetState();
+    const claim = await seedClaim();
+    assert.equal(await AssessmentModel.getByClaimRef(claim.id), null);
+
+    const a = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, stance: 1 });
+    assert.equal(await AssessmentModel.delete(a.id), true);
+    assert.equal(await AssessmentModel.get(a.id), null);
+    assert.equal(await AssessmentModel.delete(a.id), false);
+});

--- a/tests/assessment-taxonomy.test.mjs
+++ b/tests/assessment-taxonomy.test.mjs
@@ -1,0 +1,99 @@
+// Assessment taxonomy tests — Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
+//
+// The taxonomy is the single source of truth for label vocabulary,
+// stance scale, and relationship directionality — these exhaustive
+// enum pins are deliberate friction: extending the vocabulary means
+// editing this file in the same change (the EVIDENCE_RELATIONSHIPS /
+// ENTITY_TYPES house pattern).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+    ASSESSMENT_LABEL_NAMESPACE, ASSESSMENT_LABEL_GROUPS, ASSESSMENT_LABELS,
+    isStandardLabel, isValidLabel,
+    STANCE_VALUES, STANCE_LABELS, isValidStance,
+    CLAIM_RELATIONSHIPS, SYMMETRIC_RELATIONSHIPS, isSymmetricRelationship,
+    isValidSuggestedBy
+} = await import('../src/shared/assessment-taxonomy.js');
+
+test('taxonomy: namespace is pinned', () => {
+    assert.equal(ASSESSMENT_LABEL_NAMESPACE, 'xray/assessment');
+});
+
+test('taxonomy: label groups are exhaustive', () => {
+    assert.deepEqual(Object.keys(ASSESSMENT_LABEL_GROUPS).sort(),
+        ['consistency', 'factual', 'fallacy', 'provenance', 'rhetorical']);
+    assert.deepEqual(ASSESSMENT_LABEL_GROUPS.factual.slice().sort(),
+        ['cherry-picked', 'false', 'misleading', 'missing-context', 'outdated', 'unsupported']);
+    assert.deepEqual(ASSESSMENT_LABEL_GROUPS.consistency.slice().sort(),
+        ['contradicts-prior-statement', 'flip-flop', 'moved-goalposts']);
+    assert.deepEqual(ASSESSMENT_LABEL_GROUPS.fallacy.slice().sort(),
+        ['fallacy/ad-hominem', 'fallacy/appeal-to-authority', 'fallacy/appeal-to-consequences',
+         'fallacy/circular', 'fallacy/false-dilemma', 'fallacy/slippery-slope',
+         'fallacy/strawman', 'fallacy/whataboutism']);
+    assert.deepEqual(ASSESSMENT_LABEL_GROUPS.rhetorical.slice().sort(),
+        ['ambiguous', 'euphemism', 'loaded-language', 'unfalsifiable']);
+    assert.deepEqual(ASSESSMENT_LABEL_GROUPS.provenance.slice().sort(),
+        ['undisclosed-interest']);
+});
+
+test('taxonomy: flat list is the union of the groups, no duplicates', () => {
+    const union = Object.values(ASSESSMENT_LABEL_GROUPS).flat();
+    assert.deepEqual(ASSESSMENT_LABELS.slice().sort(), union.slice().sort());
+    assert.equal(new Set(ASSESSMENT_LABELS).size, ASSESSMENT_LABELS.length);
+    for (const label of ASSESSMENT_LABELS) {
+        assert.equal(isStandardLabel(label), true, `${label} is standard`);
+        assert.equal(isValidLabel(label), true, `${label} passes its own validation`);
+    }
+});
+
+test('taxonomy: custom labels ride the same rails (the escape hatch)', () => {
+    assert.equal(isStandardLabel('pinky-promise'), false);
+    assert.equal(isValidLabel('pinky-promise'), true);
+    assert.equal(isValidLabel('fallacy/tu-quoque'), true, 'custom value in a known family');
+
+    assert.equal(isValidLabel(''), false);
+    assert.equal(isValidLabel('Has Space'), false);
+    assert.equal(isValidLabel('UPPER'), false);
+    assert.equal(isValidLabel('-leading-dash'), false);
+    assert.equal(isValidLabel('a/b/c'), false, 'one namespace segment max');
+    assert.equal(isValidLabel('x'.repeat(65)), false, 'length cap');
+    assert.equal(isValidLabel(42), false);
+});
+
+test('taxonomy: stance scale is discrete -2..+2 with full display coverage', () => {
+    assert.deepEqual(STANCE_VALUES.slice(), [-2, -1, 0, 1, 2]);
+    for (const v of STANCE_VALUES) {
+        assert.equal(isValidStance(v), true);
+        assert.ok(STANCE_LABELS[String(v)], `STANCE_LABELS must cover ${v}`);
+    }
+    assert.equal(STANCE_LABELS['-2'], 'Strongly disagree');
+    assert.equal(STANCE_LABELS['2'],  'Strongly agree');
+    for (const bad of [3, -3, 1.5, '1', null, undefined, NaN]) {
+        assert.equal(isValidStance(bad), false, `rejects ${String(bad)}`);
+    }
+});
+
+test('taxonomy: relationship vocabulary + directionality', () => {
+    assert.deepEqual(CLAIM_RELATIONSHIPS.slice().sort(),
+        ['contradicts', 'duplicates', 'supports', 'updates']);
+    assert.deepEqual(SYMMETRIC_RELATIONSHIPS.slice().sort(),
+        ['contradicts', 'duplicates']);
+    assert.equal(isSymmetricRelationship('contradicts'), true);
+    assert.equal(isSymmetricRelationship('duplicates'), true);
+    assert.equal(isSymmetricRelationship('supports'), false);
+    assert.equal(isSymmetricRelationship('updates'), false);
+    assert.equal(isSymmetricRelationship('contextualizes'), false, 'legacy value is not symmetric');
+});
+
+test('taxonomy: suggested_by provenance values', () => {
+    assert.equal(isValidSuggestedBy('user'), true);
+    assert.equal(isValidSuggestedBy('llm:claude-fable-5'), true);
+    assert.equal(isValidSuggestedBy('llm:'), false, 'model name required');
+    assert.equal(isValidSuggestedBy('llm: '), false, 'whitespace-only model name rejected');
+    assert.equal(isValidSuggestedBy('llm:\t'), false);
+    assert.equal(isValidSuggestedBy('bot'), false);
+    assert.equal(isValidSuggestedBy(''), false);
+    assert.equal(isValidSuggestedBy(null), false);
+});

--- a/tests/claim-model.test.mjs
+++ b/tests/claim-model.test.mjs
@@ -200,3 +200,18 @@ test('claim: delete + markPublished', async () => {
     assert.equal(await ClaimModel.get(claim.id), null);
     assert.equal(await ClaimModel.delete(claim.id), false);
 });
+
+test('claim: markPublished records the publishing pubkey (Phase 11.1)', async () => {
+    resetState();
+    const PUBKEY = 'a'.repeat(64);
+    const claim = await ClaimModel.create({ text: 'Coordinate-bearing.', source_url: URL_A });
+    assert.equal(claim.publishedPubkey, undefined, 'unset before publish');
+
+    const marked = await ClaimModel.markPublished(claim.id, 'e'.repeat(64), PUBKEY);
+    assert.equal(marked.publishedPubkey, PUBKEY);
+    assert.equal(marked.updated, claim.updated, 'publish must not bump updated');
+
+    // Omitting the pubkey (legacy call shape) must not clear it.
+    const again = await ClaimModel.markPublished(claim.id, 'f'.repeat(64));
+    assert.equal(again.publishedPubkey, PUBKEY, 'pubkey survives a pubkey-less re-publish call');
+});

--- a/tests/claim-ref.test.mjs
+++ b/tests/claim-ref.test.mjs
@@ -1,0 +1,136 @@
+// Claim-ref tests — Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
+// Same chrome.storage.local shim pattern as entity-model.test.mjs.
+//
+// Pins the canonical-ref rules everything in the assessment layer
+// keys on: local id for our own claims, coordinate for foreign ones,
+// and the collapse of our-own-published-claim coordinates back to the
+// local id (which needs ClaimModel.markPublished's publishedPubkey).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const {
+    isLocalClaimId, isClaimCoord, parseClaimCoord, buildClaimCoord,
+    assertValidClaimRef, canonicalizeClaimRef, CLAIM_KIND
+} = await import('../src/shared/claim-ref.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+
+function resetState() { _stateStore.clear(); }
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+const LOCAL_ID = 'claim_aaaaaaaaaaaaaaaa';
+
+// ---------------------------------------------------------------------
+
+test('claim-ref: local-id shape', () => {
+    assert.equal(isLocalClaimId(LOCAL_ID), true);
+    assert.equal(isLocalClaimId('claim_AAAAAAAAAAAAAAAA'), false, 'hex is lowercase');
+    assert.equal(isLocalClaimId('claim_aaaa'), false, 'sixteen hex chars exactly');
+    assert.equal(isLocalClaimId(`30040:${PUBKEY_A}:${LOCAL_ID}`), false);
+    assert.equal(isLocalClaimId(null), false);
+});
+
+test('claim-ref: coordinate parse + build round-trip', () => {
+    assert.equal(CLAIM_KIND, 30040);
+    const coord = buildClaimCoord(PUBKEY_A, LOCAL_ID);
+    assert.equal(coord, `30040:${PUBKEY_A}:${LOCAL_ID}`);
+    assert.deepEqual(parseClaimCoord(coord), { kind: 30040, pubkey: PUBKEY_A, d: LOCAL_ID });
+    assert.equal(isClaimCoord(coord), true);
+
+    // Foreign d-tags may contain colons — only the first two delimit.
+    const colonD = parseClaimCoord(`30040:${PUBKEY_A}:ann:deadbeef:v2`);
+    assert.equal(colonD.d, 'ann:deadbeef:v2');
+
+    assert.equal(parseClaimCoord(`30023:${PUBKEY_A}:${LOCAL_ID}`), null, 'wrong kind');
+    assert.equal(parseClaimCoord(`30040:shortkey:${LOCAL_ID}`), null, 'malformed pubkey');
+    assert.equal(parseClaimCoord(`30040:${PUBKEY_A}:`), null, 'empty d');
+    assert.equal(parseClaimCoord(LOCAL_ID), null);
+
+    assert.throws(() => buildClaimCoord('nope', LOCAL_ID), /64 hex/);
+    assert.throws(() => buildClaimCoord(PUBKEY_A, ''), /d-tag value required/);
+});
+
+test('claim-ref: assertValidClaimRef accepts both forms, rejects garbage', () => {
+    assert.equal(assertValidClaimRef(LOCAL_ID, 'ref'), LOCAL_ID);
+    assert.equal(assertValidClaimRef(`  ${LOCAL_ID}  `, 'ref'), LOCAL_ID, 'trims');
+    const coord = buildClaimCoord(PUBKEY_A, LOCAL_ID);
+    assert.equal(assertValidClaimRef(coord, 'ref'), coord);
+    assert.throws(() => assertValidClaimRef('', 'source_claim_id'), /source_claim_id is required/);
+    assert.throws(() => assertValidClaimRef('not-a-ref', 'ref'),
+        /must be a claim id or a 30040 coordinate/);
+});
+
+test('claim-ref: canonicalize passes local ids through', async () => {
+    resetState();
+    assert.equal(await canonicalizeClaimRef(LOCAL_ID), LOCAL_ID);
+});
+
+test('claim-ref: canonicalize collapses coordinates of our own published claims', async () => {
+    resetState();
+    const claim = await ClaimModel.create({
+        text: 'The defendant said X.', source_url: 'https://example.com/video-1'
+    });
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64), PUBKEY_A);
+
+    const ours = buildClaimCoord(PUBKEY_A, claim.id);
+    assert.equal(await canonicalizeClaimRef(ours), claim.id, 'our published claim → local id');
+
+    // Same d under a DIFFERENT pubkey is somebody else's claim: claim
+    // ids hash (url|text), so two users capturing the same quote derive
+    // the same d. The pubkey must match.
+    const theirs = buildClaimCoord(PUBKEY_B, claim.id);
+    assert.equal(await canonicalizeClaimRef(theirs), theirs, 'foreign pubkey stays a coordinate');
+});
+
+test('claim-ref: collapse matches ANY recorded publishing pubkey (re-keyed republish)', async () => {
+    resetState();
+    const claim = await ClaimModel.create({
+        text: 'Republished under a new identity.', source_url: 'https://example.com/video-6'
+    });
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64), PUBKEY_A);
+    await ClaimModel.markPublished(claim.id, 'f'.repeat(64), PUBKEY_B);   // re-keyed
+
+    // Coordinates under BOTH identities are live addressable events on
+    // relays — both must keep collapsing (publishedPubkeys history).
+    assert.equal(await canonicalizeClaimRef(buildClaimCoord(PUBKEY_A, claim.id)), claim.id,
+        'old-identity coordinate still collapses');
+    assert.equal(await canonicalizeClaimRef(buildClaimCoord(PUBKEY_B, claim.id)), claim.id,
+        'new-identity coordinate collapses');
+});
+
+test('claim-ref: coordinates of unpublished or unknown claims stay coordinates', async () => {
+    resetState();
+    const claim = await ClaimModel.create({
+        text: 'Not yet on the wire.', source_url: 'https://example.com/video-2'
+    });
+    const coord = buildClaimCoord(PUBKEY_A, claim.id);
+    assert.equal(await canonicalizeClaimRef(coord), coord,
+        'no recorded publishedPubkey → cannot claim it as ours');
+
+    const foreign = buildClaimCoord(PUBKEY_A, 'their-arbitrary-d');
+    assert.equal(await canonicalizeClaimRef(foreign), foreign);
+});

--- a/tests/entity-model.test.mjs
+++ b/tests/entity-model.test.mjs
@@ -36,9 +36,10 @@ globalThis.chrome = {
 };
 
 const { EntityModel, ENTITY_TYPES, ENTITY_ICONS,
-        entityTypeToTag, generateEntityId } =
+        entityTypeToTag, generateEntityId, installEntityStorageBridge } =
     await import('../src/shared/entity-model.js');
 const { LocalKeyManager } = await import('../src/shared/local-key-manager.js');
+const { EventBuilder } = await import('../src/shared/event-builder.js');
 
 // Fresh state between groups of tests — tests that create entities
 // should be independent.
@@ -200,13 +201,42 @@ test('entity: markPublished records publishedAt without bumping updated', async 
 
 test('entity: tag name maps + ENTITY_TYPES is exhaustive', () => {
     // If we add a new entity type later, this map has to stay in sync
-    // with event-builder.js:121.
-    assert.deepEqual(ENTITY_TYPES.slice().sort(), ['organization', 'person', 'place', 'thing']);
+    // with the duplicated entity-tag ternaries inside
+    // EventBuilder.buildArticleEvent (the buildArticleEvent test below
+    // pins the emitted tag per type, so a divergence fails there).
+    assert.deepEqual(ENTITY_TYPES.slice().sort(), ['case', 'organization', 'person', 'place', 'thing']);
     assert.equal(entityTypeToTag('person'),       'person');
     assert.equal(entityTypeToTag('organization'), 'org');
     assert.equal(entityTypeToTag('place'),        'place');
     assert.equal(entityTypeToTag('thing'),        'thing');
+    assert.equal(entityTypeToTag('case'),         'case');
     for (const type of ENTITY_TYPES) {
         assert.ok(ENTITY_ICONS[type], `ENTITY_ICONS must cover ${type}`);
+    }
+});
+
+test('entity: buildArticleEvent name-tags every entity type per entityTypeToTag', async () => {
+    resetState();
+    installEntityStorageBridge();   // buildArticleEvent reads Storage.entities
+
+    const refs = [];
+    for (const type of ENTITY_TYPES) {
+        const e = await EntityModel.create({ name: `${type} fixture`, type });
+        refs.push({ entity_id: e.id, context: 'about' });
+    }
+
+    const ev = await EventBuilder.buildArticleEvent(
+        { url: 'https://example.com/article', title: 'T', content: 'Body text.' },
+        refs,
+        'a'.repeat(64)
+    );
+
+    // The duplicated entity-tag ternaries inside buildArticleEvent must
+    // agree with entityTypeToTag for every type — a new type that only
+    // updates the map falls back to 'place' silently on the wire.
+    for (const type of ENTITY_TYPES) {
+        const expected = [entityTypeToTag(type), `${type} fixture`, 'about'];
+        const tag = ev.tags.find((t) => t[0] === expected[0] && t[1] === expected[1]);
+        assert.deepEqual(tag, expected, `kind-30023 name tag for entity type '${type}'`);
     }
 });

--- a/tests/evidence-linker.test.mjs
+++ b/tests/evidence-linker.test.mjs
@@ -1,4 +1,5 @@
-// Evidence linker tests — Phase 5 C4 (issue #16).
+// Evidence linker tests — Phase 5 C4 (issue #16); cross-source
+// repurpose in Phase 11.1 (docs/ASSESSMENTS_DESIGN.md).
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -26,8 +27,13 @@ globalThis.chrome = {
     }
 };
 
-const { EvidenceLinker, EVIDENCE_RELATIONSHIPS, generateEvidenceLinkId } =
-    await import('../src/shared/evidence-linker.js');
+const {
+    EvidenceLinker, EVIDENCE_RELATIONSHIPS,
+    EVIDENCE_RELATIONSHIP_LABELS, EVIDENCE_RELATIONSHIP_ICONS,
+    generateEvidenceLinkId
+} = await import('../src/shared/evidence-linker.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+const { buildClaimCoord } = await import('../src/shared/claim-ref.js');
 
 function resetState() { _stateStore.clear(); }
 
@@ -37,14 +43,23 @@ const A = 'claim_aaaaaaaaaaaaaaaa';
 const B = 'claim_bbbbbbbbbbbbbbbb';
 const C = 'claim_cccccccccccccccc';
 
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+
 // ---------------------------------------------------------------------
 
-test('evidence: deterministic id derivation', async () => {
+test('evidence: deterministic id derivation — directional vs symmetric', async () => {
     const idAB_supports = await generateEvidenceLinkId(A, B, 'supports');
     const idBA_supports = await generateEvidenceLinkId(B, A, 'supports');
     const idAB_contradicts = await generateEvidenceLinkId(A, B, 'contradicts');
-    assert.notEqual(idAB_supports, idBA_supports,      'direction matters');
-    assert.notEqual(idAB_supports, idAB_contradicts,   'relationship included in hash');
+    const idBA_contradicts = await generateEvidenceLinkId(B, A, 'contradicts');
+    const idAB_duplicates = await generateEvidenceLinkId(A, B, 'duplicates');
+    const idBA_duplicates = await generateEvidenceLinkId(B, A, 'duplicates');
+
+    assert.notEqual(idAB_supports, idBA_supports,        'supports is directional');
+    assert.equal(idAB_contradicts, idBA_contradicts,     'contradicts is symmetric — A↔B === B↔A');
+    assert.equal(idAB_duplicates, idBA_duplicates,       'duplicates is symmetric');
+    assert.notEqual(idAB_supports, idAB_contradicts,     'relationship included in hash');
     assert.match(idAB_supports, /^link_[0-9a-f]{16}$/);
 });
 
@@ -59,6 +74,8 @@ test('evidence: create + get round-trip', async () => {
     assert.match(link.id, /^link_[0-9a-f]{16}$/);
     assert.equal(link.relationship, 'supports');
     assert.equal(link.note, 'Cites the same study.');
+    assert.equal(link.suggested_by, 'user');
+    assert.equal(link.source_snapshot, null, 'fake ids have no registry snapshot');
     const fetched = await EvidenceLinker.get(link.id);
     assert.deepEqual(fetched, link);
 });
@@ -76,7 +93,26 @@ test('evidence: create is idempotent on same triple', async () => {
     assert.equal(second.note, '', 'idempotent create returns the EXISTING record (without new note)');
 });
 
-test('evidence: rejects self-link, invalid relationship, malformed claim ids', async () => {
+test('evidence: symmetric relationships collapse both creation directions', async () => {
+    resetState();
+    const ab = await EvidenceLinker.create({
+        source_claim_id: A, target_claim_id: B, relationship: 'contradicts', note: 'first'
+    });
+    const ba = await EvidenceLinker.create({
+        source_claim_id: B, target_claim_id: A, relationship: 'contradicts', note: 'second — ignored'
+    });
+    assert.equal(ab.id, ba.id, 'one logical contradiction, one record');
+    assert.equal(ba.note, 'first');
+    assert.equal(ab.source_claim_id, A, 'endpoints stored in sorted order');
+    assert.equal(ab.target_claim_id, B);
+
+    // Directional relationships still produce two distinct records.
+    const sup = await EvidenceLinker.create({ source_claim_id: A, target_claim_id: B, relationship: 'supports' });
+    const pus = await EvidenceLinker.create({ source_claim_id: B, target_claim_id: A, relationship: 'supports' });
+    assert.notEqual(sup.id, pus.id);
+});
+
+test('evidence: rejects self-link, invalid/legacy relationship, malformed refs', async () => {
     resetState();
     await assert.rejects(() => EvidenceLinker.create({
         source_claim_id: A, target_claim_id: A, relationship: 'supports'
@@ -85,11 +121,181 @@ test('evidence: rejects self-link, invalid relationship, malformed claim ids', a
         source_claim_id: A, target_claim_id: B, relationship: 'loves'
     }), /Invalid relationship/);
     await assert.rejects(() => EvidenceLinker.create({
+        source_claim_id: A, target_claim_id: B, relationship: 'contextualizes'
+    }), /Invalid relationship/, 'legacy contextualizes is read-only');
+    await assert.rejects(() => EvidenceLinker.create({
         source_claim_id: 'not-a-claim', target_claim_id: B, relationship: 'supports'
-    }), /must be a claim id/);
+    }), /must be a claim id or a 30040 coordinate/);
     await assert.rejects(() => EvidenceLinker.create({
         source_claim_id: '', target_claim_id: B, relationship: 'supports'
     }), /source_claim_id is required/);
+});
+
+test('evidence: cross-source links — coordinate endpoints and canonicalization', async () => {
+    resetState();
+    // A real local claim, published — so its coordinate collapses to
+    // the local id (claim-ref canonical rule).
+    const local = await ClaimModel.create({
+        text: 'Police dislocated my shoulder.', source_url: 'https://example.com/video-3'
+    });
+    await ClaimModel.markPublished(local.id, 'e'.repeat(64), PUBKEY_A);
+    const ourCoord = buildClaimCoord(PUBKEY_A, local.id);
+
+    // A foreign claim, referenced by coordinate with a snapshot.
+    const foreignCoord = buildClaimCoord(PUBKEY_B, 'their-claim-d');
+    const link = await EvidenceLinker.create({
+        source_claim_id: ourCoord,
+        target_claim_id: foreignCoord,
+        relationship: 'contradicts',
+        target_snapshot: { url: 'https://example.com/charges?utm_source=x', text: 'Charges: trespassing.' }
+    });
+
+    // Symmetric sort is deterministic: '30040:bbbb…' < 'claim_…', so
+    // the foreign coordinate lands in the source slot — and the
+    // snapshots must travel with their endpoints through the swap.
+    assert.equal(link.source_claim_id, foreignCoord, 'foreign coordinate stored as-is, sorted first');
+    assert.equal(link.target_claim_id, local.id, 'our coordinate collapsed to the local id');
+    assert.deepEqual(link.source_snapshot, {
+        url: 'https://example.com/charges',          // normalized
+        text: 'Charges: trespassing.',
+        author_pubkey: PUBKEY_B                       // backfilled from the coord
+    });
+    assert.deepEqual(link.target_snapshot, {
+        url: 'https://example.com/video-3',           // auto-filled from the registry
+        text: 'Police dislocated my shoulder.',
+        author_pubkey: PUBKEY_A
+    });
+
+    // Lookup by any representation of either endpoint finds it.
+    const byId      = await EvidenceLinker.getForClaim(local.id);
+    const byCoord   = await EvidenceLinker.getForClaim(ourCoord);
+    const byForeign = await EvidenceLinker.getForClaim(foreignCoord);
+    assert.deepEqual([byId.length, byCoord.length, byForeign.length], [1, 1, 1]);
+    assert.equal(byId[0].id, link.id);
+    assert.equal(byCoord[0].id, link.id);
+    assert.equal(byForeign[0].id, link.id);
+
+    // Malformed refs now throw (pre-11.1 returned [] for any string).
+    await assert.rejects(() => EvidenceLinker.getForClaim('not-a-ref'),
+        /must be a claim id or a 30040 coordinate/);
+
+    // deleteForClaim works by coordinate too.
+    assert.equal(await EvidenceLinker.deleteForClaim(foreignCoord), 1);
+    assert.deepEqual(await EvidenceLinker.getForClaim(local.id), []);
+});
+
+test('evidence: publish-boundary idempotency — link pre-publish, re-create by coordinate', async () => {
+    resetState();
+    const local = await ClaimModel.create({
+        text: 'We cooperated for 20 years.', source_url: 'https://example.com/video-4'
+    });
+    const foreignCoord = buildClaimCoord(PUBKEY_B, 'their-claim-d');
+
+    // Link while OUR claim is unpublished (ref = local id)…
+    const before = await EvidenceLinker.create({
+        source_claim_id: local.id, target_claim_id: foreignCoord,
+        relationship: 'contradicts', note: 'original'
+    });
+
+    // …then publish and re-create the same logical link by coordinate.
+    await ClaimModel.markPublished(local.id, 'e'.repeat(64), PUBKEY_A);
+    const after = await EvidenceLinker.create({
+        source_claim_id: buildClaimCoord(PUBKEY_A, local.id), target_claim_id: foreignCoord,
+        relationship: 'contradicts', note: 'should be ignored'
+    });
+    assert.equal(after.id, before.id, 'same record across the publish boundary');
+    assert.equal(after.note, 'original');
+});
+
+test('evidence: drift — coordinate-stored endpoints stay reachable once the claim gains publishedPubkey', async () => {
+    resetState();
+    const local = await ClaimModel.create({
+        text: 'Drifting claim.', source_url: 'https://example.com/video-5'
+    });
+    // Published pre-11.1 style: publishedAt recorded, but no pubkey —
+    // so the claim's own coordinate does NOT collapse yet.
+    await ClaimModel.markPublished(local.id, 'e'.repeat(64));
+    const ourCoord = buildClaimCoord(PUBKEY_A, local.id);
+    const foreignCoord = buildClaimCoord(PUBKEY_B, 'their-claim-d');
+
+    const link = await EvidenceLinker.create({
+        source_claim_id: ourCoord, target_claim_id: foreignCoord,
+        relationship: 'contradicts', note: 'keyed by coordinate',
+        source_snapshot: { url: 'https://example.com/video-5', text: 'Drifting claim.' }
+    });
+    assert.ok([link.source_claim_id, link.target_claim_id].includes(ourCoord),
+        'endpoint stored as a coordinate while the pubkey is unknown');
+
+    // The pubkey lands later (a republish) — the stored coordinate is
+    // now collapsible, and matching must canonicalize the STORED side
+    // too or the record is orphaned by both representations.
+    await ClaimModel.markPublished(local.id, 'f'.repeat(64), PUBKEY_A);
+    const byId    = await EvidenceLinker.getForClaim(local.id);
+    const byCoord = await EvidenceLinker.getForClaim(ourCoord);
+    assert.equal(byId.length, 1, 'reachable by local id after drift');
+    assert.equal(byCoord.length, 1, 'reachable by coordinate after drift');
+
+    // …and idempotent create must find the drifted record, not mint a
+    // duplicate for the same logical pair.
+    const again = await EvidenceLinker.create({
+        source_claim_id: local.id, target_claim_id: foreignCoord,
+        relationship: 'contradicts', note: 'should be ignored'
+    });
+    assert.equal(again.id, link.id, 'one logical link, one record — even after drift');
+    assert.equal(Object.keys(await EvidenceLinker.getAll()).length, 1);
+
+    // deleteForClaim must not orphan it either.
+    assert.equal(await EvidenceLinker.deleteForClaim(local.id), 1);
+});
+
+test('evidence: legacy contextualizes records normalize on read', async () => {
+    resetState();
+    // A pre-11.1 record written straight into storage: no suggested_by,
+    // no snapshots, legacy relationship value.
+    _stateStore.set('evidence_links', {
+        link_0123456789abcdef: {
+            id: 'link_0123456789abcdef',
+            source_claim_id: A,
+            target_claim_id: B,
+            relationship: 'contextualizes',
+            note: 'old link',
+            created: 100, updated: 100,
+            publishedAt: null, publishedEventId: null
+        }
+    });
+    const link = await EvidenceLinker.get('link_0123456789abcdef');
+    assert.equal(link.relationship, 'contextualizes', 'legacy records stay readable');
+    assert.equal(link.suggested_by, 'user', 'backfilled');
+    assert.equal(link.source_snapshot, null);
+    const forA = await EvidenceLinker.getForClaim(A);
+    assert.equal(forA.length, 1);
+
+    // getAll normalizes too.
+    const all = await EvidenceLinker.getAll();
+    assert.equal(all.link_0123456789abcdef.suggested_by, 'user');
+
+    // update is the one path that PERSISTS the normalized shape while
+    // patching the note and preserving the legacy relationship.
+    const updated = await EvidenceLinker.update('link_0123456789abcdef', { note: 'revised' });
+    assert.equal(updated.note, 'revised');
+    assert.equal(updated.relationship, 'contextualizes');
+    assert.equal(updated.suggested_by, 'user');
+    // Storage.set JSON-serializes values — parse the raw store entry.
+    const rawStored = _stateStore.get('evidence_links');
+    const stored = typeof rawStored === 'string' ? JSON.parse(rawStored) : rawStored;
+    assert.equal(stored.link_0123456789abcdef.suggested_by, 'user',
+        'normalized shape persisted to storage');
+
+    // markPublished returns the normalized record as well.
+    const marked = await EvidenceLinker.markPublished('link_0123456789abcdef', 'e'.repeat(64));
+    assert.equal(marked.suggested_by, 'user');
+});
+
+test('evidence: relationship label/icon maps cover the enum + legacy contextualizes', () => {
+    for (const r of [...EVIDENCE_RELATIONSHIPS, 'contextualizes']) {
+        assert.ok(EVIDENCE_RELATIONSHIP_LABELS[r], `label for ${r}`);
+        assert.ok(EVIDENCE_RELATIONSHIP_ICONS[r], `icon for ${r}`);
+    }
 });
 
 test('evidence: update patches note, preserves structural fields', async () => {
@@ -113,13 +319,13 @@ test('evidence: update patches note, preserves structural fields', async () => {
 test('evidence: getForClaim returns both source-side and target-side links', async () => {
     resetState();
     const ab_supports = await EvidenceLinker.create({ source_claim_id: A, target_claim_id: B, relationship: 'supports' });
-    const ab_context  = await EvidenceLinker.create({ source_claim_id: A, target_claim_id: B, relationship: 'contextualizes' });
+    const ab_updates  = await EvidenceLinker.create({ source_claim_id: A, target_claim_id: B, relationship: 'updates' });
     const ba_contra   = await EvidenceLinker.create({ source_claim_id: B, target_claim_id: A, relationship: 'contradicts' });
     const cb_support  = await EvidenceLinker.create({ source_claim_id: C, target_claim_id: B, relationship: 'supports' });
 
     const forA = await EvidenceLinker.getForClaim(A);
     const ids = forA.map((l) => l.id).sort();
-    assert.deepEqual(ids.sort(), [ab_supports.id, ab_context.id, ba_contra.id].sort());
+    assert.deepEqual(ids.sort(), [ab_supports.id, ab_updates.id, ba_contra.id].sort());
 });
 
 test('evidence: delete removes the specific link', async () => {
@@ -156,6 +362,6 @@ test('evidence: markPublished records publishedAt without bumping updated', asyn
 test('evidence: relationship enum is exhaustive', () => {
     assert.deepEqual(
         EVIDENCE_RELATIONSHIPS.slice().sort(),
-        ['contextualizes', 'contradicts', 'supports']
+        ['contradicts', 'duplicates', 'supports', 'updates']
     );
 });


### PR DESCRIPTION
## What this is

The first Phase 11 implementation slice, per the agreed design ([docs/ASSESSMENTS_DESIGN.md](../blob/claude/phase-11.1-assessment-model/docs/ASSESSMENTS_DESIGN.md), PR #37): **model + tests only** — no UI surfacing (11.3–11.5), no new wire kinds (11.2).

## What landed

- **`assessment-taxonomy.js`** — the `xray/assessment` label vocabulary (factual / consistency / fallacy / rhetorical / provenance, plus the custom-label escape hatch with a wire-safe token grammar), the −2..+2 stance scale, relationship directionality, and `suggested_by` validation.
- **`claim-ref.js`** — canonical claim references: local id for our claims, `30040:<pubkey>:<d>` coordinate for foreign ones. Coordinates of our own published claims collapse to the local id against an **append-only publishing-pubkey history** (re-keyed republish safe).
- **`assessment-model.js`** — one assessment per claim (`claim_assessments` key): stance + labels as orthogonal axes, per-label anchor/note/provenance, rationale, idempotent create across the publish boundary, coordinate backfill, `markPublished` without bumping `updated`.
- **`evidence-linker.js` repurposed cross-source** — endpoints take local ids or foreign coordinates; relationship enum is `contradicts / supports / updates / duplicates` (`contextualizes` is read-only legacy); symmetric relationships sort endpoints so A↔B ≡ B↔A; endpoint `{url, text, author}` snapshots; `suggested_by`.
- **Legacy kind-30043 publishing switched off** (behavior change, called out in CHANGELOG + JOURNAL): the reader batch no longer emits 30043s; the kind retires per the design and 30055 lands flag-gated in a later slice. Already-published 30043s stay on relays.
- **`ClaimModel.markPublished` records the publishing pubkey** (+ history) so published-claim coordinates stay recoverable.
- **`case` entity type** (🗂️) end to end: model, tag maps, article-event ternaries, side-panel chip/badge, tagger create button.

## Review provenance

Before this went up, an adversarial multi-agent review (correctness / integration / design-fidelity / test-quality lenses, each finding independently verified with probes against HEAD) confirmed 22 findings, all addressed here. The headline catch: **canonicalization is time-dependent** — a record keyed by a coordinate gets orphaned (and idempotency duplicates) once its claim later records a publishing pubkey. Fixed by canonicalizing the *stored* side at match time (one-storage-read snapshot canonicalizer) plus match-based create dedupe, with drift regression tests in both model suites.

## Gates

`npm run build` ✅ · **560/560 tests** (34 new) ✅ · `web-ext lint` ✅ (0 errors, same warnings as CI)

Next slice on approval: **11.2 — wire builders + NIP draft** (kind 30054 + 30055, `assessmentPublishing` flag, CHANGELOG/JOURNAL wire callouts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)