### PR TITLE
Phase 11.8 — Case collaboration bundles (shared entity keys)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Case collaboration bundles** (Phase 11.8). A case entity's detail view
+  gains **Share case bundle (includes keys)**: a JSON file carrying the
+  case and every entity its claims reference — names, alias links, and
+  **private keys** (clearly warned; share it like a password). A
+  collaborator imports it via the entity list's existing Import button:
+  keys install conflict-safely (an existing different key is never
+  overwritten — reported instead), records keep the exporter's original
+  entity ids, and from then on both sides tag claims under the **same
+  entity pubkeys**, so published claims aggregate in the `#p` queries and
+  the case dashboard across installs. This closes the known
+  per-install-pubkey limitation for shared cases.
+
 - **Judgment publishing** (Phase 11.7; behind **Settings → Advanced →
   Experimental → "Publish assessments & claim links to relays"**, default
   off). When enabled, the reader's Publish batch also emits — after the

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,38 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-10 — Phase 11.8: collaboration = shared entity keys, by bundle
+
+**Tags:** design
+
+Cross-user aggregation was the design note's first known limitation:
+entity keypairs are random per install, so two users' "claims about P"
+never meet. The fix is deliberately low-tech — a **case bundle** file
+(case entity + every entity its claims reference, WITH private keys)
+that a collaborator imports.
+
+Decisions worth remembering:
+
+- **Bundle import preserves the exporter's entity ids** via the new
+  `EntityModel.importRecord` (upsert-as-given). `create()` re-derives
+  ids from (type, name), which breaks after renames — and the id is
+  what `keyName` and claim `about` refs point at. Discovered en route:
+  the panel's legacy array-import path creates entities with FRESH
+  keypairs, so it never enabled aggregation; it remains for name-set
+  sharing, bundles are the collaboration path.
+- **Key conflicts are terminal, not merged:** `LocalKeyManager.importKey`
+  is idempotent for the same key and throws for a different one — we
+  never overwrite key material. The same case independently created on
+  two installs (deterministic ids collide on purpose) reports a
+  conflict; claims published under the two keys won't merge, pick one
+  side's bundle and re-tag.
+- **Security posture:** the bundle is plaintext keys, same as the
+  keypair-registry export precedent. The UI says "share it like a
+  password" twice. Encrypting to a collaborator's npub (NIP-44) is the
+  obvious upgrade once a key-exchange UX exists.
+
+---
+
 ## 2026-06-10 — Phase 11.7: judgment publishing behind the flag
 
 **Tags:** design, wire-format

