### PR TITLE
Phase 11.7 — Judgment publishing (30054/30055 + 1985 mirror, flag-gated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Judgment publishing** (Phase 11.7; behind **Settings → Advanced →
+  Experimental → "Publish assessments & claim links to relays"**, default
+  off). When enabled, the reader's Publish batch also emits — after the
+  claims, so own-claim coordinates resolve from the recorded publishing
+  pubkey — your wire-ready judgments: kind-30054 assessments (stance,
+  labels with anchors/notes, rationale, mirrored about-entity `p` tags),
+  kind-30055 claim links (both endpoints' coordinates required), and a
+  one-time kind-1985 label mirror per labeled assessment on its first
+  publish (the plain-NIP-32 aggregation path). Selection spans ALL
+  wire-ready judgments (judgments are article-agnostic), uses the standard
+  `updated > publishedAt` re-emit gate, backfills assessment coordinates
+  at publish time, and reports per-type results in the publish summary.
+  Local capture continues to work with the switch off.
+
 - **Case export** (Phase 11.6 — the last Phase 11 v1 slice). Case
   entities' detail view gains **Export JSON** + **Export Markdown**: the
   deterministic case file (local claims about the case, your stances +

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,41 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-10 — Phase 11.7: judgment publishing behind the flag
+
+**Tags:** design, wire-format
+
+The `assessmentPublishing` flag now does something: the reader's batch
+publishes wire-ready 30054 assessments + 30055 claim links + kind-1985
+label mirrors, after the claims (publish ordering per design rule 4 —
+own-claim coordinates derive from the RECORDED publishedPubkey, never
+the current signer). Selection logic is pure + unit-tested
+(`shared/assessment-publish.js`); the options Advanced tab grew an
+Experimental toggle (writes the `xray:flags` override; the reader
+re-reads flags at publish time, so no reload ping is needed — the
+`xray:flags:reload` message remains aspirational).
+
+Three second-guessable calls:
+
+- **Batch scope is ALL wire-ready judgments**, not just this article's:
+  judgments are article-agnostic records, and cross-article ones
+  (foreign-claim assessments, cross-source links) would otherwise never
+  publish. The progress total extends mid-batch (judgment counts aren't
+  knowable until claims record their pubkeys); a second toast announces
+  the judgment sub-batch.
+- **Mirrors are first-publish only, and only when their 30054 landed.**
+  Kind 1985 is a regular (non-replaceable) event — re-mirroring on every
+  edit would accumulate duplicates in naive aggregators. Cost: a label
+  edit after first publish leaves the mirror stale until a NIP-09
+  cleanup pass exists (same posture as every other superseded event).
+- **Pre-backfill ambiguity, accepted:** an assessment stored against our
+  own claim's coordinate BEFORE the claim recorded its pubkey publishes
+  "as foreign" (correct coordinate, just no registry enrichment); once
+  the pubkey lands, the same record selects via the local claim. Either
+  path emits the same coordinate, so the wire d is identical.
+
+---
+
 ## 2026-06-10 — Phase 11.3: assess UI; the one UI module in src/shared/
 
 **Tags:** design

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -7,6 +7,7 @@
 import { Storage } from '../shared/storage.js';
 import { Crypto } from '../shared/crypto.js';
 import { NSecBunkerClient } from '../shared/nsecbunker-client.js';
+import { loadFlags, isEnabled, setOverride } from '../shared/metadata/feature-flags.js';
 
 const browserApi = (typeof browser !== 'undefined' && browser.runtime) ? browser : chrome;
 
@@ -443,6 +444,12 @@ async function loadAdvanced() {
         prefs.archive_banner_sensitivity || 'always';
     document.getElementById('pref-debug').checked = prefs.debug === true;
 
+    // Experimental flags (metadata/feature-flags.js — stored under the
+    // `xray:flags` key, not preferences).
+    await loadFlags();
+    document.getElementById('pref-assessment-publishing').checked =
+        isEnabled('assessmentPublishing');
+
     const overrides = prefs.config_overrides || {};
     document.getElementById('pref-cache-enabled').checked =
         overrides.article_cache_enabled !== false;
@@ -471,6 +478,12 @@ async function saveAdvanced() {
     };
 
     await storageSet('preferences', prefs);
+
+    // Experimental flags: checked → explicit override on; unchecked →
+    // clear the override back to the default (off).
+    const publishJudgments = document.getElementById('pref-assessment-publishing').checked;
+    await setOverride('assessmentPublishing', publishJudgments ? true : null);
+
     flash(document.getElementById('advanced-status'), 'Saved.');
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -217,6 +217,22 @@
       </p>
 
       <hr />
+      <h3 class="xr-opt__subhead">Experimental</h3>
+
+      <label class="xr-opt__field xr-opt__field--inline">
+        <input type="checkbox" id="pref-assessment-publishing" />
+        <span>Publish assessments &amp; claim links to relays</span>
+      </label>
+      <p class="xr-opt__hint" style="margin-top:-8px">
+        Off by default. When on, the reader's Publish batch also emits your
+        judgments — kind-30054 assessments (stance + labels + rationale),
+        kind-30055 claim links, and a one-time kind-1985 label mirror per
+        labeled assessment — signed by your publishing identity and
+        <strong>publicly visible to anyone with relay access</strong>.
+        Local capture always works regardless of this switch.
+      </p>
+
+      <hr />
       <h3 class="xr-opt__subhead">Power user</h3>
 
       <label class="xr-opt__field xr-opt__field--inline">

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -22,6 +22,10 @@ import { installEntityTagger, rehydrateEntityMarks } from './entity-tagger.js';
 import { openClaimModal, openEvidenceLinkModal, openOthersClaimsModal, renderClaimsBar, rehydrateClaimMarks } from './claim-extractor.js';
 import { openAssessModal } from '../shared/assess-modal.js';
 import { AssessmentModel } from '../shared/assessment-model.js';
+import { makeClaimRefCanonicalizer } from '../shared/claim-ref.js';
+import { selectAssessmentsToPublish, selectLinksToPublish, selectMirrors } from '../shared/assessment-publish.js';
+import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent } from '../shared/metadata/builders.js';
+import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
 
 const browserApi = typeof browser !== 'undefined' && browser.runtime ? browser : chrome;
 
@@ -1421,8 +1425,11 @@ async function publish() {
     // published + unchanged claims).
     const relationshipsToPublish = await resolveRelationshipsToPublish(claimsToPublish, state.article.url);
 
-    const totalEvents = 1 + commentList.length + entitiesToPublish.length
-                          + claimsToPublish.length + relationshipsToPublish.length;
+    // `let`: the judgment batch (Phase 11.7, flag-gated) extends the
+    // total after claims publish — own-claim coordinates only resolve
+    // once their publishing pubkey is recorded.
+    let totalEvents = 1 + commentList.length + entitiesToPublish.length
+                        + claimsToPublish.length + relationshipsToPublish.length;
 
     // Per-relay rollup across the entire batch.
     const relayStats = new Map(); // url → { ok, fail, lastError }
@@ -1747,9 +1754,167 @@ async function publish() {
             if (i < relationshipsToPublish.length - 1) await sleep(BATCH_PUBLISH_DELAY_MS);
         }
 
-        // (Claim-link publishing: the legacy kind-30043 batch was retired
-        // in Phase 11.1; the kind-30055 path lands behind the
-        // assessmentPublishing flag in the Phase 11 publish slice.)
+        // ---- Judgments: assessments + mirrors + claim links ------------
+        // (Phase 11.7 — behind the assessmentPublishing flag, default
+        // off.) Runs AFTER the claims batch: claims published above
+        // recorded their publishing pubkey, so own-claim coordinates
+        // resolve; foreign refs carry theirs. The selection spans ALL
+        // wire-ready judgments, not just this article's — judgments are
+        // article-agnostic records and cross-article ones would
+        // otherwise never publish.
+        await loadFlags();
+        const publishJudgments = isEnabled('assessmentPublishing');
+        const assessResults = { ok: 0, fail: 0, errors: [] };
+        const mirrorResults = { ok: 0, fail: 0, errors: [] };
+        const jLinkResults  = { ok: 0, fail: 0, errors: [] };
+        let assessSel = [], mirrorSel = [], linkSel = [];
+        if (publishJudgments) {
+            const [claimsAll, assessmentsAll, linksAll, canon] = await Promise.all([
+                ClaimModel.getAll(), AssessmentModel.getAll(), EvidenceLinker.getAll(),
+                makeClaimRefCanonicalizer()
+            ]);
+            assessSel = selectAssessmentsToPublish({ assessments: assessmentsAll, claims: claimsAll, canon });
+            mirrorSel = selectMirrors(assessSel);
+            linkSel   = selectLinksToPublish({ links: linksAll, claims: claimsAll, canon });
+        }
+        const judgmentBase = relBatchBase + relationshipsToPublish.length;
+        let judgmentStep = 0;
+        if (assessSel.length + mirrorSel.length + linkSel.length > 0) {
+            totalEvents += assessSel.length + mirrorSel.length + linkSel.length;
+            toast(`Also publishing your judgments: ${assessSel.length} assessment${assessSel.length === 1 ? '' : 's'}`
+                  + (mirrorSel.length ? ` + ${mirrorSel.length} label mirror${mirrorSel.length === 1 ? '' : 's'}` : '')
+                  + (linkSel.length ? ` + ${linkSel.length} claim link${linkSel.length === 1 ? '' : 's'}` : '')
+                  + '…', 'warning', 4000);
+
+            const sendJudgment = async (unsigned) => {
+                unsigned.pubkey = userPubkey;
+                return await browserApi.runtime.sendMessage({
+                    type: 'xray:capture:publish', id: state.id, event: unsigned
+                });
+            };
+            const entitiesAll = await EntityModel.getAll();
+
+            // Assessments (kind 30054). Track which landed their FIRST
+            // publish — only those get a 1985 mirror below.
+            const firstPublishOk = new Set();
+            for (const sel of assessSel) {
+                btn.textContent = `Publishing (${judgmentBase + (++judgmentStep)}/${totalEvents})…`;
+                const label = (sel.assessment.claim_ref.text || '').slice(0, 40);
+                try {
+                    if (sel.needsCoordBackfill) {
+                        try { await AssessmentModel.backfillCoord(sel.assessment.id, sel.coord); }
+                        catch (_) { /* best-effort */ }
+                    }
+                    const aboutPubkeys = [];
+                    for (const id of sel.aboutIds) {
+                        const ent = entitiesAll[id];
+                        if (ent && ent.keypair) aboutPubkeys.push(ent.keypair.pubkey);
+                    }
+                    const wasFirst = !sel.assessment.publishedAt;
+                    const { event: unsigned } = await buildAssessmentEvent({
+                        claimCoord:   sel.coord,
+                        claimUrl:     sel.url,
+                        claimEventId: sel.eventId,
+                        stance:       sel.assessment.stance,
+                        labels:       sel.assessment.labels,
+                        rationale:    sel.assessment.rationale,
+                        aboutPubkeys,
+                        suggestedBy:  sel.assessment.suggested_by || 'user'
+                    });
+                    const resp = await sendJudgment(unsigned);
+                    if (resp && resp.ok && resp.results) {
+                        recordRelayResults(resp.results);
+                        if (resp.results.successful > 0) {
+                            assessResults.ok++;
+                            if (wasFirst) firstPublishOk.add(sel.assessment.id);
+                            try { await AssessmentModel.markPublished(sel.assessment.id, resp.signedEvent?.id || null); }
+                            catch (_) { /* best-effort */ }
+                        } else {
+                            assessResults.fail++;
+                            assessResults.errors.push(`${label}…: no relays accepted`);
+                        }
+                    } else {
+                        assessResults.fail++;
+                        assessResults.errors.push(`${label}…: ${(resp && resp.error) || 'unknown'}`);
+                    }
+                } catch (err) {
+                    assessResults.fail++;
+                    assessResults.errors.push(`${label}…: ${err.message || String(err)}`);
+                    console.warn('[X-Ray Reader] assessment publish failed:', sel.assessment.id, err);
+                }
+                setProgress(judgmentBase + judgmentStep, totalEvents);
+                await sleep(BATCH_PUBLISH_DELAY_MS);
+            }
+
+            // Label mirrors (kind 1985) — first publish only, and only
+            // when the 30054 actually landed.
+            for (const sel of mirrorSel) {
+                btn.textContent = `Publishing (${judgmentBase + (++judgmentStep)}/${totalEvents})…`;
+                if (!firstPublishOk.has(sel.assessment.id)) {
+                    setProgress(judgmentBase + judgmentStep, totalEvents);
+                    continue;   // its 30054 didn't land — no orphan mirrors
+                }
+                try {
+                    const { event: unsigned } = buildAssessmentMirrorEvent({
+                        claimCoord: sel.coord,
+                        labels:     sel.assessment.labels
+                    });
+                    const resp = await sendJudgment(unsigned);
+                    if (resp && resp.ok && resp.results) {
+                        recordRelayResults(resp.results);
+                        if (resp.results.successful > 0) mirrorResults.ok++;
+                        else { mirrorResults.fail++; mirrorResults.errors.push('mirror: no relays accepted'); }
+                    } else {
+                        mirrorResults.fail++;
+                        mirrorResults.errors.push(`mirror: ${(resp && resp.error) || 'unknown'}`);
+                    }
+                } catch (err) {
+                    mirrorResults.fail++;
+                    mirrorResults.errors.push(`mirror: ${err.message || String(err)}`);
+                }
+                setProgress(judgmentBase + judgmentStep, totalEvents);
+                await sleep(BATCH_PUBLISH_DELAY_MS);
+            }
+
+            // Claim links (kind 30055).
+            for (const sel of linkSel) {
+                btn.textContent = `Publishing (${judgmentBase + (++judgmentStep)}/${totalEvents})…`;
+                try {
+                    const { event: unsigned } = await buildClaimRelationshipEvent({
+                        sourceCoord:   sel.source.coord,
+                        targetCoord:   sel.target.coord,
+                        relationship:  sel.link.relationship,
+                        sourceUrl:     sel.source.url,
+                        targetUrl:     sel.target.url,
+                        sourceEventId: sel.source.eventId,
+                        targetEventId: sel.target.eventId,
+                        note:          sel.link.note,
+                        suggestedBy:   sel.link.suggested_by || 'user'
+                    });
+                    const resp = await sendJudgment(unsigned);
+                    if (resp && resp.ok && resp.results) {
+                        recordRelayResults(resp.results);
+                        if (resp.results.successful > 0) {
+                            jLinkResults.ok++;
+                            try { await EvidenceLinker.markPublished(sel.link.id, resp.signedEvent?.id || null); }
+                            catch (_) { /* best-effort */ }
+                        } else {
+                            jLinkResults.fail++;
+                            jLinkResults.errors.push(`${sel.link.relationship} link: no relays accepted`);
+                        }
+                    } else {
+                        jLinkResults.fail++;
+                        jLinkResults.errors.push(`${sel.link.relationship} link: ${(resp && resp.error) || 'unknown'}`);
+                    }
+                } catch (err) {
+                    jLinkResults.fail++;
+                    jLinkResults.errors.push(`${sel.link.relationship} link: ${err.message || String(err)}`);
+                    console.warn('[X-Ray Reader] claim-link publish failed:', sel.link.id, err);
+                }
+                setProgress(judgmentBase + judgmentStep, totalEvents);
+                await sleep(BATCH_PUBLISH_DELAY_MS);
+            }
+        }
 
         // Build + surface the end-of-batch summary.
         showPublishSummary({
@@ -1763,6 +1928,12 @@ async function publish() {
             claimCount: claimsToPublish.length,
             relationshipResults,
             relationshipCount: relationshipsToPublish.length,
+            assessResults,
+            assessCount: assessSel.length,
+            mirrorResults,
+            mirrorCount: mirrorSel.length,
+            jLinkResults,
+            jLinkCount: linkSel.length,
             relayStats
         });
 
@@ -1933,6 +2104,8 @@ function showPublishSummary({
     includeComments, totalEvents, articleResults,
     commentResults, entityResults, entityCount,
     claimResults, claimCount, relationshipResults, relationshipCount,
+    assessResults, assessCount = 0, mirrorResults, mirrorCount = 0,
+    jLinkResults, jLinkCount = 0,
     relayStats
 }) {
     // Console breakdown (always useful for debugging)
@@ -1942,6 +2115,9 @@ function showPublishSummary({
     if (entityResults && entityCount > 0)                    console.log('entities:',       entityResults);
     if (claimResults  && claimCount  > 0)                    console.log('claims:',         claimResults);
     if (relationshipResults && relationshipCount > 0)        console.log('relationships:',  relationshipResults);
+    if (assessResults && assessCount > 0)                    console.log('assessments:',    assessResults);
+    if (mirrorResults && mirrorCount > 0)                    console.log('label mirrors:',  mirrorResults);
+    if (jLinkResults && jLinkCount > 0)                      console.log('claim links:',    jLinkResults);
     console.log('per relay:', Object.fromEntries(relayStats));
     console.groupEnd();
 
@@ -1954,6 +2130,9 @@ function showPublishSummary({
     const cmtFails  = (commentResults      && commentResults.fail)      || 0;
     const clmFails  = (claimResults        && claimResults.fail)        || 0;
     const relFails  = (relationshipResults && relationshipResults.fail) || 0;
+    const jdgFails  = ((assessResults && assessResults.fail) || 0)
+                    + ((mirrorResults && mirrorResults.fail) || 0)
+                    + ((jLinkResults && jLinkResults.fail) || 0);
 
     const segments = [];
     segments.push(articleResults.successful > 0
@@ -1971,6 +2150,15 @@ function showPublishSummary({
     if (relationshipCount > 0) {
         segments.push(`${relationshipResults.ok}/${relationshipResults.ok + relationshipResults.fail} relationship${relationshipCount === 1 ? '' : 's'}`);
     }
+    if (assessCount > 0) {
+        segments.push(`${assessResults.ok}/${assessCount} assessment${assessCount === 1 ? '' : 's'}`);
+    }
+    if (mirrorCount > 0) {
+        segments.push(`${mirrorResults.ok}/${mirrorCount} label mirror${mirrorCount === 1 ? '' : 's'}`);
+    }
+    if (jLinkCount > 0) {
+        segments.push(`${jLinkResults.ok}/${jLinkCount} claim link${jLinkCount === 1 ? '' : 's'}`);
+    }
     let line = 'Published: ' + segments.join(', ') + '.';
 
     const acceptedAll = [...relayStats.values()].filter((s) => s.fail === 0 && s.ok > 0).length;
@@ -1983,7 +2171,7 @@ function showPublishSummary({
         line += ` Rejected by ${names} — consider removing in Options.`;
     }
 
-    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0;
+    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0 || jdgFails > 0;
     const level = (anyFail || articleResults.successful === 0)
         ? (articleResults.successful > 0 ? 'warning' : 'error')
         : 'success';
@@ -2001,7 +2189,7 @@ function showPublishSummary({
             : 'X-Ray: Publish complete';
     notify(notifyTitle, line, level);
 
-    return totalEvents - cmtFails - entFails - clmFails - relFails
+    return totalEvents - cmtFails - entFails - clmFails - relFails - jdgFails
                        - (articleResults.successful === 0 ? 1 : 0);
 }
 

--- a/src/shared/assessment-publish.js
+++ b/src/shared/assessment-publish.js
@@ -1,0 +1,106 @@
+// Assessment publish selection — Phase 11.7 (docs/ASSESSMENTS_DESIGN.md,
+// the flag-gated publish slice).
+//
+// Pure selection logic for which judgment records are wire-ready in a
+// publish batch, kept out of the reader so it's unit-testable:
+//
+//   - an ASSESSMENT publishes when its claim's coordinate is known:
+//     foreign refs carry it; own claims need a recorded
+//     publishedPubkey (claims publish before assessments in the
+//     batch, so a claim published moments ago qualifies). The
+//     coordinate is derived from the RECORDED publishing pubkey,
+//     never the current signer.
+//   - a LINK publishes when BOTH endpoints' coordinates are known.
+//   - the usual `updated > publishedAt` staleness gate applies, so
+//     edits re-emit (NIP-01 replaceable semantics on the wire d-tag).
+//
+// Callers pass plain dictionaries (model getAll() results) plus a
+// snapshot canonicalizer — no storage access here.
+
+import { isLocalClaimId, parseClaimCoord, buildClaimCoord } from './claim-ref.js';
+
+/**
+ * Wire-readiness of one claim ref. Returns
+ * `{ coord, url, eventId, aboutIds }` or null when the claim can't be
+ * referenced on the wire yet (our own claim, not yet published).
+ */
+export function claimWireInfo(claims, canonicalRef, fallback = {}) {
+    if (isLocalClaimId(canonicalRef)) {
+        const claim = claims[canonicalRef];
+        if (!claim || !claim.publishedPubkey) return null;
+        return {
+            coord:    buildClaimCoord(claim.publishedPubkey, claim.id),
+            url:      claim.source_url || '',
+            eventId:  claim.publishedEventId || null,
+            aboutIds: claim.about || []
+        };
+    }
+    if (!parseClaimCoord(canonicalRef)) return null;
+    return {
+        coord:    canonicalRef,
+        url:      fallback.url || '',
+        eventId:  fallback.event_id || null,
+        aboutIds: []
+    };
+}
+
+/**
+ * Assessments that are wire-ready and stale. Sorted by creation time
+ * so batches are stable. Each entry: `{ assessment, coord, url,
+ * eventId, aboutIds, needsCoordBackfill }`.
+ */
+export function selectAssessmentsToPublish({ assessments, claims, canon }) {
+    const out = [];
+    for (const a of Object.values(assessments || {})) {
+        if (a.publishedAt && (a.updated || 0) <= a.publishedAt) continue;
+        const rawRef = a.claim_ref && (a.claim_ref.claim_id || a.claim_ref.coord);
+        if (!rawRef) continue;
+        const ref = canon(rawRef);
+        const info = claimWireInfo(claims, ref, a.claim_ref || {});
+        if (!info) continue;   // own claim still unpublished — a later batch
+        out.push({
+            assessment: a,
+            ...info,
+            needsCoordBackfill: !!(a.claim_ref && a.claim_ref.claim_id
+                                   && a.claim_ref.coord !== info.coord)
+        });
+    }
+    out.sort((x, y) => (x.assessment.created || 0) - (y.assessment.created || 0));
+    return out;
+}
+
+/**
+ * Links that are wire-ready (both endpoints) and stale. Legacy
+ * `contextualizes` records never publish — the relationship isn't in
+ * the kind-30055 vocabulary. Each entry: `{ link, source, target }`
+ * with per-endpoint `{ coord, url, eventId }`.
+ */
+export function selectLinksToPublish({ links, claims, canon }) {
+    const out = [];
+    for (const link of Object.values(links || {})) {
+        if (link.relationship === 'contextualizes') continue;
+        if (link.publishedAt && (link.updated || 0) <= link.publishedAt) continue;
+        const source = claimWireInfo(claims, canon(link.source_claim_id), link.source_snapshot || {});
+        const target = claimWireInfo(claims, canon(link.target_claim_id), link.target_snapshot || {});
+        if (!source || !target) continue;
+        out.push({ link, source, target });
+    }
+    out.sort((x, y) => (x.link.created || 0) - (y.link.created || 0));
+    return out;
+}
+
+/**
+ * The kind-1985 mirrors for a batch: one per labeled assessment on
+ * its FIRST publish only. Kind 1985 is a regular (non-replaceable)
+ * event, so re-mirroring on every edit would accumulate duplicates in
+ * naive aggregators; the trade-off (a label edit after first publish
+ * leaves the mirror stale until a NIP-09 cleanup pass exists) is
+ * recorded in the JOURNAL.
+ */
+export function selectMirrors(assessmentSelections) {
+    return (assessmentSelections || []).filter((s) =>
+        !s.assessment.publishedAt
+        && Array.isArray(s.assessment.labels)
+        && s.assessment.labels.length > 0
+    );
+}

--- a/src/shared/metadata/builders.js
+++ b/src/shared/metadata/builders.js
@@ -675,6 +675,49 @@ export async function buildClaimRelationshipEvent({
   };
 }
 
+/**
+ * Build an unsigned kind 1985 label event mirroring an assessment's
+ * labels — the designated plain-NIP-32 ecosystem-aggregation path
+ * (NIP draft §30054): generic NIP-32 consumers query kind 1985 and
+ * read `L`/`l` against the `a`-referenced target, which is exactly
+ * this shape. Emitted alongside a labeled 30054 on its FIRST publish,
+ * behind the same `assessmentPublishing` flag. Notes/anchors/stance
+ * stay on the 30054 — the mirror is aggregation-only.
+ *
+ * @param {object} args
+ * @param {string} args.claimCoord      — `30040:<pubkey>:<d>` (required)
+ * @param {Array<string>} args.labels   — at least one taxonomy/custom label
+ * @param {string} [args.relayHint]
+ * @param {number} [args.createdAt]
+ * @returns {{event, body, dTag: null}}  (kind 1985 is a regular event)
+ */
+export function buildAssessmentMirrorEvent({
+  claimCoord,
+  labels,
+  relayHint = '',
+  createdAt = nowSeconds()
+} = {}) {
+  const coord = assertClaimCoordinate(claimCoord, 'buildAssessmentMirrorEvent', 'claimCoord');
+  const labelList = cleanWireLabels(labels, 'buildAssessmentMirrorEvent');
+  if (labelList.length === 0) {
+    throw new Error('buildAssessmentMirrorEvent: at least one label required');
+  }
+
+  const tags = [
+    tag('L', ASSESSMENT_LABEL_NAMESPACE),
+    ...labelList.map((l) => tag('l', l.label, ASSESSMENT_LABEL_NAMESPACE)),
+    tag('a', claimCoord, relayHint),
+    tag('p', coord.pubkey),
+    tag('client', 'xray')
+  ];
+
+  return {
+    event: { kind: 1985, created_at: createdAt, tags, content: '' },
+    body: '',
+    dTag: null
+  };
+}
+
 // ------------------------------------------------------------------
 // `responds-to` tag for kind 30023 (extension)
 // ------------------------------------------------------------------

--- a/tests/assessment-publish.test.mjs
+++ b/tests/assessment-publish.test.mjs
@@ -1,0 +1,224 @@
+// Assessment publish-selection tests — Phase 11.7 (the flag-gated
+// publish slice; docs/ASSESSMENTS_DESIGN.md).
+// Same chrome.storage.local shim pattern as entity-model.test.mjs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const { claimWireInfo, selectAssessmentsToPublish, selectLinksToPublish, selectMirrors } =
+    await import('../src/shared/assessment-publish.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+const { AssessmentModel } = await import('../src/shared/assessment-model.js');
+const { EvidenceLinker } = await import('../src/shared/evidence-linker.js');
+const { makeClaimRefCanonicalizer, buildClaimCoord } = await import('../src/shared/claim-ref.js');
+
+function resetState() { _stateStore.clear(); }
+
+const PUBKEY_A = 'a'.repeat(64);
+const PUBKEY_B = 'b'.repeat(64);
+
+async function ctx() {
+    return {
+        claims: await ClaimModel.getAll(),
+        assessments: await AssessmentModel.getAll(),
+        links: await EvidenceLinker.getAll(),
+        canon: await makeClaimRefCanonicalizer()
+    };
+}
+
+// ---------------------------------------------------------------------
+
+test('publish-select: claimWireInfo gates on the recorded publishing pubkey', async () => {
+    resetState();
+    const claim = await ClaimModel.create({ text: 'Own claim.', source_url: 'https://example.com/a' });
+    let { claims } = await ctx();
+    assert.equal(claimWireInfo(claims, claim.id), null, 'unpublished own claim is not wire-ready');
+
+    // Published pre-11.1 style (no pubkey recorded) — still not ready.
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64));
+    ({ claims } = await ctx());
+    assert.equal(claimWireInfo(claims, claim.id), null, 'publishedAt alone is insufficient');
+
+    await ClaimModel.markPublished(claim.id, 'f'.repeat(64), PUBKEY_A);
+    ({ claims } = await ctx());
+    const info = claimWireInfo(claims, claim.id);
+    assert.equal(info.coord, buildClaimCoord(PUBKEY_A, claim.id));
+    assert.equal(info.url, 'https://example.com/a');
+    assert.equal(info.eventId, 'f'.repeat(64));
+
+    // Foreign coordinates are always wire-ready; fallback carries url.
+    const foreign = claimWireInfo(claims, buildClaimCoord(PUBKEY_B, 'their-d'), { url: 'https://example.com/b' });
+    assert.equal(foreign.coord, buildClaimCoord(PUBKEY_B, 'their-d'));
+    assert.equal(foreign.url, 'https://example.com/b');
+});
+
+test('publish-select: assessments — readiness, staleness, and coord backfill flag', async () => {
+    resetState();
+    const unpub = await ClaimModel.create({ text: 'Unpublished.', source_url: 'https://example.com/u' });
+    const pub   = await ClaimModel.create({ text: 'Published.', source_url: 'https://example.com/p' });
+    await ClaimModel.markPublished(pub.id, 'e'.repeat(64), PUBKEY_A);
+
+    const aUnpub = await AssessmentModel.create({ claim_ref: { claim_id: unpub.id }, stance: 1 });
+    const aPub   = await AssessmentModel.create({ claim_ref: { claim_id: pub.id }, stance: -1, labels: ['misleading'] });
+    const aForeign = await AssessmentModel.create({
+        claim_ref: { coord: buildClaimCoord(PUBKEY_B, 'their-d'), url: 'https://example.com/f', text: 'Foreign.' },
+        labels: ['euphemism']
+    });
+
+    let sel = selectAssessmentsToPublish(await ctx());
+    const ids = sel.map((s) => s.assessment.id);
+    assert.ok(!ids.includes(aUnpub.id), 'own-unpublished-claim assessment waits');
+    assert.ok(ids.includes(aPub.id));
+    assert.ok(ids.includes(aForeign.id));
+    assert.equal(sel.length, 2);
+
+    const pubSel = sel.find((s) => s.assessment.id === aPub.id);
+    assert.equal(pubSel.coord, buildClaimCoord(PUBKEY_A, pub.id));
+    assert.equal(pubSel.needsCoordBackfill, false,
+        'assessed AFTER publish → the model auto-filled the coordinate at create');
+    assert.deepEqual(pubSel.aboutIds, [], 'no about entities on this fixture');
+
+    // The backfill flag DOES fire when the assessment predates the
+    // claim's publish (the coordinate wasn't knowable at create time).
+    const early = await ClaimModel.create({ text: 'Assessed first.', source_url: 'https://example.com/e' });
+    const aEarly = await AssessmentModel.create({ claim_ref: { claim_id: early.id }, stance: 2 });
+    await ClaimModel.markPublished(early.id, '9'.repeat(64), PUBKEY_A);
+    const selEarly = selectAssessmentsToPublish(await ctx())
+        .find((s) => s.assessment.id === aEarly.id);
+    assert.equal(selEarly.needsCoordBackfill, true, 'record predates the coordinate');
+    assert.equal(selEarly.coord, buildClaimCoord(PUBKEY_A, early.id));
+
+    // Once published and unchanged, an assessment drops out…
+    await AssessmentModel.markPublished(aPub.id, '1'.repeat(64));
+    sel = selectAssessmentsToPublish(await ctx());
+    assert.ok(!sel.map((s) => s.assessment.id).includes(aPub.id), 'published + unchanged → skipped');
+
+    // …and re-enters after an edit (updated > publishedAt).
+    await new Promise((r) => setTimeout(r, 1100));
+    await AssessmentModel.update(aPub.id, { stance: -2 });
+    sel = selectAssessmentsToPublish(await ctx());
+    assert.ok(sel.map((s) => s.assessment.id).includes(aPub.id), 'edited → re-emits');
+});
+
+test('publish-select: links need BOTH endpoints wire-ready; legacy contextualizes never publishes', async () => {
+    resetState();
+    const pubClaim = await ClaimModel.create({ text: 'Ours, published.', source_url: 'https://example.com/p' });
+    await ClaimModel.markPublished(pubClaim.id, 'e'.repeat(64), PUBKEY_A);
+    const unpubClaim = await ClaimModel.create({ text: 'Ours, local.', source_url: 'https://example.com/u' });
+    const foreignCoord = buildClaimCoord(PUBKEY_B, 'their-d');
+
+    const ready = await EvidenceLinker.create({
+        source_claim_id: pubClaim.id, target_claim_id: foreignCoord,
+        relationship: 'contradicts',
+        target_snapshot: { url: 'https://example.com/f', text: 'Foreign.' }
+    });
+    const half = await EvidenceLinker.create({
+        source_claim_id: unpubClaim.id, target_claim_id: foreignCoord,
+        relationship: 'supports',
+        target_snapshot: { url: 'https://example.com/f', text: 'Foreign.' }
+    });
+    // Legacy record written straight into storage.
+    _stateStore.set('evidence_links', JSON.stringify({
+        ...JSON.parse(_stateStore.get('evidence_links')),
+        link_0123456789abcdef: {
+            id: 'link_0123456789abcdef',
+            source_claim_id: pubClaim.id, target_claim_id: foreignCoord,
+            relationship: 'contextualizes', note: '', created: 1, updated: 1,
+            publishedAt: null, publishedEventId: null
+        }
+    }));
+
+    const sel = selectLinksToPublish(await ctx());
+    assert.equal(sel.length, 1, 'half-ready and legacy links are skipped');
+    assert.equal(sel[0].link.id, ready.id);
+    // contradicts is symmetric — endpoints were stored sorted, so the
+    // foreign coordinate ('30040:bbbb…' < 'claim_…') is the source.
+    assert.deepEqual(
+        [sel[0].source.coord, sel[0].target.coord].sort(),
+        [buildClaimCoord(PUBKEY_A, pubClaim.id), foreignCoord].sort()
+    );
+    const foreignSide = sel[0].source.coord === foreignCoord ? sel[0].source : sel[0].target;
+    assert.equal(foreignSide.url, 'https://example.com/f', 'snapshot url rides along');
+
+    await EvidenceLinker.markPublished(ready.id, '2'.repeat(64));
+    assert.equal(selectLinksToPublish(await ctx()).length, 0, 'published + unchanged → skipped');
+});
+
+test('publish-select: drift-stored refs still resolve (coordinate stored, pubkey recorded later)', async () => {
+    resetState();
+    const claim = await ClaimModel.create({ text: 'Drifter.', source_url: 'https://example.com/d' });
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64));   // no pubkey yet
+    const coord = buildClaimCoord(PUBKEY_A, claim.id);
+    const a = await AssessmentModel.create({
+        claim_ref: { coord, url: 'https://example.com/d', text: claim.text }, stance: 0
+    });
+    assert.equal(a.claim_ref.claim_id, null, 'stored coordinate-keyed');
+
+    // Not selectable yet: the coordinate canonicalizes to itself, and
+    // claimWireInfo can't verify a foreign coord? It CAN — foreign
+    // coords are always wire-ready. This is the known pre-backfill
+    // ambiguity: until the pubkey is recorded, our own coordinate is
+    // indistinguishable from a foreign one and publishes as foreign.
+    let sel = selectAssessmentsToPublish(await ctx());
+    assert.equal(sel.length, 1);
+    assert.equal(sel[0].coord, coord);
+
+    // After the pubkey lands, the same record selects via the LOCAL
+    // claim (canonicalization collapses), picking up registry data.
+    await ClaimModel.markPublished(claim.id, 'f'.repeat(64), PUBKEY_A);
+    sel = selectAssessmentsToPublish(await ctx());
+    assert.equal(sel.length, 1);
+    assert.equal(sel[0].coord, coord, 'same coordinate either way');
+    assert.equal(sel[0].eventId, 'f'.repeat(64), 'registry event id now available');
+});
+
+test('publish-select: mirrors — labeled, first-publish only', async () => {
+    resetState();
+    const claim = await ClaimModel.create({ text: 'Mirrored.', source_url: 'https://example.com/m' });
+    await ClaimModel.markPublished(claim.id, 'e'.repeat(64), PUBKEY_A);
+    const labeled   = await AssessmentModel.create({ claim_ref: { claim_id: claim.id }, labels: ['misleading'] });
+
+    const claim2 = await ClaimModel.create({ text: 'Stance only.', source_url: 'https://example.com/m2' });
+    await ClaimModel.markPublished(claim2.id, 'e'.repeat(64), PUBKEY_A);
+    await AssessmentModel.create({ claim_ref: { claim_id: claim2.id }, stance: 2 });
+
+    let sel = selectAssessmentsToPublish(await ctx());
+    assert.equal(sel.length, 2);
+    let mirrors = selectMirrors(sel);
+    assert.equal(mirrors.length, 1, 'stance-only assessments do not mirror');
+    assert.equal(mirrors[0].assessment.id, labeled.id);
+
+    // A REpublish (edit after first publish) must not re-mirror. The
+    // stance-only assessment is still unpublished, so it stays in the
+    // selection alongside the edited one.
+    await AssessmentModel.markPublished(labeled.id, '1'.repeat(64));
+    await new Promise((r) => setTimeout(r, 1100));
+    await AssessmentModel.update(labeled.id, { labels: ['misleading', 'outdated'] });
+    sel = selectAssessmentsToPublish(await ctx());
+    assert.ok(sel.map((s) => s.assessment.id).includes(labeled.id), 'edited assessment re-selects');
+    mirrors = selectMirrors(sel);
+    assert.equal(mirrors.length, 0, 'mirrors are first-publish only (1985 is non-replaceable)');
+});

--- a/tests/metadata-assessments.test.mjs
+++ b/tests/metadata-assessments.test.mjs
@@ -12,7 +12,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-const { buildAssessmentEvent, buildClaimRelationshipEvent } =
+const { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent } =
   await import('../src/shared/metadata/builders.js');
 const { ASSESSMENT_LABEL_NAMESPACE } =
   await import('../src/shared/assessment-taxonomy.js');
@@ -293,6 +293,40 @@ test('30055: validation', async () => {
     /cannot link a claim to itself/);
   await assert.rejects(() => buildClaimRelationshipEvent({ ...ok, suggestedBy: 'llm: ' }),
     /suggestedBy/);
+});
+
+// ---------------------------------------------------------------------
+// Kind 1985 — assessment label mirror
+// ---------------------------------------------------------------------
+
+test('1985 mirror: tag shape, regular-event semantics, validation', () => {
+  const { event, dTag } = buildAssessmentMirrorEvent({
+    claimCoord: COORD_A,
+    labels: [{ label: 'misleading', note: 'note stays on the 30054' }, 'flip-flop'],
+    relayHint: 'wss://relay.example'
+  });
+
+  assert.equal(event.kind, 1985);
+  assert.equal(event.content, '');
+  assert.equal(dTag, null, 'kind 1985 is a regular event — no d');
+
+  assert.deepEqual(firstTag(event, 'L'), ['L', ASSESSMENT_LABEL_NAMESPACE]);
+  assert.deepEqual(tagsNamed(event, 'l'), [
+    ['l', 'misleading', ASSESSMENT_LABEL_NAMESPACE],
+    ['l', 'flip-flop', ASSESSMENT_LABEL_NAMESPACE]
+  ]);
+  assert.deepEqual(firstTag(event, 'a'), ['a', COORD_A, 'wss://relay.example']);
+  assert.deepEqual(firstTag(event, 'p'), ['p', PUBKEY_A], 'claim author from the coordinate');
+  assert.deepEqual(firstTag(event, 'client'), ['client', 'xray']);
+  assert.equal(firstTag(event, 'label-note'), undefined, 'enrichments stay on the 30054');
+  for (const t of event.tags) {
+    for (const v of t) assert.equal(typeof v, 'string');
+  }
+
+  assert.throws(() => buildAssessmentMirrorEvent({ claimCoord: COORD_A, labels: [] }),
+    /at least one label/);
+  assert.throws(() => buildAssessmentMirrorEvent({ claimCoord: 'claim_aaaaaaaaaaaaaaaa', labels: ['misleading'] }),
+    /must be a 30040:<pubkey>:<d> coordinate/);
 });
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
The publish slice from docs/ASSESSMENTS_DESIGN.md's follow-up list: flag-gated wire emission of assessments, claim links, and first-publish label mirrors, with claim-before-assessment ordering, recorded-pubkey coordinates, coord backfill, and an options toggle. Gates: build ✅ 582/582 ✅ lint ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)