### PR TITLE
Phase 11.6 — Case export (JSON + Markdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Case export** (Phase 11.6 — the last Phase 11 v1 slice). Case
+  entities' detail view gains **Export JSON** + **Export Markdown**: the
+  deterministic case file (local claims about the case, your stances +
+  labels with notes/anchors/provenance, contradictions with embedded
+  endpoint snapshots — never dangling — and the label tally; viewed-only
+  network claims are excluded so the same case always exports the same
+  bytes) and the publishable research-notes report (claims grouped by
+  stance, inconsistencies pairing the contradicting quotes, label tally).
+  `docs/SMOKE_TEST.md` gains the full Phase 11 walkthrough (§11.1–11.24).
+
 - **The case dashboard: side-panel rollups + inconsistencies**
   (Phase 11.5). The entity detail view now has three judgment surfaces:
   **Your claims about this entity** (local claims tagging it, each with

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,8 +54,10 @@ Cleanup  ████████████████████  complete 
 Phase 10 ████████████████████  complete — claim tracking (thin entity-centric
                                 claims). 10.1–10.4 shipped; 10.5 (metadata reframe)
                                 superseded by Phase 11 (see below)
-Phase 11 ░░░░░░░░░░░░░░░░░░░░  design — assessments & contradictions
-                                (docs/ASSESSMENTS_DESIGN.md)
+Phase 11 ██████████████████░░  implemented — assessments & contradictions
+                                (docs/ASSESSMENTS_DESIGN.md). 11.1–11.6
+                                shipped; remaining: case smoke-runs +
+                                the flag-gated publish slice
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -839,19 +841,25 @@ former 10.5 metadata-reframe slice.
 
 Slices (one PR each):
 
-- ⬜ **11.1** Taxonomy + assessment model + tests; evidence-linker
-  cross-source refs + relationship enum; legacy `30043` publish gated off.
-- ⬜ **11.2** Wire builders + NIP draft — `30054` assessment + `30055`
-  claim relationship (the wire-format PR).
-- ⬜ **11.3** Assess UI in the reader (stance chips, label badges, foreign
-  claims).
-- ⬜ **11.4** Cross-source link UI (search all captured claims; ⚠ badges).
-- ⬜ **11.5** Side-panel rollups + inconsistencies (case dashboard).
-- ⬜ **11.6** Case export (JSON + Markdown).
+- ✅ **11.1** Taxonomy + assessment model + tests; evidence-linker
+  cross-source refs + relationship enum; legacy `30043` publish gated
+  off. — #38
+- ✅ **11.2** Wire builders + NIP draft — `30054` assessment + `30055`
+  claim relationship (the wire-format PR). — #39
+- ✅ **11.3** Assess UI in the reader (stance chips, label badges, span
+  anchors, foreign claims, sticky about-defaults). — #40
+- ✅ **11.4** Cross-source link UI (search all captured claims; ⚠
+  badges; snapshot rendering). — #41
+- ✅ **11.5** Side-panel rollups + inconsistencies (the case
+  dashboard + label tally + replaceable dedupe). — #42
+- ✅ **11.6** Case export (JSON + Markdown, deterministic content
+  set). — #43
 
-Acceptance: demo end-to-end on the two driving cases (LDS Church v. Dehlin;
-Bricks & Minifigs v. Reckless Ben) — capture, atomize, assess, link a
-cross-video contradiction, see it on the case dashboard, export.
+Remaining: run the acceptance demo end-to-end on the two driving cases
+(LDS Church v. Dehlin; Bricks & Minifigs v. Reckless Ben) — the
+checklist is `docs/SMOKE_TEST.md` §Phase 11 — and, later, the
+flag-gated publish slice (30054/30055 + the 1985 mirror behind
+`assessmentPublishing`).
 
 ---
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -318,17 +318,81 @@ verify the page actually shows Disqus comments inline).
 
 ---
 
-## Phase 5 — Claims + evidence
+## Phase 5/10 — Claims (thin model)
 
 | # | Test | Pass criteria |
 |---|---|---|
 | 5.1 | Select text → entity popover → click "📋 Add as claim" | ✅ claim modal opens with text pre-filled |
-| 5.2 | Pick a type, fill in subject/predicate/object (mix entity + freetext), set crux + confidence, save | ✅ claim card appears in the claims bar; selection gets dashed colored underline |
+| 5.2 | Pick **About** entities, optionally "who said it" + ⭐ key, save | ✅ claim card appears in the claims bar; selection gets dashed colored underline (exact passage, not first occurrence) |
 | 5.3 | Click ✎ on a claim → edit a field → save | ✅ card updates |
-| 5.4 | Click 🔗 on a claim → link modal opens with other claims as targets | ✅ pick relationship + (optional) note → save |
-| 5.5 | Both linked claims show the link block under the triple line | ✅ direction arrow + relationship label correct |
-| 5.6 | Publish | ✅ batch toast names: article + N claims + M relationships + K evidence links + (entity profiles for any new entities referenced) |
+| 5.4 | Click 🔗 on a claim → link modal opens (see 11.x for the cross-source flow) | ✅ pick target + relationship + (optional) note → save |
+| 5.5 | Both linked claims show the link block | ✅ relationship label correct; ↔ for contradicts/duplicates, →/← otherwise |
+| 5.6 | Publish | ✅ batch toast names: article + N claims + M relationships + (entity profiles for any new entities referenced) — **no evidence links** (kind 30043 retired in Phase 11) |
 | 5.7 | Look up your published article on a NOSTR client → its `p` tags should include each tagged entity's pubkey | ✅ |
+
+---
+
+## Phase 11 — Assessments, contradictions & cases
+
+The "Community Notes for the internet" loop, end to end on a real
+story. Use a real case (e.g. two YouTube videos from opposing sides).
+Everything here is **local-first** — no relay publish is involved
+except where marked, and assessment/link publishing stays off until
+the `assessmentPublishing` flag ships.
+
+**Setup: the case entity**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 11.1 | Side panel → ➕ → type chips include 🗂️ **Case** → create "My test case" | ✅ case entity appears in the list; 🗂️ chip filters to it |
+| 11.2 | Open its detail view | ✅ sections present: *Your claims about this entity* (empty hint), *Claims about this entity* (Load button), *⚠ Inconsistencies* (empty hint), **Export case** (JSON + Markdown buttons — case entities only) |
+
+**Capture + assess (reader)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 11.3 | Capture page 1 → select a quote → "Add as claim" → About = the case entity (+ a person) → save | ✅ claim row in the bar |
+| 11.4 | Add a second claim on the same page | ✅ the About picker **pre-fills the last-used entities** (sticky session default) |
+| 11.5 | Click **⚖** on a claim → stance **Disagree** → labels `misleading` + `fallacy/strawman` → note on `misleading` → rationale → Save | ✅ button shows ⚖✓; row shows the 👎 stance chip + label badges |
+| 11.6 | Re-open ⚖ → click the active stance to clear → Save | ✅ badges show labels only (label-only assessment is valid) |
+| 11.7 | In the assess modal, add a custom label "my made up label" | ✅ normalizes to `my-made-up-label`, renders with the dashed *custom* style |
+| 11.8 | Select a label → **📍** → modal minimizes to the pill → select a passage in the article → Done | ✅ label badge gains 📍; re-opening shows ✓ on the mark button |
+| 11.9 | ⚖ → **Remove** | ✅ badges disappear; button back to plain ⚖ |
+| 11.10 | 🌐 **Others' claims** → any foreign claim → ⚖ → judge it | ✅ badges render on the foreign card; if the "foreign" claim is actually yours, the claims bar badge updates too after closing the modal |
+
+**Cross-source contradiction (reader)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 11.11 | Capture page 2 (different site/video) → add a claim contradicting page 1's claim, About = same case | ✅ |
+| 11.12 | 🔗 on it → candidate list shows **claims from page 1** (📋) and any assessed-foreign claims (⚖) with hostnames; search box filters | ✅ |
+| 11.13 | Pick page 1's claim → relationship **Contradicts** (default) → note → Save | ✅ both claims' rows show the **⚠ badge**; link row highlighted, ↔ arrow, other endpoint shows text + source host |
+| 11.14 | Create the same link from the other claim's 🔗 in the opposite direction | ✅ no duplicate — the existing link is returned (symmetric identity) |
+
+**Case dashboard (side panel)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 11.15 | Open the case entity | ✅ *Your claims* lists every claim about it with stance chips + label badges; ⚖ Assess works here too |
+| 11.16 | *⚠ Inconsistencies* | ✅ the contradiction pair renders: both quotes, source hosts, your note; **label tally** on top (e.g. `2× misleading`) |
+| 11.17 | Assess/link something in the reader while the panel is open | ✅ the dashboard refreshes live (storage listener) |
+| 11.18 | **Load from relays** (needs the case published/p-tagged or returns the empty hint) | ✅ rows render with badges + ⚖; republished claims appear **once** (latest-wins dedupe) |
+
+**Export**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 11.19 | **Export JSON** | ✅ `xray-case-<name>-<date>.json` downloads: case header, claims (incl. the foreign endpoint with its snapshot), per-label notes/anchors/`suggested_by`, contradictions with embedded endpoint texts, `label_counts` |
+| 11.20 | **Export Markdown** | ✅ readable report: claims grouped by stance, labels + notes per claim, *Inconsistencies* pairing the quotes, label tally |
+| 11.21 | Re-export without changing anything | ✅ identical content (deterministic set — viewed-only network claims are excluded) |
+
+**Regression guards**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 11.22 | Publish an article with claims | ✅ batch has **no evidence-link events**; claims publish normally |
+| 11.23 | Delete a claim that has an assessment + links | ✅ confirm lists the blast radius; assessment and links are removed with it |
+| 11.24 | Settings → no assessment publishing toggle anywhere | ✅ publishing stays flag-gated off (`xray:flags` → `assessmentPublishing`) |
 
 ---
 

--- a/src/shared/case-export.js
+++ b/src/shared/case-export.js
@@ -1,0 +1,259 @@
+// Case export — Phase 11.6 (docs/ASSESSMENTS_DESIGN.md).
+//
+// Turns a case entity's orbit — claims about it, your assessments,
+// and its contradiction links — into a machine-readable JSON case
+// file and a publishable Markdown report.
+//
+// DETERMINISTIC CONTENT SET: local claims whose `about` includes the
+// entity, plus the foreign endpoints of `contradicts` links touching
+// those claims (rendered from the links' stored snapshots). Network
+// claims that were merely *viewed* are deliberately excluded — their
+// presence would make the same case export differently depending on
+// whether/when "Load from relays" was clicked.
+//
+// Split into a storage-aware `collectCaseData` and pure
+// `buildCaseJson` / `buildCaseMarkdown` builders (the caller injects
+// `generatedAt`, keeping the builders deterministic and testable).
+
+import { ClaimModel } from './claim-model.js';
+import { AssessmentModel } from './assessment-model.js';
+import { EvidenceLinker } from './evidence-linker.js';
+import { EntityModel } from './entity-model.js';
+import { makeClaimRefCanonicalizer, isLocalClaimId } from './claim-ref.js';
+import { STANCE_LABELS } from './assessment-taxonomy.js';
+
+// ------------------------------------------------------------------
+// Gather (storage-aware)
+// ------------------------------------------------------------------
+
+/**
+ * Collect the case data for one entity. Returns the plain object the
+ * pure builders consume.
+ */
+export async function collectCaseData(entityId) {
+    const entity = await EntityModel.get(entityId);
+    if (!entity) throw new Error(`Entity not found: ${entityId}`);
+
+    const [allClaims, allAssessments, allLinks, canon] = await Promise.all([
+        ClaimModel.getAll(),
+        AssessmentModel.getAll(),
+        EvidenceLinker.getAll(),
+        makeClaimRefCanonicalizer()
+    ]);
+
+    // Canonical-keyed assessment lookup.
+    const assessByRef = new Map();
+    for (const a of Object.values(allAssessments)) {
+        const ref = a.claim_ref && (a.claim_ref.claim_id || a.claim_ref.coord);
+        if (ref) assessByRef.set(canon(ref), a);
+    }
+
+    // Local claims about the entity.
+    const localClaims = Object.values(allClaims)
+        .filter((c) => (c.about || []).includes(entityId))
+        .sort((a, b) => (b.is_key ? 1 : 0) - (a.is_key ? 1 : 0) || (a.created || 0) - (b.created || 0));
+    const aboutIds = new Set(localClaims.map((c) => c.id));
+
+    // Contradiction links with at least one endpoint about the entity
+    // (the 11.5 dashboard rule).
+    const contradictions = [];
+    const foreignEndpoints = new Map();   // canonicalRef → {ref, text, url, author_pubkey}
+    for (const link of Object.values(allLinks)) {
+        if (link.relationship !== 'contradicts') continue;
+        const a = canon(link.source_claim_id);
+        const b = canon(link.target_claim_id);
+        if (!aboutIds.has(a) && !aboutIds.has(b)) continue;
+
+        const endpoint = async (ref, snap) => {
+            if (isLocalClaimId(ref)) {
+                const rec = allClaims[ref] || await ClaimModel.get(ref);
+                if (rec) {
+                    return { ref: { claim_id: ref }, text: rec.text, url: rec.source_url };
+                }
+            }
+            const out = {
+                ref:  { coord: ref },
+                text: (snap && snap.text) || '',
+                url:  (snap && snap.url) || ''
+            };
+            if (snap && snap.author_pubkey) out.ref.author_pubkey = snap.author_pubkey;
+            if (!isLocalClaimId(ref)) {
+                foreignEndpoints.set(ref, {
+                    coord: ref, text: out.text, url: out.url,
+                    author_pubkey: (snap && snap.author_pubkey) || null
+                });
+            }
+            return out;
+        };
+
+        contradictions.push({
+            relationship: link.relationship,
+            note:         link.note || '',
+            suggested_by: link.suggested_by || 'user',
+            source:       await endpoint(a, link.source_snapshot),
+            target:       await endpoint(b, link.target_snapshot)
+        });
+    }
+
+    // Entity-name resolution for about/source display.
+    const nameCache = new Map();
+    const entityName = async (id) => {
+        if (!nameCache.has(id)) {
+            const e = await EntityModel.get(id);
+            nameCache.set(id, e ? e.name : '(missing entity)');
+        }
+        return nameCache.get(id);
+    };
+
+    const exportAssessment = (ref) => {
+        const a = assessByRef.get(ref);
+        if (!a) return null;
+        return {
+            stance:       a.stance,
+            stance_label: a.stance === null || a.stance === undefined
+                              ? null : (STANCE_LABELS[String(a.stance)] || String(a.stance)),
+            rationale:    a.rationale || '',
+            suggested_by: a.suggested_by || 'user',
+            labels:       (a.labels || []).map((l) => ({
+                label: l.label,
+                ...(l.note ? { note: l.note } : {}),
+                ...(l.anchor ? { anchor: l.anchor } : {}),
+                suggested_by: l.suggested_by || 'user'
+            }))
+        };
+    };
+
+    const claims = [];
+    for (const c of localClaims) {
+        const aboutNames = [];
+        for (const id of c.about || []) aboutNames.push(await entityName(id));
+        let source = null;
+        if (c.source) {
+            source = /^entity_/.test(c.source) ? await entityName(c.source) : c.source;
+        }
+        claims.push({
+            ref:        { claim_id: c.id },
+            text:       c.text,
+            url:        c.source_url,
+            about:      aboutNames,
+            ...(source ? { source } : {}),
+            ...(c.is_key ? { is_key: true } : {}),
+            origin:     'local',
+            assessment: exportAssessment(c.id)
+        });
+    }
+    for (const f of foreignEndpoints.values()) {
+        claims.push({
+            ref:        { coord: f.coord, ...(f.author_pubkey ? { author_pubkey: f.author_pubkey } : {}) },
+            text:       f.text,
+            url:        f.url,
+            about:      [],
+            origin:     'foreign',
+            assessment: exportAssessment(canon(f.coord))
+        });
+    }
+
+    // Label tally across everything included.
+    const label_counts = {};
+    for (const c of claims) {
+        for (const l of (c.assessment && c.assessment.labels) || []) {
+            label_counts[l.label] = (label_counts[l.label] || 0) + 1;
+        }
+    }
+
+    return {
+        case: {
+            id:     entity.id,
+            name:   entity.name,
+            type:   entity.type,
+            pubkey: (entity.keypair && entity.keypair.pubkey) || null
+        },
+        claims,
+        contradictions,
+        label_counts
+    };
+}
+
+// ------------------------------------------------------------------
+// Pure builders
+// ------------------------------------------------------------------
+
+/** The machine-readable case file. */
+export function buildCaseJson(data, generatedAt) {
+    return JSON.stringify({
+        case:           data.case,
+        generated_at:   generatedAt,
+        generator:      'xray',
+        claims:         data.claims,
+        contradictions: data.contradictions,
+        label_counts:   data.label_counts
+    }, null, 2);
+}
+
+/** The publishable research-notes report. */
+export function buildCaseMarkdown(data, generatedAt) {
+    const lines = [];
+    lines.push(`# Case: ${data.case.name}`);
+    lines.push('');
+    lines.push(`Generated ${generatedAt} by X-Ray · ${data.claims.length} claim${data.claims.length === 1 ? '' : 's'} · ${data.contradictions.length} contradiction${data.contradictions.length === 1 ? '' : 's'}`);
+    lines.push('');
+
+    // Claims grouped by stance (judged groups first, strongest
+    // disagreement → strongest agreement, then unjudged).
+    const groups = new Map();   // stance key → claims
+    for (const c of data.claims) {
+        const key = c.assessment && c.assessment.stance !== null && c.assessment.stance !== undefined
+            ? String(c.assessment.stance) : 'no-stance';
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(c);
+    }
+    const order = ['-2', '-1', '0', '1', '2', 'no-stance'];
+
+    lines.push('## Claims');
+    for (const key of order) {
+        const group = groups.get(key);
+        if (!group || group.length === 0) continue;
+        lines.push('');
+        lines.push(`### ${key === 'no-stance' ? 'No stance recorded' : `${STANCE_LABELS[key]} (${key})`}`);
+        for (const c of group) {
+            lines.push('');
+            lines.push(`> ${c.text}`);
+            const meta = [];
+            if (c.is_key) meta.push('⭐ key');
+            if (c.source) meta.push(`per ${c.source}`);
+            if (c.about && c.about.length) meta.push(`about ${c.about.join(', ')}`);
+            meta.push(c.origin === 'local' ? `[source](${c.url})` : `[foreign source](${c.url})`);
+            lines.push(`— ${meta.join(' · ')}`);
+            const a = c.assessment;
+            if (a) {
+                for (const l of a.labels || []) {
+                    lines.push(`  - **${l.label}**${l.note ? ` — ${l.note}` : ''}`);
+                }
+                if (a.rationale) lines.push(`  - _${a.rationale}_`);
+            }
+        }
+    }
+
+    lines.push('');
+    lines.push('## Inconsistencies');
+    if (data.contradictions.length === 0) {
+        lines.push('');
+        lines.push('None recorded.');
+    }
+    for (const x of data.contradictions) {
+        lines.push('');
+        lines.push(`- “${x.source.text}” ([source](${x.source.url}))`);
+        lines.push(`  **⚔ contradicts**`);
+        lines.push(`  “${x.target.text}” ([source](${x.target.url}))${x.note ? ` — ${x.note}` : ''}`);
+    }
+
+    const tally = Object.entries(data.label_counts).sort((a, b) => b[1] - a[1]);
+    if (tally.length > 0) {
+        lines.push('');
+        lines.push('## Label tally');
+        lines.push('');
+        for (const [label, n] of tally) lines.push(`- ${n}× ${label}`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}

--- a/src/sidepanel/index.css
+++ b/src/sidepanel/index.css
@@ -738,3 +738,8 @@ body.xr-side {
   font-style: italic;
   margin-top: 2px;
 }
+
+.xr-side__case-export-row {
+  display: flex;
+  gap: 8px;
+}

--- a/src/sidepanel/index.js
+++ b/src/sidepanel/index.js
@@ -20,6 +20,7 @@ import { parseClaimEvent, ClaimModel } from '../shared/claim-model.js';
 import { EvidenceLinker, EVIDENCE_RELATIONSHIP_ICONS } from '../shared/evidence-linker.js';
 import { openAssessModal, renderAssessmentBadges, assessmentsByCanonicalRef } from '../shared/assess-modal.js';
 import { makeClaimRefCanonicalizer, isLocalClaimId, buildClaimCoord } from '../shared/claim-ref.js';
+import { collectCaseData, buildCaseJson, buildCaseMarkdown } from '../shared/case-export.js';
 import { accountsForEntity, listUnlinkedAccounts, linkAccountToEntity, unlinkAccount } from '../shared/identity/account-registry.js';
 import { LocalKeyManager } from '../shared/local-key-manager.js';
 import { Crypto } from '../shared/crypto.js';
@@ -269,6 +270,16 @@ function renderDetail(entity) {
         <div id="xr-inconsistencies">Loading…</div>
       </div>
 
+      ${entity.type === 'case' ? `
+      <div class="xr-side__case-export">
+        <h3>Export case</h3>
+        <p class="xr-side__hint">The case file: local claims about this case, your stances + labels, and its contradictions. JSON for machines, Markdown for humans. (Viewed-only network claims are excluded so the same case always exports the same.)</p>
+        <div class="xr-side__case-export-row">
+          <button type="button" class="xr-side__ghost-btn" id="xr-export-case-json">Export JSON</button>
+          <button type="button" class="xr-side__ghost-btn" id="xr-export-case-md">Export Markdown</button>
+        </div>
+      </div>` : ''}
+
       <div class="xr-side__publish">
         <h3>Publish status</h3>
         <p class="xr-side__pub-line">${pubInfo}</p>
@@ -319,6 +330,12 @@ function renderDetail(entity) {
         paintNetworkClaims(entity, state.networkClaims.events, state.networkClaims.byRelay)
             .catch(() => {});
     }
+
+    // Phase 11.6 — case export (case entities only).
+    const exportJsonBtn = $('#xr-export-case-json');
+    const exportMdBtn   = $('#xr-export-case-md');
+    if (exportJsonBtn) exportJsonBtn.addEventListener('click', () => exportCase(entity, 'json'));
+    if (exportMdBtn)   exportMdBtn.addEventListener('click', () => exportCase(entity, 'md'));
 
     // Keypair controls.
     $('#xr-copy-npub').addEventListener('click', () => {
@@ -626,6 +643,33 @@ async function renderInconsistencies(entity) {
 
 function hostOf(url) {
     try { return new URL(url).host; } catch { return String(url || ''); }
+}
+
+/** Export a case entity as JSON or Markdown (Phase 11.6). */
+async function exportCase(entity, format) {
+    try {
+        const data = await collectCaseData(entity.id);
+        const generatedAt = new Date().toISOString();
+        const slug = entity.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'case';
+        const date = generatedAt.slice(0, 10);
+        if (format === 'json') {
+            downloadText(`xray-case-${slug}-${date}.json`, buildCaseJson(data, generatedAt), 'application/json');
+        } else {
+            downloadText(`xray-case-${slug}-${date}.md`, buildCaseMarkdown(data, generatedAt), 'text/markdown');
+        }
+    } catch (err) {
+        alert(`Export failed: ${err.message || err}`);
+    }
+}
+
+function downloadText(filename, text, mime) {
+    const blob = new Blob([text], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 2000);
 }
 
 /**

--- a/tests/case-export.test.mjs
+++ b/tests/case-export.test.mjs
@@ -1,0 +1,193 @@
+// Case export tests — Phase 11.6 (docs/ASSESSMENTS_DESIGN.md).
+// Same chrome.storage.local shim pattern as entity-model.test.mjs.
+//
+// collectCaseData is storage-aware (seeded through the real models);
+// the JSON/Markdown builders are pure — generatedAt is injected, so
+// outputs are fully deterministic.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const { collectCaseData, buildCaseJson, buildCaseMarkdown } =
+    await import('../src/shared/case-export.js');
+const { EntityModel } = await import('../src/shared/entity-model.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+const { AssessmentModel } = await import('../src/shared/assessment-model.js');
+const { EvidenceLinker } = await import('../src/shared/evidence-linker.js');
+const { LocalKeyManager } = await import('../src/shared/local-key-manager.js');
+const { buildClaimCoord } = await import('../src/shared/claim-ref.js');
+
+function resetState() {
+    _stateStore.clear();
+    LocalKeyManager.keys.clear();
+}
+
+const PUBKEY_B = 'b'.repeat(64);
+const GENERATED = '2026-06-10T12:00:00.000Z';
+
+/** One full case fixture: entity, two local claims, a foreign claim,
+ *  assessments, and a cross-source contradiction. */
+async function seedCase() {
+    const caseEntity = await EntityModel.create({ name: 'Bricks & Minifigs scandal', type: 'case' });
+
+    const claimA = await ClaimModel.create({
+        text: 'The new owners illegally retained the consigned collection.',
+        source_url: 'https://example.com/video-1',
+        about: [caseEntity.id],
+        is_key: true
+    });
+    const claimB = await ClaimModel.create({
+        text: 'The collection was worth $200,000.',
+        source_url: 'https://example.com/video-2',
+        about: [caseEntity.id]
+    });
+
+    await AssessmentModel.create({
+        claim_ref: { claim_id: claimA.id },
+        stance: 1,
+        labels: [{ label: 'unsupported', note: 'needs the consignment contract' }],
+        rationale: 'Schneider shows paperwork but not the contract terms.'
+    });
+    await AssessmentModel.create({
+        claim_ref: { claim_id: claimB.id },
+        stance: null,
+        labels: ['unsupported']
+    });
+
+    // Cross-source contradiction: local claim A vs a foreign statement.
+    const foreignCoord = buildClaimCoord(PUBKEY_B, 'their-claim-d');
+    await EvidenceLinker.create({
+        source_claim_id: claimA.id,
+        target_claim_id: foreignCoord,
+        relationship: 'contradicts',
+        note: 'Closure framed as mutual vs illegal retention.',
+        target_snapshot: {
+            url: 'https://example.com/corp-statement',
+            text: 'We parted ways by mutual agreement.'
+        }
+    });
+    // Assess the foreign endpoint too (label-only).
+    await AssessmentModel.create({
+        claim_ref: { coord: foreignCoord, url: 'https://example.com/corp-statement', text: 'We parted ways by mutual agreement.' },
+        labels: ['euphemism', 'misleading']
+    });
+
+    // Noise that must NOT leak into the export: a claim about nobody,
+    // and a supports link between unrelated fake ids.
+    await ClaimModel.create({ text: 'Unrelated claim.', source_url: 'https://example.com/other' });
+    await EvidenceLinker.create({
+        source_claim_id: 'claim_eeeeeeeeeeeeeeee',
+        target_claim_id: 'claim_ffffffffffffffff',
+        relationship: 'supports'
+    });
+
+    return { caseEntity, claimA, claimB, foreignCoord };
+}
+
+// ---------------------------------------------------------------------
+
+test('case-export: collectCaseData gathers the deterministic content set', async () => {
+    resetState();
+    const { caseEntity, claimA, claimB, foreignCoord } = await seedCase();
+
+    const data = await collectCaseData(caseEntity.id);
+
+    assert.equal(data.case.name, 'Bricks & Minifigs scandal');
+    assert.equal(data.case.type, 'case');
+    assert.match(data.case.pubkey, /^[0-9a-f]{64}$/);
+
+    // Local claims about the case + the contradiction's foreign endpoint.
+    assert.equal(data.claims.length, 3);
+    const byOrigin = (o) => data.claims.filter((c) => c.origin === o);
+    assert.equal(byOrigin('local').length, 2);
+    assert.equal(byOrigin('foreign').length, 1);
+
+    const localA = data.claims.find((c) => c.ref.claim_id === claimA.id);
+    assert.equal(localA.is_key, true);
+    assert.deepEqual(localA.about, ['Bricks & Minifigs scandal']);
+    assert.equal(localA.assessment.stance, 1);
+    assert.equal(localA.assessment.stance_label, 'Agree');
+    assert.equal(localA.assessment.labels[0].label, 'unsupported');
+    assert.equal(localA.assessment.labels[0].note, 'needs the consignment contract');
+
+    const localB = data.claims.find((c) => c.ref.claim_id === claimB.id);
+    assert.equal(localB.assessment.stance, null, 'label-only assessment exports');
+
+    const foreign = byOrigin('foreign')[0];
+    assert.equal(foreign.ref.coord, foreignCoord);
+    assert.equal(foreign.ref.author_pubkey, PUBKEY_B, 'snapshot author rides into the ref');
+    assert.equal(foreign.text, 'We parted ways by mutual agreement.');
+    assert.deepEqual(foreign.assessment.labels.map((l) => l.label), ['euphemism', 'misleading']);
+
+    // One contradiction, endpoint snapshots embedded — no dangling refs.
+    assert.equal(data.contradictions.length, 1);
+    const x = data.contradictions[0];
+    assert.equal(x.note, 'Closure framed as mutual vs illegal retention.');
+    const texts = [x.source.text, x.target.text];
+    assert.ok(texts.includes('The new owners illegally retained the consigned collection.'));
+    assert.ok(texts.includes('We parted ways by mutual agreement.'));
+
+    // Label tally across everything included.
+    assert.deepEqual(data.label_counts, { unsupported: 2, euphemism: 1, misleading: 1 });
+
+    await assert.rejects(() => collectCaseData('entity_0000000000000000'), /Entity not found/);
+});
+
+test('case-export: buildCaseJson is deterministic and machine-readable', async () => {
+    resetState();
+    const { caseEntity } = await seedCase();
+    const data = await collectCaseData(caseEntity.id);
+
+    const json = buildCaseJson(data, GENERATED);
+    const again = buildCaseJson(await collectCaseData(caseEntity.id), GENERATED);
+    assert.equal(json, again, 'same case + same timestamp → byte-identical export');
+
+    const parsed = JSON.parse(json);
+    assert.equal(parsed.generated_at, GENERATED);
+    assert.equal(parsed.generator, 'xray');
+    assert.equal(parsed.claims.length, 3);
+    assert.equal(parsed.contradictions.length, 1);
+    // Per-label provenance survives into the machine-readable file.
+    const labeled = parsed.claims.find((c) => c.origin === 'foreign');
+    assert.equal(labeled.assessment.labels[0].suggested_by, 'user');
+});
+
+test('case-export: buildCaseMarkdown groups by stance and pairs the contradiction', async () => {
+    resetState();
+    const { caseEntity } = await seedCase();
+    const md = buildCaseMarkdown(await collectCaseData(caseEntity.id), GENERATED);
+
+    assert.ok(md.startsWith('# Case: Bricks & Minifigs scandal'));
+    assert.ok(md.includes('### Agree (1)'), 'stance group heading');
+    assert.ok(md.includes('### No stance recorded'), 'label-only assessments group under No stance');
+    assert.ok(md.includes('> The new owners illegally retained the consigned collection.'));
+    assert.ok(md.includes('**unsupported** — needs the consignment contract'));
+    assert.ok(md.includes('## Inconsistencies'));
+    assert.ok(md.includes('**⚔ contradicts**'));
+    assert.ok(md.includes('“We parted ways by mutual agreement.”'));
+    assert.ok(md.includes('## Label tally'));
+    assert.ok(md.includes('- 2× unsupported'));
+});


### PR DESCRIPTION
The final Phase 11 v1 slice per docs/ASSESSMENTS_DESIGN.md: deterministic case export (JSON case file + Markdown research notes) from the case entity's detail view, with unit-tested pure builders, plus the Phase 11 smoke-test checklist (docs/SMOKE_TEST.md §11.1–11.24) and ROADMAP closeout. Gates: build ✅ 576/576 ✅ lint ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)