### PR TITLE
Phase 11.2 — Kind 30054/30055 wire builders + NIP draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Assessment + claim-relationship wire builders** (Phase 11.2;
+  **wire-format addition**, publishing stays off). `buildAssessmentEvent`
+  (kind `30054`: claim referenced by `a` coordinate, `d` recomputable from
+  it, stance −2..+2, NIP-32-style `L`/`l` labels under `xray/assessment`
+  with per-label anchor/note tags, mirrored about-entity `p` tags, the
+  claim's `r` verbatim + normalized `i`/`k`) and `buildClaimRelationshipEvent`
+  (kind `30055`: two `a`-coordinate endpoints with `source`/`target` markers,
+  symmetric relationships sort endpoints so A↔B republishes the same `d`)
+  + `parseRelationshipEvent`. Both publish paths are gated behind the new
+  **`assessmentPublishing` flag (default off)** — nothing is emitted yet;
+  this slice makes the local records publish-*ready*. `docs/NIP_DRAFT.md`
+  gains §30040 (claim), §30054, §30055, updated querying filters, and the
+  30051-vs-30054 delineation (formal ClaimReview vs personal judgment).
+
 - **Assessment data layer** (Phase 11.1; local-only, no UI yet — see
   `docs/ASSESSMENTS_DESIGN.md`). New `assessment-model.js` +
   `assessment-taxonomy.js`: register a personal judgment on any claim —
@@ -137,6 +151,11 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Removed
 
+- **`buildEvidenceLinkEvent` (kind `30043`) and the reader's dead
+  evidence-link publish loop** (Phase 11.2). Publishing was already switched
+  off in 11.1; this removes the builder and plumbing. Already-published
+  30043s stay on relays (NIP-09 cleanup remains a later phase); local link
+  records are untouched and republish as `30055` when the flag turns on.
 - **The "Migrate from userscript" Settings tab** and its importer
   (`shared/userscript-migration.js` + tests). The legacy
   `nostr-article-capture` userscript data import is no longer shipped.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,45 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-10 — Phase 11.2: kind 30054/30055 wire builders; 30043 builder deleted
+
+**Tags:** design, wire-format
+
+The wire-format slice (docs/ASSESSMENTS_DESIGN.md §wire; NIP_DRAFT.md gains
+§30040/§30054/§30055 + querying filters). Builders only — **nothing
+publishes yet**: both paths gate behind the new `assessmentPublishing`
+flag (default off), wired in the Phase 11 publish slice.
+
+**What landed:** `buildAssessmentEvent` (kind 30054) +
+`buildClaimRelationshipEvent`/`parseRelationshipEvent` (kind 30055) in the
+metadata-builders family ({event, body, dTag} contract);
+`buildEvidenceLinkEvent` (kind 30043) deleted along with the reader's dead
+link-publish loop and summary plumbing (publishing was gated off in 11.1,
+so this is pure code removal — no behavior change).
+
+Wire rules worth remembering:
+
+- **d-tags are recomputable from the `a` tags** — 30054's d hashes the
+  claim coordinate; 30055's hashes `coordA|coordB|relationship` with
+  endpoints (and their url/eventId bundles) sorted lexically for the
+  symmetric relationships. Local ids never hit the wire; the builders
+  throw on `claim_*` refs.
+- **`r` verbatim / `i` normalized:** both kinds mirror the target claim's
+  `r` value exactly (the `#r` join with 30040s, which publish raw URLs
+  today) and carry the normalized URL in the NIP-73 `i`/`k` pair. One
+  rule, stated in the design note's URL section.
+- **NIP-32 honesty:** `L`/`l` on a non-1985 kind are formally self-labels;
+  NIP_DRAFT §30054 defines them as applying to the `a`-referenced claim
+  (documented deviation), and the kind-1985 mirror is the designated
+  ecosystem-aggregation path (publish slice).
+- **builders.js stays chromeless:** it can't import claim-ref.js (which
+  pulls claim-model → storage.js, and storage.js dereferences
+  `chrome.storage.local` at module load — would break the shimless
+  metadata tests). It carries a local 10-line coordinate shape-parser
+  instead; claim-ref.js keeps the registry-aware canonicalization.
+
+---
+
 ## 2026-06-09 — Phase 11.1: assessment data layer; legacy 30043 publish retired
 
 **Tags:** design, wire-format

--- a/docs/NIP_DRAFT.md
+++ b/docs/NIP_DRAFT.md
@@ -6,7 +6,7 @@ Web Content Annotations, Fact-Checks, and Topic Trust
 
 `draft` `optional`
 
-This NIP defines five event kinds and one tag extension that together let users publish structured, anchored metadata about web content — annotations, fact-checks, ratings, topic-scoped trust assertions, and helpfulness votes — and lets readers query, rank, and surface that metadata in context.
+This NIP defines eight event kinds and one tag extension that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, and helpfulness votes — and lets readers query, rank, and surface that metadata in context.
 
 It composes with rather than replaces:
 
@@ -49,6 +49,35 @@ The recommended selector types, in order of robustness preference:
 4. `FragmentSelector` — for media fragments only: `xywh=...` for images, `t=Ns` for time offsets in audio/video.
 
 Authors SHOULD include multiple selectors. Consumers SHOULD try them in order and treat the first match with confidence ≥ 0.7 as the resolution. Annotations whose selectors do not resolve on the current page are NOT discarded; they are surfaced as page-level annotations with a "could not be located" indicator.
+
+## Kind 30040 — Claim
+
+Addressable. An atomized assertion extracted from web content: the claim text plus the real-world entities it concerns. This is the unit the assessment (30054) and relationship (30055) kinds target.
+
+```jsonc
+{
+  "kind": 30040,
+  "tags": [
+    ["d", "claim_<sha256(source_url + '|' + normalized_text).slice(0,16)>"],
+    ["r", "<source-url>"],
+    ["title", "<source title>"],
+    ["p", "<entity-pubkey>", "", "about"],     // one per entity the claim concerns
+    ["entity", "<entity name>", "about"],      // human-readable mirror per entity
+    ["p", "<source-pubkey>", "", "source"],    // who asserts it, when a quoted entity
+    ["source", "<who said it>"],               // entity name or free text
+    ["anchor", "<selector-json>"],             // W3C selector array for the exact span
+    ["key", "true"],                           // present only on key claims
+    ["client", "<client>"]
+  ],
+  "content": "<the claim text>"
+}
+```
+
+The `d` tag is deterministic over the verbatim (trimmed) source URL and the whitespace-collapsed, casefolded claim text, so re-publishing an edited claim's metadata replaces rather than duplicates, and two captures of the same quote from the same page-as-captured by the *same* author coincide. (URL variants — tracking parameters, trailing slashes — derive distinct `d`s; the reference implementation does not normalize the URL input here.) Note that two **different** authors who capture the same quote derive the same `d` under different pubkeys — those are distinct addressable events, and consumers MUST treat the full `30040:<pubkey>:<d>` coordinate as the claim's identity.
+
+The `p` tags carry the queryable signal: `{ "kinds": [30040], "#p": ["<entity-pubkey>"] }` returns everything the network claims about an entity. The 4th-position `about`/`source` markers distinguish the entity's role; `#p` filters match either, so role-sensitive consumers filter client-side.
+
+*Caveat for the kind registry:* `30040` has known third-party uses in the wild (NKBIP-01 curated publications). The reference implementation predates this NIP; a kind renumber is a pre-submission question, not a format one.
 
 ## Kind 30050 — Annotation
 