--- a/src/shared/case-bundle.js
+++ b/src/shared/case-bundle.js
@@ -1,0 +1,145 @@
+// Case collaboration bundles — Phase 11.8 (docs/ASSESSMENTS_DESIGN.md
+// "Known limitations": entity pubkeys are per-install, so cross-user
+// aggregation only works between users who share entity keys).
+//
+// A bundle carries a case entity and every entity its claims
+// reference — INCLUDING their private keys — so a collaborator who
+// imports it tags claims under the SAME entity pubkeys, and both
+// sides' published claims aggregate in the `#p` queries / case
+// dashboard. Treat bundle files like nsec backups: anyone holding one
+// can sign as those entities.
+//
+// Import is conflict-safe: a different key already installed under an
+// entity's name is never overwritten — the entity is reported as a
+// conflict (claims published under the two keys won't merge; pick one
+// side's bundle and re-tag).
+
+import { Storage } from './storage.js';
+import { ClaimModel } from './claim-model.js';
+import { EntityModel } from './entity-model.js';
+import { LocalKeyManager } from './local-key-manager.js';
+
+export const CASE_BUNDLE_FORMAT = 'xray-case-bundle';
+export const CASE_BUNDLE_VERSION = 1;
+
+/**
+ * Every entity id in the case's orbit: the case itself, every entity
+ * a claim about the case is `about`, entity claim sources, and the
+ * canonical targets of any of those (aliases must travel with their
+ * canonical or the importer's alias graph dangles).
+ */
+async function collectCaseEntityIds(caseEntityId) {
+    const ids = new Set([caseEntityId]);
+    const claims = Object.values(await ClaimModel.getAll())
+        .filter((c) => (c.about || []).includes(caseEntityId));
+    for (const c of claims) {
+        for (const id of c.about || []) ids.add(id);
+        if (c.source && /^entity_/.test(c.source)) ids.add(c.source);
+    }
+    // Pull in canonical targets (alias graph is depth ≤ 1 by design).
+    const all = await Storage.get('entities', {});
+    for (const id of [...ids]) {
+        const rec = all[id];
+        if (rec && rec.canonical_id) ids.add(rec.canonical_id);
+    }
+    return [...ids];
+}
+
+/**
+ * Build the shareable bundle for a case. Returns the plain object;
+ * `buildCaseBundleJson` serializes it.
+ */
+export async function collectCaseBundle(caseEntityId) {
+    const caseEntity = await EntityModel.get(caseEntityId);
+    if (!caseEntity) throw new Error(`Entity not found: ${caseEntityId}`);
+
+    const ids = await collectCaseEntityIds(caseEntityId);
+    const entities = [];
+    for (const id of ids) {
+        const e = await EntityModel.get(id);
+        if (!e) continue;   // dangling about-ref — claim survives, bundle skips it
+        entities.push({
+            id:           e.id,
+            name:         e.name,
+            type:         e.type,
+            description:  e.description || '',
+            nip05:        e.nip05 || '',
+            canonical_id: e.canonical_id || null,
+            keyName:      e.keyName || `entity:${e.id}`,
+            // The collaboration payload. Reference-only entities (no
+            // local key) export without one — the importer gets the
+            // record but can't sign for it.
+            privkey:      (e.keypair && e.keypair.privateKey) || null
+        });
+    }
+
+    return {
+        format:   CASE_BUNDLE_FORMAT,
+        version:  CASE_BUNDLE_VERSION,
+        case_id:  caseEntity.id,
+        entities
+    };
+}
+
+/** Serialize with an injected timestamp (pure; deterministic in tests). */
+export function buildCaseBundleJson(bundle, exportedAt) {
+    return JSON.stringify({ ...bundle, exported_at: exportedAt }, null, 2);
+}
+
+/** Shape check for incoming parsed JSON. */
+export function isCaseBundle(parsed) {
+    return !!(parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        && parsed.format === CASE_BUNDLE_FORMAT
+        && Array.isArray(parsed.entities));
+}
+
+/**
+ * Import a parsed bundle: install keys (conflict-safe), upsert entity
+ * records under their ORIGINAL ids. Returns
+ * `{ caseId, added, updated, keysInstalled, conflicts, skipped }`.
+ */
+export async function importCaseBundle(parsed) {
+    if (!isCaseBundle(parsed)) throw new Error('Not an X-Ray case bundle');
+    if (parsed.version > CASE_BUNDLE_VERSION) {
+        throw new Error(`Bundle version ${parsed.version} is newer than this X-Ray understands (${CASE_BUNDLE_VERSION})`);
+    }
+
+    const existingAll = await Storage.get('entities', {});
+    let added = 0, updated = 0, keysInstalled = 0;
+    const conflicts = [];
+    let skipped = 0;
+
+    for (const row of parsed.entities) {
+        if (!row || !/^entity_[0-9a-f]{16}$/.test(String(row.id || '')) || !row.name || !row.type) {
+            skipped++;
+            continue;
+        }
+        const keyName = row.keyName || `entity:${row.id}`;
+        let keyOk = true;
+        if (row.privkey) {
+            try {
+                const before = LocalKeyManager.getKey(keyName);
+                await LocalKeyManager.importKey(keyName, row.privkey, {
+                    entityId: row.id, entityName: row.name, entityType: row.type
+                });
+                if (!before) keysInstalled++;
+            } catch (err) {
+                // A DIFFERENT key already lives here — never overwrite.
+                keyOk = false;
+                conflicts.push(`${row.name}: ${err.message || err}`);
+            }
+        }
+        if (!keyOk) continue;   // record under a conflicting key would mislead
+
+        try {
+            const existed = !!existingAll[row.id];
+            await EntityModel.importRecord({ ...row, keyName });
+            if (existed) updated++; else added++;
+        } catch (err) {
+            skipped++;
+            conflicts.push(`${row.name}: ${err.message || err}`);
+        }
+    }
+
+    return { caseId: parsed.case_id || null, added, updated, keysInstalled, conflicts, skipped };
+}

--- a/src/shared/entity-model.js
+++ b/src/shared/entity-model.js
@@ -205,6 +205,54 @@ export const EntityModel = {
     },
 
     /**
+     * Upsert an entity record AS GIVEN — id included (Phase 11.8).
+     * Unlike `create`, the id is NOT re-derived from (type, name):
+     * collaboration bundles must preserve the exporter's id, which can
+     * diverge from sha(type:name) after renames, and the id is what
+     * `keyName` and claim `about` refs point at. Existing records are
+     * patched (name/description/nip05/canonical_id/keyName); missing
+     * ones are written whole. Keypair installation is the caller's job
+     * (LocalKeyManager.importKey) — this only writes the record.
+     */
+    importRecord: async (row) => {
+        if (!row || typeof row.id !== 'string' || !/^entity_[0-9a-f]{16}$/.test(row.id)) {
+            throw new Error('importRecord: row.id must be an entity id');
+        }
+        const name = assertValidName(row.name);
+        assertValidType(row.type);
+
+        const all = await Storage.get('entities', {});
+        const existing = all[row.id];
+        const now = Math.floor(Date.now() / 1000);
+        if (existing) {
+            all[row.id] = {
+                ...existing,
+                name,
+                type:         row.type,
+                description:  row.description || existing.description || '',
+                nip05:        row.nip05 || existing.nip05 || '',
+                canonical_id: row.canonical_id || existing.canonical_id || null,
+                keyName:      row.keyName || existing.keyName,
+                updated:      now
+            };
+        } else {
+            all[row.id] = {
+                id:           row.id,
+                name,
+                type:         row.type,
+                description:  row.description || '',
+                nip05:        row.nip05 || '',
+                canonical_id: row.canonical_id || null,
+                keyName:      row.keyName || `entity:${row.id}`,
+                created:      now,
+                updated:      now
+            };
+        }
+        await Storage.set('entities', all);
+        return await EntityModel.get(row.id);
+    },
+
+    /**
      * Patch an existing entity. Keypair and id are immutable. Name and
      * type changes don't rederive the id — this is intentional: the id
      * is the stable identifier for relay-published kind-0 events.

--- a/src/shared/local-key-manager.js
+++ b/src/shared/local-key-manager.js
@@ -50,6 +50,39 @@ export const LocalKeyManager = {
         return keyData;
     },
 
+    /**
+     * Install a known private key under `name` (Phase 11.8 — case
+     * collaboration bundles import collaborators' entity keys so
+     * claims aggregate under the same pubkeys). Idempotent when the
+     * same key is already installed; CONFLICT (throws) when a
+     * different key occupies the name — never silently overwrite key
+     * material.
+     */
+    importKey: async (name, privateKeyHex, metadata = {}) => {
+        if (!/^[0-9a-f]{64}$/.test(String(privateKeyHex || ''))) {
+            throw new Error('importKey: privateKey must be 64 hex chars');
+        }
+        const existing = LocalKeyManager.keys.get(name);
+        if (existing) {
+            if (existing.privateKey === privateKeyHex) return existing;   // idempotent
+            throw new Error('Key conflict: a different key already exists for ' + name);
+        }
+        const pubkey = Crypto.getPublicKey(privateKeyHex);
+        const keyData = {
+            name,
+            privateKey: privateKeyHex,
+            pubkey,
+            npub: Crypto.hexToNpub(pubkey),
+            nsec: Crypto.hexToNsec(privateKeyHex),
+            metadata: { ...metadata, imported: true },
+            created: Math.floor(Date.now() / 1000)
+        };
+        LocalKeyManager.keys.set(name, keyData);
+        await LocalKeyManager.save();
+        Utils.log('Imported local key:', name, keyData.npub);
+        return keyData;
+    },
+
     getKey: (name) => LocalKeyManager.keys.get(name) || null,
 
     listKeys: () => Array.from(LocalKeyManager.keys.values()),