@@ -237,6 +266,75 @@ A user MAY publish a TopicTrust assertion encrypted to themselves (using [NIP-44
 
 Clients computing trust graphs SHOULD treat the absence of an assertion as neutral, NOT as distrust. A separate distrust primitive is out of scope for this NIP and should be modeled via [NIP-51](51.md) mute lists or [NIP-56](56.md) reports.
 
+## Kind 30054 — Assessment
+
+Addressable. A **personal judgment** on one claim (kind 30040): a graded stance and/or typed issue labels, with an optional rationale. One assessment per (author, claim) — the `d` tag hashes the claim's coordinate, so editing republishes the same `d` and replaces.
+
+This kind is deliberately distinct from kind 30051 (FactCheck): a FactCheck is a *formal review against a published truth scale* (Schema.org ClaimReview — interoperable with professional fact-checking tooling), keyed by claim text. An Assessment is a *personal agree/disagree judgment with issue labels*, keyed by claim coordinate (stable under claim-text edits). They are different aggregation signals; consumers MUST NOT merge them.
+
+```jsonc
+{
+  "kind": 30054,
+  "tags": [
+    ["d", "assess:<sha256(claim_coordinate).slice(0,16)>"],
+    ["a", "30040:<claim-author-pubkey>:<claim-d>", "<relay-hint>"],
+    ["e", "<claim-event-id>", "<relay-hint>"],
+    ["p", "<claim-author-pubkey>"],
+    ["r", "<claim-r-verbatim>"],
+    ["i", "<normalized-url>"], ["k", "web"],
+    ["stance", "-1"],
+    ["L", "xray/assessment"],
+    ["l", "misleading", "xray/assessment"],
+    ["l", "fallacy/strawman", "xray/assessment"],
+    ["label-anchor", "misleading", "<selector-json>"],
+    ["label-note", "misleading", "<short note>"],
+    ["p", "<about-entity-pubkey>", "", "about"],
+    ["suggested-by", "user"],
+    ["client", "<client>"]
+  ],
+  "content": "<markdown rationale>"
+}
+```
+
+- The `a` tag is the claim reference; the `d` MUST be recomputable as `assess:<sha256(a-tag value).slice(0,16)>`. The `e` tag is an optional pointer to a specific seen event. At least one of `stance` / `l` MUST be present.
+- **`stance`** is a discrete integer in −2..+2: −2 strongly disagree · −1 disagree · 0 unsure · +1 agree · +2 strongly agree. Omitted for label-only assessments.
+- **Labels** use the `L`/`l` structure with the `xray/assessment` namespace. Per NIP-32, `L`/`l` on a non-1985 kind are formally *self*-labels; this kind **defines** them as applying to the `a`-referenced claim (a documented deviation). Clients wanting plain-NIP-32 aggregation SHOULD also publish a kind-1985 mirror (`a`-targeted at the claim, same `L`/`l`). The standardized vocabulary: factual (`false`, `unsupported`, `misleading`, `cherry-picked`, `missing-context`, `outdated`), consistency (`contradicts-prior-statement`, `flip-flop`, `moved-goalposts`), fallacy (`fallacy/strawman`, `fallacy/ad-hominem`, `fallacy/false-dilemma`, `fallacy/whataboutism`, `fallacy/circular`, `fallacy/slippery-slope`, `fallacy/appeal-to-authority`, `fallacy/appeal-to-consequences`), rhetorical (`loaded-language`, `unfalsifiable`, `ambiguous`, `euphemism`), provenance (`undisclosed-interest`). Other values are valid custom labels if they match the token grammar (lowercase `a-z0-9-`, at most one `/` namespace segment, ≤ 64 chars). At most one `l` per label value.
+- **`label-anchor`** / **`label-note`** enrich a label with the offending span (a W3C selector array, JSON, as in the 30040 `anchor` tag — a deviation from the content-borne selectors of 30050/30051, since `content` here is human-readable markdown) and a short note, keyed by the label value in slot 1.
+- **`r` carries the claim's `r` value verbatim** (the per-URL join key with the 30040); `i`/`k` carry the normalized NIP-73 form. Consumers joining assessments to claims by URL SHOULD use `#r`; consumers needing the canonical URL use `i`.
+- **About-entity `p` tags are mirrored from the claim** (4th-position marker `about`) so a single `{"kinds":[30040,30054],"#p":[entity]}` filter returns an entity's claims and their assessments together. The unmarked `p` is the claim's author (the kind-9803 idiom).
+- **`suggested-by`** is `user` or `llm:<model>` — provenance for machine-suggested judgments.
+- `stance`, `label-anchor`, `label-note`, and `suggested-by` are multi-letter tags and therefore not relay-indexed; all standard queries for this kind filter on `#a` / `#r` / `#p` / `#l` + `kinds`, with stance filtering client-side.
+
+## Kind 30055 — ClaimRelationship
+
+Addressable. A typed link between two claims — the cross-source contradiction tracker.
+
+```jsonc
+{
+  "kind": 30055,
+  "tags": [
+    ["d", "rel:<sha256(coordA + '|' + coordB + '|' + relationship).slice(0,16)>"],
+    ["a", "30040:<author-A>:<d-A>", "<relay-hint>", "source"],
+    ["a", "30040:<author-B>:<d-B>", "<relay-hint>", "target"],
+    ["e", "<event-id-A>", "", "source"],
+    ["e", "<event-id-B>", "", "target"],
+    ["relationship", "contradicts"],
+    ["r", "<claim-A-r-verbatim>"],
+    ["r", "<claim-B-r-verbatim>"],
+    ["i", "<normalized-url-A>"], ["i", "<normalized-url-B>"], ["k", "web"],
+    ["suggested-by", "user"],
+    ["client", "<client>"]
+  ],
+  "content": "<note>"
+}
+```
+
+- `relationship` MUST be one of: `contradicts`, `supports`, `updates`, `duplicates`.
+- **`contradicts` and `duplicates` are symmetric**: the two coordinates MUST be sorted lexically — both in the `d` hash and in `a`-tag order — so the same logical link republishes the same `d` regardless of creation direction, and the `source`/`target` markers carry no meaning. **`supports` and `updates` are directional** (source → target) and hash in semantic order.
+- The `d` MUST be recomputable from the two `a` tags + `relationship`. The 4th-position markers on `a`/`e` follow the same role-marker idiom as `p` tags elsewhere in this NIP.
+- `r` tags carry each claim's `r` verbatim, `i` tags the normalized forms (values deduplicated when both claims share a URL); one `k` = `web` accompanies them. Relationship events anchor to the claims (via `a`), not to pages — the URL tags exist for `#r`-join convenience and MAY be omitted when an endpoint's URL is unknown.
+- Surfacing rule: a `contradicts` link SHOULD surface a warning indicator on **both** claims wherever they render.
+
 ## Kind 30023 — `responds-to` tag (extension)
 
 A long-form article (kind 30023) MAY declare that it responds to one or more other pieces of content. Each response is a separate `responds-to` tag:
@@ -267,7 +365,7 @@ A client wishing to display all metadata for a URL SHOULD issue these filters in
 
 ```jsonc
 [
-  { "kinds": [30050, 30051, 30052], "#r": ["<url>"], "limit": 200 },
+  { "kinds": [30040, 30050, 30051, 30052, 30054, 30055], "#r": ["<url>"], "limit": 200 },
   { "kinds": [9802], "#r": ["<url>"], "limit": 100 },
   { "kinds": [1111], "#i": ["<url>"], "limit": 200 },
   { "kinds": [1985], "#r": ["<url>"], "limit": 100 },
@@ -278,6 +376,14 @@ A client wishing to display all metadata for a URL SHOULD issue these filters in
 ```
 
 The kind 30023 query catches articles published with `responds-to`; clients filter client-side to those with a matching `responds-to` tag.
+
+Other standard queries:
+
+```jsonc
+{ "kinds": [30040, 30054], "#p": ["<entity-pubkey>"], "limit": 200 }   // claims about an entity + their assessments
+{ "kinds": [30054, 30055], "#a": ["30040:<pubkey>:<d>"], "limit": 100 } // judgments + links targeting one claim
+{ "kinds": [30054], "#l": ["misleading"], "limit": 100 }                // everything labeled `misleading`
+```
 
 A client wishing to display helpfulness aggregates for a set of metadata events SHOULD then issue a follow-up `#a` query against kind 9803 keyed by the addressable coordinates of those events.
 
@@ -294,5 +400,5 @@ This NIP does not specify a ranking algorithm. Recommended approaches:
 
 ## Reference implementations
 
-- [x-ray browser extension](https://github.com/bryanmatthewsimonson/xray) — Phase 9, currently shipping kinds 30050 + the `responds-to` extension; remaining kinds scaffolded.
+- [x-ray browser extension](https://github.com/bryanmatthewsimonson/xray) — shipping kinds 30040 + 30050 + the `responds-to` extension; 30054/30055 builders implemented with publishing flag-gated (Phase 11); remaining kinds scaffolded.
 - *(second client, TBD pre-merge)*

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1391,14 +1391,8 @@ async function publish() {
     // published + unchanged claims).
     const relationshipsToPublish = await resolveRelationshipsToPublish(claimsToPublish, state.article.url);
 
-    // Claim links: the legacy kind-30043 publish path is retired
-    // (Phase 11.1) — this always resolves to [] until the kind-30055
-    // path lands behind the assessmentPublishing flag.
-    const linksToPublish = await resolveEvidenceLinksToPublish();
-
     const totalEvents = 1 + commentList.length + entitiesToPublish.length
-                          + claimsToPublish.length + relationshipsToPublish.length
-                          + linksToPublish.length;
+                          + claimsToPublish.length + relationshipsToPublish.length;
 
     // Per-relay rollup across the entire batch.
     const relayStats = new Map(); // url → { ok, fail, lastError }
@@ -1427,7 +1421,7 @@ async function publish() {
 
         btn.textContent = 'Signing…';
         toast(totalEvents > 1
-            ? buildPublishStartMessage(commentList.length, entitiesToPublish.length, claimsToPublish.length, relationshipsToPublish.length, linksToPublish.length)
+            ? buildPublishStartMessage(commentList.length, entitiesToPublish.length, claimsToPublish.length, relationshipsToPublish.length)
             : 'Approving signature in your NOSTR extension…', 'warning', 5000);
 
         setProgress(0, totalEvents);
@@ -1723,48 +1717,9 @@ async function publish() {
             if (i < relationshipsToPublish.length - 1) await sleep(BATCH_PUBLISH_DELAY_MS);
         }
 
-        // ---- Evidence links (kind-30043) ------------------------------
-        // Signed by the user. `buildEvidenceLinkEvent` needs the full
-        // claim registry to resolve source + target claim ids to their
-        // source_urls (for `r` tags) — pass the dict we already have
-        // on `allArticleClaims` keyed by id, plus any missing ones
-        // pulled from ClaimModel.
-        const linkBatchBase = relBatchBase + relationshipsToPublish.length;
-        const linkResults = { ok: 0, fail: 0, errors: [] };
-        const claimsDict = {};
-        for (const c of allArticleClaims) claimsDict[c.id] = c;
-        for (let i = 0; i < linksToPublish.length; i++) {
-            const link = linksToPublish[i];
-            btn.textContent = `Publishing (${linkBatchBase + i + 1}/${totalEvents})…`;
-            try {
-                const unsigned = await EventBuilder.buildEvidenceLinkEvent(link, claimsDict, userPubkey);
-                const resp = await browserApi.runtime.sendMessage({
-                    type:  'xray:capture:publish',
-                    id:    state.id,
-                    event: unsigned
-                });
-                if (resp && resp.ok && resp.results) {
-                    recordRelayResults(resp.results);
-                    if (resp.results.successful > 0) {
-                        linkResults.ok++;
-                        try { await EvidenceLinker.markPublished(link.id, resp.signedEvent?.id || null); }
-                        catch (_) { /* best-effort */ }
-                    } else {
-                        linkResults.fail++;
-                        linkResults.errors.push(`${link.relationship} link: no relays accepted`);
-                    }
-                } else {
-                    linkResults.fail++;
-                    linkResults.errors.push(`${link.relationship} link: ${(resp && resp.error) || 'unknown'}`);
-                }
-            } catch (err) {
-                linkResults.fail++;
-                linkResults.errors.push(`${link.relationship} link: ${err.message || String(err)}`);
-                console.warn('[X-Ray Reader] evidence-link publish failed:', link.id, err);
-            }
-            setProgress(linkBatchBase + i + 1, totalEvents);
-            if (i < linksToPublish.length - 1) await sleep(BATCH_PUBLISH_DELAY_MS);
-        }
+        // (Claim-link publishing: the legacy kind-30043 batch was retired
+        // in Phase 11.1; the kind-30055 path lands behind the
+        // assessmentPublishing flag in the Phase 11 publish slice.)
 
         // Build + surface the end-of-batch summary.
         showPublishSummary({
@@ -1778,8 +1733,6 @@ async function publish() {
             claimCount: claimsToPublish.length,
             relationshipResults,
             relationshipCount: relationshipsToPublish.length,
-            linkResults,
-            linkCount: linksToPublish.length,
             relayStats
         });
 
@@ -1870,18 +1823,6 @@ function collectClaimEntityIds(claims) {
     return ids;
 }
 
-/**
- * Phase 11.1: the legacy kind-30043 evidence-link publish path is
- * RETIRED (docs/ASSESSMENTS_DESIGN.md — "30043 retires"). Link records
- * stay local-only until the cross-source kind-30055 publish path lands
- * behind the `assessmentPublishing` flag (Phase 11 publish slice);
- * already-published 30043s stay on relays per the standing NIP-09
- * posture. Returning [] keeps the batch flow untouched — every count
- * downstream guards on `> 0`.
- */
-async function resolveEvidenceLinksToPublish() {
-    return [];
-}
 
 /**
  * For every claim, enumerate the (entity, relationshipType, claimId)
@@ -1943,14 +1884,13 @@ async function getConfiguredRelays() {
  * what's about to happen. Pluralizes correctly and only mentions
  * parts that actually exist.
  */
-function buildPublishStartMessage(commentCount, entityCount, claimCount = 0, relationshipCount = 0, linkCount = 0) {
+function buildPublishStartMessage(commentCount, entityCount, claimCount = 0, relationshipCount = 0) {
     const parts = ['article'];
     if (commentCount > 0)      parts.push(`${commentCount} comment${commentCount === 1 ? '' : 's'}`);
     if (entityCount > 0)       parts.push(`${entityCount} entity profile${entityCount === 1 ? '' : 's'}`);
     if (claimCount > 0)        parts.push(`${claimCount} claim${claimCount === 1 ? '' : 's'}`);
     if (relationshipCount > 0) parts.push(`${relationshipCount} relationship${relationshipCount === 1 ? '' : 's'}`);
-    if (linkCount > 0)         parts.push(`${linkCount} evidence link${linkCount === 1 ? '' : 's'}`);
-    const total = 1 + commentCount + entityCount + claimCount + relationshipCount + linkCount;
+    const total = 1 + commentCount + entityCount + claimCount + relationshipCount;
     return `Publishing ${total} events (${parts.join(' + ')})…`;
 }
 
@@ -1963,7 +1903,6 @@ function showPublishSummary({
     includeComments, totalEvents, articleResults,
     commentResults, entityResults, entityCount,
     claimResults, claimCount, relationshipResults, relationshipCount,
-    linkResults, linkCount,
     relayStats
 }) {
     // Console breakdown (always useful for debugging)
@@ -1973,7 +1912,6 @@ function showPublishSummary({
     if (entityResults && entityCount > 0)                    console.log('entities:',       entityResults);
     if (claimResults  && claimCount  > 0)                    console.log('claims:',         claimResults);
     if (relationshipResults && relationshipCount > 0)        console.log('relationships:',  relationshipResults);
-    if (linkResults && linkCount > 0)                        console.log('evidence links:', linkResults);
     console.log('per relay:', Object.fromEntries(relayStats));
     console.groupEnd();
 
@@ -1986,7 +1924,6 @@ function showPublishSummary({
     const cmtFails  = (commentResults      && commentResults.fail)      || 0;
     const clmFails  = (claimResults        && claimResults.fail)        || 0;
     const relFails  = (relationshipResults && relationshipResults.fail) || 0;
-    const linkFails = (linkResults         && linkResults.fail)         || 0;
 
     const segments = [];
     segments.push(articleResults.successful > 0
@@ -2004,9 +1941,6 @@ function showPublishSummary({
     if (relationshipCount > 0) {
         segments.push(`${relationshipResults.ok}/${relationshipResults.ok + relationshipResults.fail} relationship${relationshipCount === 1 ? '' : 's'}`);
     }
-    if (linkCount > 0) {
-        segments.push(`${linkResults.ok}/${linkResults.ok + linkResults.fail} evidence link${linkCount === 1 ? '' : 's'}`);
-    }
     let line = 'Published: ' + segments.join(', ') + '.';
 
     const acceptedAll = [...relayStats.values()].filter((s) => s.fail === 0 && s.ok > 0).length;
@@ -2019,7 +1953,7 @@ function showPublishSummary({
         line += ` Rejected by ${names} — consider removing in Options.`;
     }
 
-    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0 || linkFails > 0;
+    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0;
     const level = (anyFail || articleResults.successful === 0)
         ? (articleResults.successful > 0 ? 'warning' : 'error')
         : 'success';
@@ -2037,7 +1971,7 @@ function showPublishSummary({
             : 'X-Ray: Publish complete';
     notify(notifyTitle, line, level);
 
-    return totalEvents - cmtFails - entFails - clmFails - relFails - linkFails
+    return totalEvents - cmtFails - entFails - clmFails - relFails
                        - (articleResults.successful === 0 ? 1 : 0);
 }
 

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -633,30 +633,10 @@ export const EventBuilder = {
     };
   },
 
-  // Build kind 30043 evidence link event
-  buildEvidenceLinkEvent: async (link, allClaims, userPubkey) => {
-    const sourceClaim = allClaims[link.source_claim_id];
-    const targetClaim = allClaims[link.target_claim_id];
-
-    const tags = [
-      ['d', link.id],
-      ['source-claim', link.source_claim_id],
-      ['target-claim', link.target_claim_id],
-      ['relationship', link.relationship],
-      ['client', 'xray']
-    ];
-
-    if (sourceClaim?.source_url) tags.push(['r', sourceClaim.source_url]);
-    if (targetClaim?.source_url) tags.push(['r', targetClaim.source_url]);
-
-    return {
-      kind: 30043,
-      pubkey: userPubkey,
-      created_at: Math.floor(Date.now() / 1000),
-      tags,
-      content: link.note || ''
-    };
-  },
+  // (Kind-30043 evidence links: builder deleted in Phase 11.2 — the
+  // kind is retired per docs/ASSESSMENTS_DESIGN.md. Cross-source claim
+  // relationships publish as kind 30055 via
+  // metadata/builders.buildClaimRelationshipEvent, flag-gated.)
 
   // ─── Archive Reader: Relay Retrieval ───
 

--- a/src/shared/evidence-linker.js
+++ b/src/shared/evidence-linker.js
@@ -67,6 +67,52 @@ export const EVIDENCE_RELATIONSHIP_ICONS = {
 };
 
 // ------------------------------------------------------------------
+// Wire parse — kind 30055 (Phase 11.2)
+// ------------------------------------------------------------------
+
+/**
+ * Parse a foreign kind-30055 ClaimRelationship event into a
+ * display-ready object (the parseClaimEvent sibling — pure; no DOM,
+ * no storage). Endpoints come from the `a` tags' `source`/`target`
+ * markers, falling back to tag order; for symmetric relationships the
+ * markers carry no meaning. Returns null for anything that isn't a
+ * kind-30055 event.
+ *
+ * @param {{kind?: number, tags?: Array, content?: string, pubkey?: string, created_at?: number, id?: string}} event
+ * @returns {{id, relationship, source: {coord, eventId}, target: {coord, eventId}, note, suggestedBy, urls: string[], pubkey, created_at} | null}
+ */
+export function parseRelationshipEvent(event) {
+    if (!event || event.kind !== 30055) return null;
+    const tags = event.tags || [];
+    const first = (name) => { const t = tags.find((x) => x[0] === name); return t ? t[1] : ''; };
+    // Positional fallback applies only to UNMARKED tags — a lone tag
+    // carrying the opposite marker must not be misattributed (e.g. a
+    // link with only a target event id).
+    const marked = (name, marker, fallbackIndex) => {
+        const list = tags.filter((x) => x[0] === name);
+        const hit = list.find((x) => x[3] === marker);
+        if (hit) return hit;
+        const fallback = list[fallbackIndex];
+        return (fallback && !fallback[3]) ? fallback : null;
+    };
+    const srcA = marked('a', 'source', 0);
+    const tgtA = marked('a', 'target', 1);
+    const srcE = marked('e', 'source', 0);
+    const tgtE = marked('e', 'target', 1);
+    return {
+        id:           first('d') || (event.id || ''),
+        relationship: first('relationship'),
+        source:       { coord: (srcA && srcA[1]) || '', eventId: (srcE && srcE[1]) || null },
+        target:       { coord: (tgtA && tgtA[1]) || '', eventId: (tgtE && tgtE[1]) || null },
+        note:         event.content || '',
+        suggestedBy:  first('suggested-by') || 'user',
+        urls:         tags.filter((x) => x[0] === 'r').map((x) => x[1]),
+        pubkey:       event.pubkey || '',
+        created_at:   event.created_at || 0
+    };
+}
+
+// ------------------------------------------------------------------
 // ID derivation
 // ------------------------------------------------------------------
 

--- a/src/shared/metadata/builders.js
+++ b/src/shared/metadata/builders.js
@@ -11,6 +11,10 @@
 //   - Kind 30053 (TopicTrust)              — buildTopicTrustEvent (lives
 //     in topic-trust-builder.js so the trust-tab can import without
 //     pulling in the rest of this module)
+//   - Kind 30054 (Assessment)              — buildAssessmentEvent (gated;
+//     Phase 11.2, docs/ASSESSMENTS_DESIGN.md)
+//   - Kind 30055 (ClaimRelationship)       — buildClaimRelationshipEvent
+//     (gated; Phase 11.2 — replaces the retired kind 30043)
 //
 // Plus: `buildRespondsToTag()` — the kind 30023 extension tag.
 //
@@ -27,6 +31,10 @@
 // the spec's tag table verbatim.
 
 import { normalize } from './url-normalizer.js';
+import {
+  ASSESSMENT_LABEL_NAMESPACE, isValidLabel, isValidStance,
+  isValidSuggestedBy, CLAIM_RELATIONSHIPS, isSymmetricRelationship
+} from '../assessment-taxonomy.js';
 
 // ------------------------------------------------------------------
 // Common helpers
@@ -400,6 +408,270 @@ export function buildHelpfulnessEvent({
     event: { kind: 9803, created_at: createdAt, tags, content: String(rationale || '') },
     body: String(rationale || ''),
     dTag: null    // 9803 is regular, not addressable
+  };
+}
+
+// ------------------------------------------------------------------
+// Assessment — kind 30054 (Phase 11.2; publish flag-gated)
+// ------------------------------------------------------------------
+
+/**
+ * Shape-validate + split a `30040:<pubkey>:<d>` claim coordinate.
+ * Deliberately local: claim-ref.js owns the registry-aware
+ * canonicalization, but importing it would drag storage.js (which
+ * dereferences chrome at module load) into this chromeless module.
+ * The coordinate format is frozen NIP-01; only the first two colons
+ * delimit (foreign d-tags may contain colons).
+ */
+function parseClaimCoordinate(coord) {
+  if (typeof coord !== 'string') return null;
+  const first = coord.indexOf(':');
+  if (first === -1) return null;
+  const second = coord.indexOf(':', first + 1);
+  if (second === -1) return null;
+  const kind   = coord.slice(0, first);
+  const pubkey = coord.slice(first + 1, second);
+  const d      = coord.slice(second + 1);
+  if (kind !== '30040') return null;
+  if (!/^[0-9a-f]{64}$/.test(pubkey)) return null;
+  if (!d) return null;
+  return { pubkey, d };
+}
+
+function assertClaimCoordinate(coord, fnName, argName) {
+  const parsed = parseClaimCoordinate(coord);
+  if (!parsed) {
+    throw new Error(`${fnName}: ${argName} must be a 30040:<pubkey>:<d> coordinate (local claim ids never hit the wire)`);
+  }
+  return parsed;
+}
+
+/**
+ * Normalize + validate a labels array (strings or
+ * `{label, anchor?, note?}` objects) against the taxonomy grammar.
+ * One entry per label value — `label-anchor` / `label-note` tags are
+ * keyed by the label, so duplicates would be unmatchable on read.
+ */
+function cleanWireLabels(labels, fnName) {
+  if (labels === undefined || labels === null) return [];
+  if (!Array.isArray(labels)) throw new Error(`${fnName}: labels must be an array`);
+  const seen = new Set();
+  const out = [];
+  for (const entry of labels) {
+    const rec = typeof entry === 'string' ? { label: entry } : (entry || {});
+    if (!isValidLabel(rec.label)) throw new Error(`${fnName}: invalid label: ${rec.label}`);
+    if (seen.has(rec.label)) throw new Error(`${fnName}: duplicate label: ${rec.label}`);
+    seen.add(rec.label);
+    out.push({ label: rec.label, anchor: rec.anchor || null, note: rec.note || '' });
+  }
+  return out;
+}
+
+function assertSuggestedBy(value, fnName) {
+  const v = value === undefined || value === null ? 'user' : value;
+  if (!isValidSuggestedBy(v)) {
+    throw new Error(`${fnName}: suggestedBy must be 'user' or 'llm:<model>' (got ${v})`);
+  }
+  return v;
+}
+
+function assertEventIdOrNull(value, fnName, argName) {
+  if (value === undefined || value === null || value === '') return null;
+  if (!/^[0-9a-f]{64}$/.test(value)) {
+    throw new Error(`${fnName}: ${argName} must be a 64-hex event id (got ${value})`);
+  }
+  return value;
+}
+
+/**
+ * Build an unsigned kind 30054 Assessment event — a personal judgment
+ * on one claim (NIP draft §30054): graded stance −2..+2 and/or typed
+ * labels under the `xray/assessment` namespace, each label optionally
+ * anchored to the offending span.
+ *
+ * Wire rules (docs/ASSESSMENTS_DESIGN.md):
+ *   - the claim is referenced by `a` coordinate (+ optional `e`) —
+ *     LOCAL IDS NEVER HIT THE WIRE; `d` = assess:<sha16(coord)> is
+ *     recomputable from the `a` tag, so edits replace (NIP-01).
+ *   - `r` mirrors the claim's `r` VERBATIM (the per-URL join key);
+ *     `i`/`k` carry the normalized NIP-73 form.
+ *   - `L`/`l` here are formally NIP-32 *self*-labels; §30054 defines
+ *     them as applying to the `a`-referenced claim, and the kind-1985
+ *     mirror (publish slice) is the ecosystem-aggregation path.
+ *   - about-entity `p` tags are mirrored from the claim so one
+ *     `{kinds:[30040,30054], "#p":[entity]}` filter pulls both.
+ *
+ * @param {object} args
+ * @param {string} args.claimCoord          — `30040:<pubkey>:<d>` (required)
+ * @param {string} args.claimUrl            — the claim's `r` value, verbatim (required)
+ * @param {string} [args.claimEventId]      — specific event id for the `e` tag
+ * @param {string} [args.relayHint]
+ * @param {number|null} [args.stance]       — integer −2..2, or null (label-only)
+ * @param {Array<string|{label,anchor,note}>} [args.labels]
+ * @param {string} [args.rationale]         — markdown, becomes `content`
+ * @param {Array<string>} [args.aboutPubkeys] — entity pubkeys mirrored from the claim
+ * @param {string} [args.suggestedBy='user'] — 'user' | 'llm:<model>'
+ * @param {number} [args.createdAt]
+ * @returns {Promise<{event, body, dTag}>}
+ */
+export async function buildAssessmentEvent({
+  claimCoord,
+  claimUrl,
+  claimEventId = null,
+  relayHint = '',
+  stance = null,
+  labels = [],
+  rationale = '',
+  aboutPubkeys = [],
+  suggestedBy = 'user',
+  createdAt = nowSeconds()
+} = {}) {
+  const coord = assertClaimCoordinate(claimCoord, 'buildAssessmentEvent', 'claimCoord');
+  const eventId = assertEventIdOrNull(claimEventId, 'buildAssessmentEvent', 'claimEventId');
+  if (typeof claimUrl !== 'string' || !claimUrl) {
+    throw new Error('buildAssessmentEvent: claimUrl required (the claim\'s r value, verbatim)');
+  }
+  if (stance !== null && stance !== undefined && !isValidStance(stance)) {
+    throw new Error(`buildAssessmentEvent: stance must be an integer -2..2 or null (got ${stance})`);
+  }
+  const labelList = cleanWireLabels(labels, 'buildAssessmentEvent');
+  if ((stance === null || stance === undefined) && labelList.length === 0) {
+    throw new Error('buildAssessmentEvent: an assessment needs a stance or at least one label');
+  }
+  const provenance = assertSuggestedBy(suggestedBy, 'buildAssessmentEvent');
+  const about = uniqueStrings(arrayify(aboutPubkeys));
+  for (const pk of about) {
+    if (!/^[0-9a-f]{64}$/.test(pk)) {
+      throw new Error(`buildAssessmentEvent: aboutPubkeys entries must be 64-hex pubkeys (got ${pk})`);
+    }
+  }
+
+  const dTag = 'assess:' + (await sha16(claimCoord));
+
+  const tags = [
+    tag('d', dTag),
+    tag('a', claimCoord, relayHint)
+  ];
+  if (eventId) tags.push(tag('e', eventId, relayHint));
+  tags.push(tag('p', coord.pubkey));
+  tags.push(tag('r', claimUrl));                       // verbatim — joins with the 30040
+  tags.push(tag('i', normalize(claimUrl)));            // NIP-73, normalization-stable
+  tags.push(tag('k', 'web'));
+  if (stance !== null && stance !== undefined) tags.push(tag('stance', String(stance)));
+  if (labelList.length > 0) {
+    tags.push(tag('L', ASSESSMENT_LABEL_NAMESPACE));
+    for (const l of labelList) tags.push(tag('l', l.label, ASSESSMENT_LABEL_NAMESPACE));
+    for (const l of labelList) {
+      if (l.anchor) tags.push(tag('label-anchor', l.label, JSON.stringify(l.anchor)));
+      if (l.note)   tags.push(tag('label-note', l.label, l.note));
+    }
+  }
+  for (const pk of about) tags.push(tag('p', pk, '', 'about'));
+  tags.push(tag('suggested-by', provenance));
+  tags.push(tag('client', 'xray'));
+
+  const body = String(rationale || '');
+  return {
+    event: { kind: 30054, created_at: createdAt, tags, content: body },
+    body,
+    dTag
+  };
+}
+
+// ------------------------------------------------------------------
+// ClaimRelationship — kind 30055 (Phase 11.2; publish flag-gated)
+// ------------------------------------------------------------------
+
+/**
+ * Build an unsigned kind 30055 ClaimRelationship event — a typed link
+ * between two claims (NIP draft §30055), replacing the retired kind
+ * 30043.
+ *
+ * Wire rules (docs/ASSESSMENTS_DESIGN.md):
+ *   - both endpoints are `a` coordinates with `source`/`target`
+ *     markers in slot 4 (the repo's `['p', pk, '', role]` idiom);
+ *     local ids never hit the wire.
+ *   - symmetric relationships (`contradicts`, `duplicates`) sort the
+ *     two coordinates lexically before hashing AND in tag order, so
+ *     A↔B and B↔A republish the same `d` and replace; the markers
+ *     carry no meaning for them. `supports`/`updates` are directional.
+ *   - `d` = rel:<sha16(coordA|coordB|relationship)> MUST be
+ *     recomputable from the `a` tags + `relationship`.
+ *   - per endpoint: `r` verbatim + `i` normalized (deduped when the
+ *     two claims share a URL), one `k`=web.
+ *
+ * @param {object} args
+ * @param {string} args.sourceCoord / args.targetCoord — `30040:…` (required)
+ * @param {string} args.relationship — contradicts|supports|updates|duplicates
+ * @param {string} [args.sourceUrl] / [args.targetUrl] — claim `r` values, verbatim
+ * @param {string} [args.sourceEventId] / [args.targetEventId]
+ * @param {string} [args.sourceRelayHint] / [args.targetRelayHint]
+ * @param {string} [args.note]            — becomes `content`
+ * @param {string} [args.suggestedBy='user']
+ * @param {number} [args.createdAt]
+ * @returns {Promise<{event, body, dTag}>}
+ */
+export async function buildClaimRelationshipEvent({
+  sourceCoord,
+  targetCoord,
+  relationship,
+  sourceUrl = '',
+  targetUrl = '',
+  sourceEventId = null,
+  targetEventId = null,
+  sourceRelayHint = '',
+  targetRelayHint = '',
+  note = '',
+  suggestedBy = 'user',
+  createdAt = nowSeconds()
+} = {}) {
+  assertClaimCoordinate(sourceCoord, 'buildClaimRelationshipEvent', 'sourceCoord');
+  assertClaimCoordinate(targetCoord, 'buildClaimRelationshipEvent', 'targetCoord');
+  if (!CLAIM_RELATIONSHIPS.includes(relationship)) {
+    throw new Error(`buildClaimRelationshipEvent: relationship must be one of ${CLAIM_RELATIONSHIPS.join(', ')} (got ${relationship})`);
+  }
+  if (sourceCoord === targetCoord) {
+    throw new Error('buildClaimRelationshipEvent: cannot link a claim to itself');
+  }
+  const provenance = assertSuggestedBy(suggestedBy, 'buildClaimRelationshipEvent');
+
+  // Bundle each endpoint so the symmetric sort swaps everything together.
+  let src = {
+    coord: sourceCoord, url: sourceUrl, hint: sourceRelayHint,
+    eventId: assertEventIdOrNull(sourceEventId, 'buildClaimRelationshipEvent', 'sourceEventId')
+  };
+  let tgt = {
+    coord: targetCoord, url: targetUrl, hint: targetRelayHint,
+    eventId: assertEventIdOrNull(targetEventId, 'buildClaimRelationshipEvent', 'targetEventId')
+  };
+  if (isSymmetricRelationship(relationship) && tgt.coord < src.coord) {
+    [src, tgt] = [tgt, src];
+  }
+
+  const dTag = 'rel:' + (await sha16(`${src.coord}|${tgt.coord}|${relationship}`));
+
+  const tags = [
+    tag('d', dTag),
+    tag('a', src.coord, src.hint, 'source'),
+    tag('a', tgt.coord, tgt.hint, 'target')
+  ];
+  if (src.eventId) tags.push(tag('e', src.eventId, '', 'source'));
+  if (tgt.eventId) tags.push(tag('e', tgt.eventId, '', 'target'));
+  tags.push(tag('relationship', relationship));
+  const urls = uniqueStrings([src.url, tgt.url]);
+  for (const u of urls) tags.push(tag('r', u));                       // verbatim
+  for (const u of uniqueStrings(urls.map((x) => normalize(x)))) {
+    tags.push(tag('i', u));                                           // NIP-73
+  }
+  if (urls.length > 0) tags.push(tag('k', 'web'));
+  tags.push(tag('suggested-by', provenance));
+  tags.push(tag('client', 'xray'));
+
+  const body = String(note || '');
+  return {
+    event: { kind: 30055, created_at: createdAt, tags, content: body },
+    body,
+    dTag
   };
 }
 

--- a/src/shared/metadata/feature-flags.js
+++ b/src/shared/metadata/feature-flags.js
@@ -31,7 +31,13 @@ export const FLAGS_DEFAULTS = Object.freeze({
   ratings: false,
   helpfulnessVoting: false, // UI gate; SW always accepts incoming votes
   bridgingRanking: false,   // v3
-  transitiveTrust: false    // v2
+  transitiveTrust: false,   // v2
+
+  // Phase 11 (docs/ASSESSMENTS_DESIGN.md): gates the PUBLISH paths for
+  // kind 30054 assessments, kind 30055 claim relationships, and the
+  // kind-1985 label mirror. Local capture/badges/rollups/export are
+  // never gated — they're the product.
+  assessmentPublishing: false
 });
 
 /**

--- a/tests/evidence-linker.test.mjs
+++ b/tests/evidence-linker.test.mjs
@@ -30,8 +30,9 @@ globalThis.chrome = {
 const {
     EvidenceLinker, EVIDENCE_RELATIONSHIPS,
     EVIDENCE_RELATIONSHIP_LABELS, EVIDENCE_RELATIONSHIP_ICONS,
-    generateEvidenceLinkId
+    generateEvidenceLinkId, parseRelationshipEvent
 } = await import('../src/shared/evidence-linker.js');
+const { buildClaimRelationshipEvent } = await import('../src/shared/metadata/builders.js');
 const { ClaimModel } = await import('../src/shared/claim-model.js');
 const { buildClaimCoord } = await import('../src/shared/claim-ref.js');
 
@@ -364,4 +365,63 @@ test('evidence: relationship enum is exhaustive', () => {
         EVIDENCE_RELATIONSHIPS.slice().sort(),
         ['contradicts', 'duplicates', 'supports', 'updates']
     );
+});
+
+test('evidence: parseRelationshipEvent round-trips the kind-30055 builder', async () => {
+    const srcCoord = `30040:${PUBKEY_A}:claim_aaaaaaaaaaaaaaaa`;
+    const tgtCoord = `30040:${PUBKEY_B}:claim_bbbbbbbbbbbbbbbb`;
+    const { event, dTag } = await buildClaimRelationshipEvent({
+        sourceCoord: srcCoord, targetCoord: tgtCoord, relationship: 'contradicts',
+        sourceUrl: 'https://example.com/a', targetUrl: 'https://example.com/b',
+        sourceEventId: 'e'.repeat(64),
+        note: 'Same events, incompatible narrations.'
+    });
+
+    const parsed = parseRelationshipEvent({ ...event, pubkey: PUBKEY_A, id: 'f'.repeat(64) });
+    assert.equal(parsed.id, dTag);
+    assert.equal(parsed.relationship, 'contradicts');
+    // contradicts is symmetric: the builder sorted the endpoints.
+    assert.equal(parsed.source.coord, srcCoord);
+    assert.equal(parsed.target.coord, tgtCoord);
+    assert.equal(parsed.source.eventId, 'e'.repeat(64));
+    assert.equal(parsed.target.eventId, null);
+    assert.equal(parsed.note, 'Same events, incompatible narrations.');
+    assert.equal(parsed.suggestedBy, 'user');
+    assert.deepEqual(parsed.urls, ['https://example.com/a', 'https://example.com/b']);
+    assert.equal(parsed.pubkey, PUBKEY_A);
+});
+
+test('evidence: parseRelationshipEvent does not misattribute a lone role-marked tag', async () => {
+    // A directional link with ONLY a target event id: the single e tag
+    // carries the 'target' marker, and the positional fallback must NOT
+    // hand it to the source side.
+    const { event } = await buildClaimRelationshipEvent({
+        sourceCoord: `30040:${PUBKEY_A}:claim_aaaaaaaaaaaaaaaa`,
+        targetCoord: `30040:${PUBKEY_B}:claim_bbbbbbbbbbbbbbbb`,
+        relationship: 'supports',
+        targetEventId: 'f'.repeat(64)
+    });
+    const parsed = parseRelationshipEvent(event);
+    assert.equal(parsed.source.eventId, null, 'source has no event id');
+    assert.equal(parsed.target.eventId, 'f'.repeat(64));
+});
+
+test('evidence: parseRelationshipEvent rejects non-30055 events, tolerates missing markers', () => {
+    assert.equal(parseRelationshipEvent(null), null);
+    assert.equal(parseRelationshipEvent({ kind: 30043, tags: [] }), null);
+
+    // Unmarked a-tags fall back to tag order.
+    const parsed = parseRelationshipEvent({
+        kind: 30055,
+        tags: [
+            ['d', 'rel_x'],
+            ['a', `30040:${PUBKEY_A}:claim_aaaaaaaaaaaaaaaa`],
+            ['a', `30040:${PUBKEY_B}:claim_bbbbbbbbbbbbbbbb`],
+            ['relationship', 'updates']
+        ],
+        content: ''
+    });
+    assert.equal(parsed.source.coord, `30040:${PUBKEY_A}:claim_aaaaaaaaaaaaaaaa`);
+    assert.equal(parsed.target.coord, `30040:${PUBKEY_B}:claim_bbbbbbbbbbbbbbbb`);
+    assert.equal(parsed.suggestedBy, 'user', 'defaults when absent');
 });

--- a/tests/metadata-assessments.test.mjs
+++ b/tests/metadata-assessments.test.mjs
@@ -1,0 +1,304 @@
+// Assessment + ClaimRelationship wire-builder tests — Phase 11.2
+// (docs/ASSESSMENTS_DESIGN.md; NIP_DRAFT.md §30054 / §30055).
+//
+// Same conventions as metadata-builders.test.mjs: {event, dTag} return
+// contract, deterministic-d-tag trio (same / discriminating /
+// non-discriminating inputs), URL normalization through builder output,
+// and argument validation via assert.rejects — plus the all-tag-values-
+// are-strings loop from tests/event-builder.test.mjs (the relay-
+// rejection regression). These builders are deliberately chromeless —
+// no storage shim needed.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { buildAssessmentEvent, buildClaimRelationshipEvent } =
+  await import('../src/shared/metadata/builders.js');
+const { ASSESSMENT_LABEL_NAMESPACE } =
+  await import('../src/shared/assessment-taxonomy.js');
+const { FLAGS_DEFAULTS } =
+  await import('../src/shared/metadata/feature-flags.js');
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+const ENTITY_PK = 'c'.repeat(64);
+const COORD_A = `30040:${PUBKEY_A}:claim_aaaaaaaaaaaaaaaa`;
+const COORD_B = `30040:${PUBKEY_B}:claim_bbbbbbbbbbbbbbbb`;
+
+/** First 16 hex chars of sha256 — mirrors the builders' derivation. */
+async function sha16(s) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(s));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0')).join('').slice(0, 16);
+}
+
+function tagsNamed(ev, name) {
+  return ev.tags.filter((t) => t[0] === name);
+}
+function firstTag(ev, name) {
+  return ev.tags.find((t) => t[0] === name);
+}
+
+// ---------------------------------------------------------------------
+// Kind 30054 — Assessment
+// ---------------------------------------------------------------------
+
+test('30054: full tag shape', async () => {
+  const anchor = [{ type: 'TextQuoteSelector', exact: 'mutual agreement' }];
+  const { event, body, dTag } = await buildAssessmentEvent({
+    claimCoord: COORD_A,
+    claimUrl: 'https://example.com/video?utm_source=feed',   // claim's r, VERBATIM
+    claimEventId: 'e'.repeat(64),
+    relayHint: 'wss://relay.example',
+    stance: -1,
+    labels: [
+      { label: 'misleading', anchor, note: 'closure framed as neutral' },
+      'fallacy/strawman'
+    ],
+    rationale: 'Both sides confirm it was not mutual.',
+    aboutPubkeys: [ENTITY_PK],
+    suggestedBy: 'user'
+  });
+
+  assert.equal(event.kind, 30054);
+  assert.equal(event.content, 'Both sides confirm it was not mutual.');
+  assert.equal(body, event.content);
+  assert.equal(dTag, 'assess:' + (await sha16(COORD_A)), 'd recomputable from the a-tag value');
+
+  assert.deepEqual(firstTag(event, 'd'), ['d', dTag]);
+  assert.deepEqual(firstTag(event, 'a'), ['a', COORD_A, 'wss://relay.example']);
+  assert.deepEqual(firstTag(event, 'e'), ['e', 'e'.repeat(64), 'wss://relay.example']);
+
+  // r is the claim's r VERBATIM (the #r join key); i is normalized.
+  assert.deepEqual(firstTag(event, 'r'), ['r', 'https://example.com/video?utm_source=feed']);
+  assert.deepEqual(firstTag(event, 'i'), ['i', 'https://example.com/video']);
+  assert.deepEqual(firstTag(event, 'k'), ['k', 'web']);
+
+  assert.deepEqual(firstTag(event, 'stance'), ['stance', '-1']);
+
+  // NIP-32 L/l under xray/assessment — the entity-sync pin idiom.
+  assert.deepEqual(firstTag(event, 'L'), ['L', ASSESSMENT_LABEL_NAMESPACE]);
+  assert.deepEqual(tagsNamed(event, 'l'), [
+    ['l', 'misleading', ASSESSMENT_LABEL_NAMESPACE],
+    ['l', 'fallacy/strawman', ASSESSMENT_LABEL_NAMESPACE]
+  ]);
+
+  // Per-label enrichments, keyed by label value; anchor JSON round-trips.
+  const anchorTag = firstTag(event, 'label-anchor');
+  assert.equal(anchorTag[1], 'misleading');
+  assert.deepEqual(JSON.parse(anchorTag[2]), anchor);
+  assert.deepEqual(firstTag(event, 'label-note'),
+    ['label-note', 'misleading', 'closure framed as neutral']);
+
+  // p tags: unmarked claim author (9803 idiom) + marked about-entities.
+  const pTags = tagsNamed(event, 'p');
+  assert.deepEqual(pTags[0], ['p', PUBKEY_A]);
+  assert.deepEqual(pTags[1], ['p', ENTITY_PK, '', 'about']);
+
+  assert.deepEqual(firstTag(event, 'suggested-by'), ['suggested-by', 'user']);
+  assert.deepEqual(firstTag(event, 'client'), ['client', 'xray']);
+});
+
+test('30054: deterministic d-tag trio', async () => {
+  const base = { claimCoord: COORD_A, claimUrl: 'https://example.com/v', stance: 1 };
+  const a = await buildAssessmentEvent(base);
+  const b = await buildAssessmentEvent({
+    ...base, stance: -2, labels: ['outdated'], rationale: 'changed my mind'
+  });
+  const c = await buildAssessmentEvent({ ...base, claimCoord: COORD_B });
+  assert.equal(a.dTag, b.dTag, 'judgment edits replace (same claim → same d)');
+  assert.notEqual(a.dTag, c.dTag, 'different claim → different d');
+});
+
+test('30054: omitted-when-absent tags', async () => {
+  const { event } = await buildAssessmentEvent({
+    claimCoord: COORD_A, claimUrl: 'https://example.com/v',
+    stance: null, labels: ['unsupported']
+  });
+  assert.equal(firstTag(event, 'stance'), undefined, 'no stance tag for label-only');
+  assert.equal(firstTag(event, 'e'), undefined, 'no e without an event id');
+  assert.equal(firstTag(event, 'label-anchor'), undefined);
+  assert.equal(firstTag(event, 'label-note'), undefined);
+
+  const { event: stanceOnly } = await buildAssessmentEvent({
+    claimCoord: COORD_A, claimUrl: 'https://example.com/v', stance: 2
+  });
+  assert.equal(firstTag(stanceOnly, 'L'), undefined, 'no L/l without labels');
+  assert.equal(tagsNamed(stanceOnly, 'l').length, 0);
+});
+
+test('30054: validation', async () => {
+  const ok = { claimCoord: COORD_A, claimUrl: 'https://example.com/v', stance: 0 };
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, claimCoord: 'claim_aaaaaaaaaaaaaaaa' }),
+    /must be a 30040:<pubkey>:<d> coordinate/, 'local ids never hit the wire');
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, claimCoord: undefined }),
+    /claimCoord/);
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, claimUrl: '' }),
+    /claimUrl required/);
+  for (const bad of [3, -3, 1.5, '1']) {
+    await assert.rejects(() => buildAssessmentEvent({ ...ok, stance: bad }),
+      /stance must be an integer/, `stance ${bad}`);
+  }
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, stance: null }),
+    /needs a stance or at least one label/);
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, labels: ['Has Space'] }),
+    /invalid label/);
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, labels: ['misleading', 'misleading'] }),
+    /duplicate label/);
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, suggestedBy: 'bot' }),
+    /suggestedBy/);
+  await assert.rejects(() => buildAssessmentEvent({ ...ok, aboutPubkeys: ['nope'] }),
+    /64-hex/);
+});
+
+test('30054: every tag value is a string', async () => {
+  const { event } = await buildAssessmentEvent({
+    claimCoord: COORD_A, claimUrl: 'https://example.com/v',
+    stance: 2, labels: [{ label: 'false', note: 'n' }], aboutPubkeys: [ENTITY_PK]
+  });
+  for (const t of event.tags) {
+    for (const v of t) assert.equal(typeof v, 'string', `tag ${t[0]} carries non-string ${v}`);
+  }
+  const before = Math.floor(Date.now() / 1000);
+  const { event: e2 } = await buildAssessmentEvent({
+    claimCoord: COORD_A, claimUrl: 'https://example.com/v', stance: 1
+  });
+  const after = Math.floor(Date.now() / 1000);
+  assert.ok(e2.created_at >= before && e2.created_at <= after);
+});
+
+// ---------------------------------------------------------------------
+// Kind 30055 — ClaimRelationship
+// ---------------------------------------------------------------------
+
+test('30055: full tag shape (directional)', async () => {
+  const { event, body, dTag } = await buildClaimRelationshipEvent({
+    sourceCoord: COORD_B,           // deliberately the lexically LARGER coord
+    targetCoord: COORD_A,
+    relationship: 'supports',
+    sourceUrl: 'https://example.com/video-2?utm_source=x',
+    targetUrl: 'https://example.com/video-1',
+    sourceEventId: 'e'.repeat(64),
+    targetEventId: 'f'.repeat(64),
+    note: 'Cites the same court filing.',
+    suggestedBy: 'llm:claude-fable-5'
+  });
+
+  assert.equal(event.kind, 30055);
+  assert.equal(event.content, 'Cites the same court filing.');
+  assert.equal(body, event.content);
+  // Directional: order is semantic — NOT sorted.
+  assert.equal(dTag, 'rel:' + (await sha16(`${COORD_B}|${COORD_A}|supports`)),
+    'd recomputable from the a tags + relationship, in tag order');
+
+  assert.deepEqual(tagsNamed(event, 'a'), [
+    ['a', COORD_B, '', 'source'],
+    ['a', COORD_A, '', 'target']
+  ]);
+  assert.deepEqual(tagsNamed(event, 'e'), [
+    ['e', 'e'.repeat(64), '', 'source'],
+    ['e', 'f'.repeat(64), '', 'target']
+  ]);
+  assert.deepEqual(firstTag(event, 'relationship'), ['relationship', 'supports']);
+  assert.deepEqual(tagsNamed(event, 'r'), [
+    ['r', 'https://example.com/video-2?utm_source=x'],
+    ['r', 'https://example.com/video-1']
+  ]);
+  assert.deepEqual(tagsNamed(event, 'i'), [
+    ['i', 'https://example.com/video-2'],
+    ['i', 'https://example.com/video-1']
+  ]);
+  assert.deepEqual(firstTag(event, 'k'), ['k', 'web']);
+  assert.deepEqual(firstTag(event, 'suggested-by'), ['suggested-by', 'llm:claude-fable-5']);
+  assert.deepEqual(firstTag(event, 'client'), ['client', 'xray']);
+
+  for (const t of event.tags) {
+    for (const v of t) assert.equal(typeof v, 'string', `tag ${t[0]} carries non-string ${v}`);
+  }
+});
+
+test('30055: symmetric relationships sort endpoints — both directions, one d', async () => {
+  const ab = await buildClaimRelationshipEvent({
+    sourceCoord: COORD_A, targetCoord: COORD_B, relationship: 'contradicts',
+    sourceUrl: 'https://example.com/a', targetUrl: 'https://example.com/b',
+    sourceEventId: 'e'.repeat(64), targetEventId: 'f'.repeat(64),
+    sourceRelayHint: 'wss://relay-a', targetRelayHint: 'wss://relay-b'
+  });
+  const ba = await buildClaimRelationshipEvent({
+    sourceCoord: COORD_B, targetCoord: COORD_A, relationship: 'contradicts',
+    sourceUrl: 'https://example.com/b', targetUrl: 'https://example.com/a',
+    sourceEventId: 'f'.repeat(64), targetEventId: 'e'.repeat(64),
+    sourceRelayHint: 'wss://relay-b', targetRelayHint: 'wss://relay-a'
+  });
+  assert.equal(ab.dTag, ba.dTag, 'one logical contradiction, one d');
+  assert.equal(ab.dTag, 'rel:' + (await sha16(`${COORD_A}|${COORD_B}|contradicts`)),
+    'sorted coords feed the hash');
+
+  // Tag order is sorted too, and the ENTIRE endpoint bundle — url,
+  // event id, relay hint — swaps with its coordinate.
+  for (const built of [ab, ba]) {
+    assert.deepEqual(tagsNamed(built.event, 'a'), [
+      ['a', COORD_A, 'wss://relay-a', 'source'],
+      ['a', COORD_B, 'wss://relay-b', 'target']
+    ]);
+    assert.deepEqual(tagsNamed(built.event, 'e'), [
+      ['e', 'e'.repeat(64), '', 'source'],
+      ['e', 'f'.repeat(64), '', 'target']
+    ]);
+    assert.deepEqual(tagsNamed(built.event, 'r'),
+      [['r', 'https://example.com/a'], ['r', 'https://example.com/b']]);
+  }
+
+  // Directional stays directional.
+  const sup = await buildClaimRelationshipEvent({ sourceCoord: COORD_A, targetCoord: COORD_B, relationship: 'supports' });
+  const pus = await buildClaimRelationshipEvent({ sourceCoord: COORD_B, targetCoord: COORD_A, relationship: 'supports' });
+  assert.notEqual(sup.dTag, pus.dTag);
+});
+
+test('30055: shared-URL dedupe and url-less builds', async () => {
+  const shared = await buildClaimRelationshipEvent({
+    sourceCoord: COORD_A, targetCoord: COORD_B, relationship: 'duplicates',
+    sourceUrl: 'https://example.com/same', targetUrl: 'https://example.com/same'
+  });
+  assert.equal(tagsNamed(shared.event, 'r').length, 1, 'identical r values deduped');
+  assert.equal(tagsNamed(shared.event, 'i').length, 1);
+
+  // Verbatim-different but normalized-equal URLs: two r, one i.
+  const tracked = await buildClaimRelationshipEvent({
+    sourceCoord: COORD_A, targetCoord: COORD_B, relationship: 'duplicates',
+    sourceUrl: 'https://example.com/same?utm_source=x',
+    targetUrl: 'https://example.com/same'
+  });
+  assert.equal(tagsNamed(tracked.event, 'r').length, 2, 'verbatim r values differ — both kept');
+  assert.deepEqual(tagsNamed(tracked.event, 'i'), [['i', 'https://example.com/same']],
+    'normalized i values coincide — deduped');
+
+  const bare = await buildClaimRelationshipEvent({
+    sourceCoord: COORD_A, targetCoord: COORD_B, relationship: 'updates'
+  });
+  assert.equal(tagsNamed(bare.event, 'r').length, 0);
+  assert.equal(tagsNamed(bare.event, 'i').length, 0);
+  assert.equal(firstTag(bare.event, 'k'), undefined, 'no k without i');
+});
+
+test('30055: validation', async () => {
+  const ok = { sourceCoord: COORD_A, targetCoord: COORD_B, relationship: 'contradicts' };
+  await assert.rejects(() => buildClaimRelationshipEvent({ ...ok, sourceCoord: 'claim_aaaaaaaaaaaaaaaa' }),
+    /must be a 30040:<pubkey>:<d> coordinate/, 'local ids never hit the wire');
+  await assert.rejects(() => buildClaimRelationshipEvent({ ...ok, relationship: 'loves' }),
+    /relationship must be one of/);
+  await assert.rejects(() => buildClaimRelationshipEvent({ ...ok, relationship: 'contextualizes' }),
+    /relationship must be one of/, 'legacy contextualizes is not publishable');
+  await assert.rejects(() => buildClaimRelationshipEvent({ ...ok, targetCoord: COORD_A }),
+    /cannot link a claim to itself/);
+  await assert.rejects(() => buildClaimRelationshipEvent({ ...ok, suggestedBy: 'llm: ' }),
+    /suggestedBy/);
+});
+
+// ---------------------------------------------------------------------
+// Flag
+// ---------------------------------------------------------------------
+
+test('flags: assessmentPublishing defaults OFF (publish gated, capture never)', () => {
+  assert.equal(FLAGS_DEFAULTS.assessmentPublishing, false);
+});