--- a/src/sidepanel/index.js
+++ b/src/sidepanel/index.js
@@ -21,6 +21,7 @@ import { EvidenceLinker, EVIDENCE_RELATIONSHIP_ICONS } from '../shared/evidence-
 import { openAssessModal, renderAssessmentBadges, assessmentsByCanonicalRef } from '../shared/assess-modal.js';
 import { makeClaimRefCanonicalizer, isLocalClaimId, buildClaimCoord } from '../shared/claim-ref.js';
 import { collectCaseData, buildCaseJson, buildCaseMarkdown } from '../shared/case-export.js';
+import { collectCaseBundle, buildCaseBundleJson, isCaseBundle, importCaseBundle } from '../shared/case-bundle.js';
 import { accountsForEntity, listUnlinkedAccounts, linkAccountToEntity, unlinkAccount } from '../shared/identity/account-registry.js';
 import { LocalKeyManager } from '../shared/local-key-manager.js';
 import { Crypto } from '../shared/crypto.js';
@@ -278,6 +279,11 @@ function renderDetail(entity) {
           <button type="button" class="xr-side__ghost-btn" id="xr-export-case-json">Export JSON</button>
           <button type="button" class="xr-side__ghost-btn" id="xr-export-case-md">Export Markdown</button>
         </div>
+        <p class="xr-side__hint" style="margin-top:10px">Collaborate: share this case's <em>entity keys</em> so a collaborator's claims aggregate under the same pubkeys. <strong>The bundle contains private keys</strong> — share it like a password.</p>
+        <div class="xr-side__case-export-row">
+          <button type="button" class="xr-side__ghost-btn" id="xr-share-case-bundle">Share case bundle (includes keys)</button>
+        </div>
+        <p class="xr-side__hint" style="margin-top:6px">Your collaborator imports it via the entity list's <em>Import</em> button.</p>
       </div>` : ''}
 
       <div class="xr-side__publish">
@@ -336,6 +342,10 @@ function renderDetail(entity) {
     const exportMdBtn   = $('#xr-export-case-md');
     if (exportJsonBtn) exportJsonBtn.addEventListener('click', () => exportCase(entity, 'json'));
     if (exportMdBtn)   exportMdBtn.addEventListener('click', () => exportCase(entity, 'md'));
+
+    // Phase 11.8 — collaboration bundle (case entities only).
+    const shareBtn = $('#xr-share-case-bundle');
+    if (shareBtn) shareBtn.addEventListener('click', () => shareCaseBundle(entity));
 
     // Keypair controls.
     $('#xr-copy-npub').addEventListener('click', () => {
@@ -643,6 +653,29 @@ async function renderInconsistencies(entity) {
 
 function hostOf(url) {
     try { return new URL(url).host; } catch { return String(url || ''); }
+}
+
+/** Share a case's entity keys for collaboration (Phase 11.8). */
+async function shareCaseBundle(entity) {
+    const ok = confirm(
+        `Share "${entity.name}" as a collaboration bundle?\n\n` +
+        'The file includes the PRIVATE KEYS of this case and every entity its ' +
+        'claims reference, so a collaborator can tag claims under the same ' +
+        'pubkeys. Anyone holding the file can sign as those entities — share ' +
+        'it like a password.'
+    );
+    if (!ok) return;
+    try {
+        const bundle = await collectCaseBundle(entity.id);
+        const exportedAt = new Date().toISOString();
+        const slug = entity.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'case';
+        downloadText(`xray-case-bundle-${slug}-${exportedAt.slice(0, 10)}.json`,
+            buildCaseBundleJson(bundle, exportedAt), 'application/json');
+        const withKeys = bundle.entities.filter((e) => e.privkey).length;
+        toast(`Bundle exported: ${bundle.entities.length} entities (${withKeys} with keys)`, 'success', 5000);
+    } catch (err) {
+        alert(`Bundle export failed: ${err.message || err}`);
+    }
 }
 
 /** Export a case entity as JSON or Markdown (Phase 11.6). */
@@ -988,7 +1021,25 @@ async function handleImport(file) {
     try {
         const text = await file.text();
         const parsed = JSON.parse(text);
-        if (!Array.isArray(parsed)) throw new Error('Import file must be a JSON array of entities');
+
+        // Collaboration bundle (Phase 11.8): entities + their keys,
+        // preserved under the exporter's ids so claims aggregate.
+        if (isCaseBundle(parsed)) {
+            const r = await importCaseBundle(parsed);
+            await refreshEntities();
+            renderList();
+            const bits = [`${r.added} added`, `${r.updated} updated`, `${r.keysInstalled} key${r.keysInstalled === 1 ? '' : 's'} installed`];
+            if (r.skipped) bits.push(`${r.skipped} skipped`);
+            toast(`Case bundle imported — ${bits.join(', ')}`,
+                r.conflicts.length ? 'warning' : 'success', 6000);
+            if (r.conflicts.length) {
+                alert('Key conflicts (kept your existing keys — claims under the two keys will not merge):\n\n'
+                      + r.conflicts.join('\n'));
+            }
+            return;
+        }
+
+        if (!Array.isArray(parsed)) throw new Error('Import file must be a JSON array of entities, or an X-Ray case bundle');
         // Best-effort upsert. Entities with `keyName` pointing at a
         // key we don't have locally will have `null` keypair in get(),
         // which means they'll be reference-only (can't sign, can't

--- a/tests/case-bundle.test.mjs
+++ b/tests/case-bundle.test.mjs
@@ -1,0 +1,157 @@
+// Case collaboration bundle tests — Phase 11.8.
+// Same chrome.storage.local shim pattern as entity-model.test.mjs.
+//
+// The shim's Map doubles as "two devices": exporting from a seeded
+// store, wiping it (resetState), and importing simulates the
+// collaborator's fresh install.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const { collectCaseBundle, buildCaseBundleJson, isCaseBundle, importCaseBundle,
+        CASE_BUNDLE_FORMAT } = await import('../src/shared/case-bundle.js');
+const { EntityModel } = await import('../src/shared/entity-model.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+const { LocalKeyManager } = await import('../src/shared/local-key-manager.js');
+
+function resetState() {
+    _stateStore.clear();
+    LocalKeyManager.keys.clear();
+}
+
+async function seedCase() {
+    const kase   = await EntityModel.create({ name: 'Bricks & Minifigs scandal', type: 'case' });
+    const person = await EntityModel.create({ name: 'Ben Schneider', type: 'person' });
+    const org    = await EntityModel.create({ name: 'Bricks & Minifigs', type: 'organization' });
+    await ClaimModel.create({
+        text: 'The collection was illegally retained.',
+        source_url: 'https://example.com/v1',
+        about: [kase.id, person.id],
+        source: org.id
+    });
+    // Renamed after creation — id no longer matches sha(type:name);
+    // the bundle must preserve the ORIGINAL id.
+    const renamed = await EntityModel.update(person.id, { name: 'Reckless Ben' });
+    assert.equal(renamed.id, person.id);
+    return { kase, person, org };
+}
+
+// ---------------------------------------------------------------------
+
+test('bundle: collect gathers the case orbit with keys', async () => {
+    resetState();
+    const { kase, person, org } = await seedCase();
+    // An unrelated entity must NOT ride along.
+    await EntityModel.create({ name: 'Unrelated', type: 'thing' });
+
+    const bundle = await collectCaseBundle(kase.id);
+    assert.equal(bundle.format, CASE_BUNDLE_FORMAT);
+    assert.equal(bundle.case_id, kase.id);
+    assert.deepEqual(bundle.entities.map((e) => e.id).sort(),
+        [kase.id, person.id, org.id].sort(), 'case + about + entity source, nothing else');
+    for (const e of bundle.entities) {
+        assert.match(e.privkey, /^[0-9a-f]{64}$/, `${e.name} carries its key`);
+        assert.equal(e.keyName, `entity:${e.id}`);
+    }
+    const ben = bundle.entities.find((e) => e.id === person.id);
+    assert.equal(ben.name, 'Reckless Ben', 'post-rename name with the ORIGINAL id');
+
+    const json = buildCaseBundleJson(bundle, '2026-06-10T12:00:00.000Z');
+    assert.ok(isCaseBundle(JSON.parse(json)));
+    assert.equal(isCaseBundle([{ id: 'x' }]), false, 'legacy array export is not a bundle');
+});
+
+test('bundle: import on a fresh install — same ids, same pubkeys', async () => {
+    resetState();
+    const { kase, person } = await seedCase();
+    const bundle = await collectCaseBundle(kase.id);
+    const exporterPubkeys = new Map();
+    for (const id of [kase.id, person.id]) {
+        exporterPubkeys.set(id, (await EntityModel.get(id)).keypair.pubkey);
+    }
+
+    // "Device B": wipe everything, import the parsed bundle.
+    resetState();
+    const parsed = JSON.parse(buildCaseBundleJson(bundle, '2026-06-10T12:00:00.000Z'));
+    const r = await importCaseBundle(parsed);
+    assert.equal(r.added, 3);
+    assert.equal(r.updated, 0);
+    assert.equal(r.keysInstalled, 3);
+    assert.deepEqual(r.conflicts, []);
+    assert.equal(r.caseId, kase.id);
+
+    // THE collaboration property: identical entity pubkeys, so both
+    // sides' claims aggregate under the same #p.
+    for (const [id, pubkey] of exporterPubkeys) {
+        const imported = await EntityModel.get(id);
+        assert.ok(imported, `${id} exists under its original id`);
+        assert.equal(imported.keypair.pubkey, pubkey, 'same pubkey as the exporter');
+        assert.ok(imported.keypair.privateKey, 'can sign (kind-0 publish works)');
+    }
+    const ben = await EntityModel.get(person.id);
+    assert.equal(ben.name, 'Reckless Ben');
+
+    // Re-import is idempotent: records update, no new keys.
+    const again = await importCaseBundle(parsed);
+    assert.equal(again.added, 0);
+    assert.equal(again.updated, 3);
+    assert.equal(again.keysInstalled, 0);
+    assert.deepEqual(again.conflicts, []);
+});
+
+test('bundle: key conflicts keep local keys and are reported', async () => {
+    resetState();
+    const { kase } = await seedCase();
+    const bundle = await collectCaseBundle(kase.id);
+
+    // Device B independently created the SAME case (same name+type →
+    // same deterministic id) with its OWN key.
+    resetState();
+    const local = await EntityModel.create({ name: 'Bricks & Minifigs scandal', type: 'case' });
+    assert.equal(local.id, kase.id, 'deterministic ids collide on purpose');
+    const localPubkey = local.keypair.pubkey;
+
+    const r = await importCaseBundle(JSON.parse(buildCaseBundleJson(bundle, '2026-06-10T12:00:00.000Z')));
+    assert.equal(r.conflicts.length, 1, 'the case key conflicts');
+    assert.ok(r.conflicts[0].includes('Bricks & Minifigs scandal'));
+    assert.equal(r.added, 2, 'non-conflicting entities still import');
+
+    const after = await EntityModel.get(local.id);
+    assert.equal(after.keypair.pubkey, localPubkey, 'local key NEVER overwritten');
+});
+
+test('bundle: malformed input is rejected or skipped', async () => {
+    resetState();
+    await assert.rejects(() => importCaseBundle({ format: 'nope' }), /Not an X-Ray case bundle/);
+    await assert.rejects(() => importCaseBundle({ format: CASE_BUNDLE_FORMAT, version: 99, entities: [] }),
+        /newer than this X-Ray understands/);
+    const r = await importCaseBundle({
+        format: CASE_BUNDLE_FORMAT, version: 1,
+        entities: [{ id: 'not-an-id', name: 'X', type: 'person' }, null]
+    });
+    assert.equal(r.skipped, 2);
+    assert.equal(r.added, 0);
+});


### PR DESCRIPTION
Closes the per-install-pubkey limitation for shared cases: export a case's entity keys as a warned, password-grade bundle; collaborator import preserves ids and installs keys conflict-safely, so both sides' published claims aggregate under the same #p. Gates: build ✅ 586/586 ✅ lint ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)