### PR DESCRIPTION
## What this is

The Phase 11 **wire-format slice** per the agreed design ([docs/ASSESSMENTS_DESIGN.md](../blob/claude/phase-11.2-wire-builders/docs/ASSESSMENTS_DESIGN.md)): the kinds exist and are tested, but **nothing publishes** — both paths gate behind the new `assessmentPublishing` flag (default off). The publish slice wires records→builders later.

> **Stacked on #38** (base = `claude/phase-11.1-assessment-model`). Review/merge #38 first; this retargets to `main` after.

## What landed

- **`buildAssessmentEvent` (kind 30054)** in the metadata-builders family (`{event, body, dTag}` contract): claim referenced by `a` coordinate with `d = assess:<sha16(coord)>` recomputable from it (local ids never hit the wire — the builders throw on `claim_*` refs), `stance` −2..+2, `L`/`l` labels under `xray/assessment` with per-label `label-anchor`/`label-note` tags, mirrored about-entity `p` tags, and the claim's `r` **verbatim** + normalized `i`/`k` (the one URL rule).
- **`buildClaimRelationshipEvent` (kind 30055) + `parseRelationshipEvent`**: two `a`-coordinate endpoints with `source`/`target` markers; symmetric relationships (`contradicts`/`duplicates`) sort endpoints in both the d-hash and tag order — A↔B and B↔A republish one `d` — with url/eventId/relay-hint bundles swapping together; `supports`/`updates` stay directional.
- **`buildEvidenceLinkEvent` (kind 30043) deleted** along with the reader's dead link-publish loop and summary plumbing (publishing was gated off in 11.1 — pure removal, no behavior change).
- **`assessmentPublishing` flag** added to `FLAGS_DEFAULTS` (default off).
- **NIP_DRAFT.md**: new §30040 (claim — both new kinds target it, so external implementers can resolve the reference), §30054 (including the NIP-32 self-label deviation + 1985-mirror guidance and the 30051-vs-30054 delineation), §30055, updated intro count and querying filters, and a kind-registry caveat for 30040's NKBIP-01 collision.
- `metadata/builders.js` stays **chromeless** (its tests run without a storage shim), via a local 10-line coordinate shape-parser instead of importing the claim-ref→storage chain.

## Review provenance

A focused adversarial review verified the tag sets field-by-field against the design and NIP text, the d-recomputability and symmetric-sort invariants, the chromeless import graph, and the 30043 deletion (zero dangling references). It caught one real bug — `parseRelationshipEvent`'s positional fallback misattributed a lone role-marked tag (e.g. a link with only a `targetEventId` leaked it into `source`) — fixed here with a regression test, plus event-id validation, a NIP §30040 prose correction, and three test-coverage gaps now closed.

## Gates

`npm run build` ✅ · **573/573 tests** (13 new) ✅ · `web-ext lint` ✅ (0 errors)

Next slice on approval: **11.3 — Assess UI in the reader** (draft PR for smoke-testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)