### PR TITLE
feat(portal): 'My Archive' foundation — identity, corpus query, parsers (Phase 12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,23 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **"My Archive" portal — foundation** (Phase 12.1,
+  `docs/PORTAL_DESIGN.md`). A new full-tab extension page
+  (`src/portal/`, opened from the toolbar right-click menu or the
+  `xray:openPortal` message) showing everything you've published to
+  your configured relays: identity resolution as a provenance-tagged
+  set (signer / `xray:user` sync key / claim publish history / manual
+  npub — NIP-07 users paste their npub in v1), per-relay corpus
+  queries with empty-page pagination so "which relays hold this event"
+  is exact, and a flat newest-first list with per-kind summaries and
+  raw-event view. New read-side parsers close the wire round-trip:
+  `EventBuilder.parseCommentEvent` (kind 30041) and
+  `parseAssessmentEvent` (kind 30054). The side panel's
+  replaceable-event dedupe moved to `shared/nostr-events.js` and is now
+  NIP-01-class-aware (kind-0/10002 collapse per author; 1985/9803 all
+  kept). Read-only: the portal publishes nothing and never writes the
+  local ledger.
+
 - **Case collaboration bundles** (Phase 11.8). A case entity's detail view
   gains **Share case bundle (includes keys)**: a JSON file carrying the
   case and every entity its claims reference — names, alias links, and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -896,9 +896,10 @@ brief: [`docs/PORTAL_KICKOFF.md`](PORTAL_KICKOFF.md)).
 
 Slices (one PR each):
 
-- ⬜ **12.1** Foundation — portal shell + esbuild entry + open wiring;
+- ✅ **12.1** Foundation — portal shell + esbuild entry + open wiring;
   identity resolver; corpus queries; **new `parseCommentEvent` (30041)
-  + `parseAssessmentEvent` (30054) parsers + tests**; flat event list.
+  + `parseAssessmentEvent` (30054) parsers + tests**; flat event
+  list. — #49
 - ⬜ **12.2** Library — type tabs, per-type renderers, facets,
   cross-cutting search.
 - ⬜ **12.3** Cache — IndexedDB `xray-portal`, cache-first render,

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,16 +1,18 @@
 // X-Ray build pipeline.
 //
-// Produces five bundles under `dist/`:
+// Produces seven bundles under `dist/`:
 //
-//   dist/content.bundle.js     — content script (IIFE; runs in every tab)
-//   dist/background.bundle.js  — MV3 service worker (ESM per manifest)
-//   dist/options.bundle.js     — extension options page (single settings hub)
-//   dist/sidepanel.bundle.js   — chrome.sidePanel target (shell for now)
-//   dist/reader.bundle.js      — extension-page reader view (shell for now)
+//   dist/content.bundle.js          — content script (IIFE; runs in every tab)
+//   dist/background.bundle.js       — MV3 service worker (ESM per manifest)
+//   dist/options.bundle.js          — extension options page (single settings hub)
+//   dist/sidepanel.bundle.js        — chrome.sidePanel target (entity browser)
+//   dist/reader.bundle.js           — extension-page reader view
+//   dist/portal.bundle.js           — "My Archive" data portal (Phase 12)
+//   dist/api-interceptor.bundle.js  — MAIN-world fetch/XHR hook (Phase 8a)
 //
-// The toolbar-icon click toggles the FAB on the active tab — no popup
-// surface, so no popup bundle. HTML and CSS files stay in `src/` and
-// reference the built bundles via relative paths like
+// The toolbar-icon click captures the active tab into the reader — no
+// popup surface, so no popup bundle. HTML and CSS files stay in `src/`
+// and reference the built bundles via relative paths like
 // `../../dist/options.bundle.js`. The manifest keeps its references to
 // `src/.../*.html` files unchanged.
 
@@ -54,7 +56,7 @@ const configs = [
     },
 
     // --- extension pages (each is its own IIFE bundle, loaded by its HTML shell) ---
-    ...['options', 'sidepanel', 'reader'].map((name) => ({
+    ...['options', 'sidepanel', 'reader', 'portal'].map((name) => ({
         ...shared,
         entryPoints: [resolve(root, `src/${name}/index.js`)],
         outfile: resolve(root, `dist/${name}.bundle.js`),

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -52,6 +52,7 @@ function safeParse(s) { try { return JSON.parse(s); } catch (_) { return null; }
 const MENU_IDS = {
     OPEN_CAPTURE: 'xray:open-capture',
     OPEN_ENTITIES: 'xray:open-entities',
+    OPEN_PORTAL: 'xray:open-portal',
     OPEN_SETTINGS: 'xray:open-settings',
     EXPORT_KEYPAIRS: 'xray:export-keypairs',
     VIEW_KEYPAIRS: 'xray:view-keypairs',
@@ -78,6 +79,11 @@ function registerContextMenus() {
         chrome.contextMenus.create({
             id: MENU_IDS.OPEN_ENTITIES,
             title: 'Open Entity Browser',
+            contexts: ['action']
+        });
+        chrome.contextMenus.create({
+            id: MENU_IDS.OPEN_PORTAL,
+            title: 'Open My Archive',
             contexts: ['action']
         });
         chrome.contextMenus.create({
@@ -138,6 +144,14 @@ async function openEntityBrowser() {
 }
 
 /**
+ * Open the "My Archive" portal (Phase 12) — a full-tab extension page,
+ * same pattern as the reader: no manifest entry needed.
+ */
+function openPortal() {
+    chrome.tabs.create({ url: chrome.runtime.getURL('src/portal/index.html') });
+}
+
+/**
  * Capture the active tab and open it in the reader. If the content
  * script isn't loaded (chrome://, file://, extension pages, the
  * WebStore…) fall back to opening the options page so the icon click is
@@ -171,6 +185,10 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
     }
     if (info.menuItemId === MENU_IDS.OPEN_ENTITIES) {
         openEntityBrowser();
+        return;
+    }
+    if (info.menuItemId === MENU_IDS.OPEN_PORTAL) {
+        openPortal();
         return;
     }
     if (info.menuItemId === MENU_IDS.CAPTURE_TIPS) {
@@ -222,6 +240,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     if (message.type === 'xray:openEntities') {
         openEntityBrowser();
+        sendResponse({ ok: true });
+        return false;
+    }
+    if (message.type === 'xray:openPortal') {
+        openPortal();
         sendResponse({ ok: true });
         return false;
     }

--- a/src/portal/corpus.js
+++ b/src/portal/corpus.js
@@ -1,0 +1,154 @@
+// Portal corpus fetch (Phase 12.1, docs/PORTAL_DESIGN.md).
+//
+// Extension pages have no relay access — every read goes through the
+// background pool via `xray:relay:query`. Two query classes:
+//
+//   Q1 — my content:  { authors: myPubkeys,    kinds: CONTENT_KINDS }
+//   Q2 — my entities: { authors: entityPubkeys, kinds: [0] } (chunked;
+//        kept a SEPARATE subscription from Q1 — design note, privacy)
+//
+// Each relay is queried INDIVIDUALLY (relays: [url]) rather than in one
+// fan-out: the background's queryRelays dedups by event id before
+// responding, so a pooled query can't tell us which relay actually
+// holds which event — and "which relays hold it" is the provenance the
+// inspector and reconciliation views are built on. Per-relay queries
+// cost the same number of REQs and make one slow relay's timeout
+// independent of the others.
+//
+// Backfill: relays cap responses silently (often below our `limit`),
+// so each relay pages backward with `until = oldest - 1` until it
+// returns an EMPTY page (not a short one — a short page may just be
+// the relay's own cap) or the page ceiling hits. Known v1 edge: a
+// relay holding more than a full page of events at one identical
+// timestamp can hide the overflow; accepted, per the design note.
+
+import { Utils } from '../shared/utils.js';
+
+export const CONTENT_KINDS = [
+    30023, // articles
+    30040, // claims
+    30041, // captured comments
+    30054, // assessments
+    30055, // claim relationships
+    1985,  // assessment label mirrors
+    32125, // entity↔article relationships
+    32126, // platform accounts
+    10002, // NIP-65 relay list (signed by the xray:user sync key)
+    30078, // entity-sync blobs (ciphertext; listed, never decrypted)
+    30050, 30051, 30052, 30053, 9803 // dormant metadata kinds (flag-gated writers)
+];
+
+// Mirrors the background service worker's hardcoded fallback
+// (src/background/index.js) — the portal needs the concrete list
+// client-side because provenance requires addressing relays one at a
+// time, so it can't lean on the worker's internal default.
+export const FALLBACK_RELAYS = [
+    'wss://relay.damus.io',
+    'wss://nos.lol',
+    'wss://relay.nostr.band'
+];
+
+const PAGE_LIMIT = 1000;
+const MAX_PAGES_PER_QUERY = 10;
+const QUERY_TIMEOUT_MS = 6000;
+const ENTITY_AUTHOR_CHUNK = 100;
+
+/** One `xray:relay:query` round-trip. Resolves `{ok,...}`, never rejects. */
+function relayQuery(filter, relays, timeoutMs = QUERY_TIMEOUT_MS) {
+    return new Promise((resolve) => {
+        try {
+            chrome.runtime.sendMessage({ type: 'xray:relay:query', relays, filter, timeoutMs }, (resp) => {
+                if (chrome.runtime.lastError) {
+                    resolve({ ok: false, error: chrome.runtime.lastError.message });
+                    return;
+                }
+                resolve(resp || { ok: false, error: 'No response from service worker' });
+            });
+        } catch (err) {
+            resolve({ ok: false, error: (err && err.message) || String(err) });
+        }
+    });
+}
+
+/**
+ * Page one relay backward through one base filter, feeding every event
+ * into `collect(event, relayUrl)`.
+ */
+async function backfillRelay(relayUrl, baseFilter, collect, onProgress) {
+    let until;
+    let pages = 0;
+    for (;;) {
+        const filter = { ...baseFilter, limit: PAGE_LIMIT };
+        if (until !== undefined) filter.until = until;
+        const resp = await relayQuery(filter, [relayUrl]);
+        if (!resp.ok) return { ok: false, error: resp.error || 'query failed', pages };
+        const events = Array.isArray(resp.events) ? resp.events : [];
+        pages++;
+        if (events.length === 0) break;
+        let oldest = Infinity;
+        for (const ev of events) {
+            if (!ev || !ev.id) continue;
+            if (typeof ev.created_at === 'number' && ev.created_at < oldest) oldest = ev.created_at;
+            collect(ev, relayUrl);
+        }
+        if (typeof onProgress === 'function') onProgress();
+        if (!Number.isFinite(oldest)) break;
+        if (pages >= MAX_PAGES_PER_QUERY) {
+            Utils.log('Portal corpus: page ceiling hit on', relayUrl, '— older events not fetched');
+            return { ok: true, pages, truncated: true };
+        }
+        until = oldest - 1;
+    }
+    return { ok: true, pages, truncated: false };
+}
+
+function chunk(list, size) {
+    const out = [];
+    for (let i = 0; i < list.length; i += size) out.push(list.slice(i, i + size));
+    return out;
+}
+
+/**
+ * Fetch the full published corpus across the given relays.
+ *
+ * @param {object}   opts
+ * @param {string[]} opts.pubkeys        the user's resolved author pubkeys
+ * @param {string[]} opts.entityPubkeys  entity pubkeys (kind-0 authors)
+ * @param {string[]} opts.relays         relay URLs (callers resolve config/fallback)
+ * @param {function} [opts.onProgress]   ({fetched}) per page, for the status line
+ * @returns {Promise<{
+ *   records: Array<{event: object, relays: string[]}>,
+ *   relayErrors: Object<string,string>,
+ *   truncated: boolean
+ * }>}
+ */
+export async function fetchCorpus({ pubkeys = [], entityPubkeys = [], relays = [], onProgress } = {}) {
+    const byId = new Map(); // event id → { event, relays:Set }
+    const relayErrors = {};
+    let truncated = false;
+
+    const collect = (ev, relayUrl) => {
+        const seen = byId.get(ev.id);
+        if (seen) { seen.relays.add(relayUrl); return; }
+        byId.set(ev.id, { event: ev, relays: new Set([relayUrl]) });
+    };
+    const tick = () => {
+        if (typeof onProgress === 'function') onProgress({ fetched: byId.size });
+    };
+
+    await Promise.all(relays.map(async (url) => {
+        if (pubkeys.length > 0) {
+            const r = await backfillRelay(url, { authors: pubkeys, kinds: CONTENT_KINDS }, collect, tick);
+            if (!r.ok) relayErrors[url] = r.error;
+            if (r.truncated) truncated = true;
+        }
+        for (const authors of chunk(entityPubkeys, ENTITY_AUTHOR_CHUNK)) {
+            const r = await backfillRelay(url, { authors, kinds: [0] }, collect, tick);
+            if (!r.ok) relayErrors[url] = relayErrors[url] || r.error;
+            if (r.truncated) truncated = true;
+        }
+    }));
+
+    const records = [...byId.values()].map((r) => ({ event: r.event, relays: [...r.relays] }));
+    return { records, relayErrors, truncated };
+}

--- a/src/portal/identity.js
+++ b/src/portal/identity.js
@@ -1,0 +1,165 @@
+// Portal identity resolution (Phase 12.1, docs/PORTAL_DESIGN.md).
+//
+// "Me" is a resolved SET of author pubkeys, not one key. The portal runs
+// outside any capture context, so the reader's source-tab path
+// (`xray:capture:getPubkey`) is unavailable and NIP-07 cannot answer
+// from an extension page at all. Instead we union four sources, each
+// tagged with its provenance so the UI can show honest chips:
+//
+//   'signer'          — Signer.getPublicKey(): Local reads the primary
+//                       identity from storage; NSecBunker connects out
+//                       (bounded by a timeout so a dead bunker can't
+//                       hang the portal); NIP-07 is skipped entirely.
+//   'sync-key'        — the reserved `xray:user` LocalKeyManager slot
+//                       (signs entity-sync 30078 + the 10002 relay list).
+//   'publish-history' — the union of `publishedPubkeys` recorded on
+//                       claims (append-only since Phase 11.1) plus any
+//                       `publishedPubkey` singletons.
+//   'manual'          — npubs/hex the user pasted into the portal
+//                       header, persisted under `portal_identities`.
+//
+// Entity pubkeys are resolved separately (they author only entity
+// kind-0 profiles and are queried in their own subscription — see the
+// design note's privacy section).
+
+import { Storage } from '../shared/storage.js';
+import { Signer } from '../shared/signer.js';
+import { LocalKeyManager } from '../shared/local-key-manager.js';
+import { ClaimModel } from '../shared/claim-model.js';
+import { EntityModel } from '../shared/entity-model.js';
+import { Crypto } from '../shared/crypto.js';
+import { Utils } from '../shared/utils.js';
+
+const MANUAL_KEY = 'portal_identities';
+const SYNC_KEY_NAME = 'xray:user'; // sidepanel/index.js USER_KEY_NAME
+const HEX64 = /^[0-9a-f]{64}$/;
+const SIGNER_TIMEOUT_MS = 4000;
+
+function withTimeout(promise, ms) {
+    return Promise.race([
+        promise,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timed out')), ms))
+    ]);
+}
+
+/**
+ * Resolve the signer-derived pubkey, or explain why we couldn't.
+ * Never throws.
+ *
+ * @returns {Promise<{method: string, pubkey: string|null, reason: string|null}>}
+ */
+async function resolveSignerPubkey() {
+    let method = 'local';
+    try { method = await Signer.getMethod(); } catch (_) { /* default */ }
+    if (method === 'nip07') {
+        return {
+            method,
+            pubkey: null,
+            reason: 'NIP-07 signs in page tabs only — paste your npub below, or publish once so the portal can use your publish history.'
+        };
+    }
+    try {
+        const pubkey = await withTimeout(Signer.getPublicKey(), SIGNER_TIMEOUT_MS);
+        return HEX64.test(pubkey || '')
+            ? { method, pubkey, reason: null }
+            : { method, pubkey: null, reason: 'Signer returned an unusable key.' };
+    } catch (err) {
+        return { method, pubkey: null, reason: err && err.message ? err.message : String(err) };
+    }
+}
+
+/**
+ * Resolve the full identity picture for the portal.
+ *
+ * @returns {Promise<{
+ *   identities: Array<{pubkey: string, sources: string[]}>,
+ *   entities:   Array<{pubkey: string, entityId: string, name: string, type: string}>,
+ *   signer:     {method: string, pubkey: string|null, reason: string|null}
+ * }>}
+ */
+export async function resolveIdentities() {
+    const sourcesByPubkey = new Map(); // pubkey → Set(source)
+    const add = (pubkey, source) => {
+        if (typeof pubkey !== 'string' || !HEX64.test(pubkey)) return;
+        if (!sourcesByPubkey.has(pubkey)) sourcesByPubkey.set(pubkey, new Set());
+        sourcesByPubkey.get(pubkey).add(source);
+    };
+
+    const signer = await resolveSignerPubkey();
+    if (signer.pubkey) add(signer.pubkey, 'signer');
+
+    // EntityModel.getAll() joins keypairs from LocalKeyManager, so the
+    // key registry must be hydrated before either lookup below.
+    try { await LocalKeyManager.init(); } catch (err) {
+        Utils.error('Portal identity: LocalKeyManager init failed', err);
+    }
+    const syncKey = LocalKeyManager.getKey(SYNC_KEY_NAME);
+    if (syncKey && syncKey.pubkey) add(syncKey.pubkey, 'sync-key');
+
+    try {
+        const claims = await ClaimModel.getAll();
+        for (const claim of Object.values(claims || {})) {
+            if (claim && claim.publishedPubkey) add(claim.publishedPubkey, 'publish-history');
+            for (const pk of (claim && Array.isArray(claim.publishedPubkeys)) ? claim.publishedPubkeys : []) {
+                add(pk, 'publish-history');
+            }
+        }
+    } catch (err) {
+        Utils.error('Portal identity: claim history scan failed', err);
+    }
+
+    for (const pk of await getManualIdentities()) add(pk, 'manual');
+
+    const entities = [];
+    try {
+        const all = await EntityModel.getAll();
+        for (const entity of Object.values(all || {})) {
+            const pk = entity && entity.keypair && entity.keypair.pubkey;
+            if (typeof pk !== 'string' || !HEX64.test(pk)) continue;
+            entities.push({ pubkey: pk, entityId: entity.id, name: entity.name || '', type: entity.type || '' });
+        }
+    } catch (err) {
+        Utils.error('Portal identity: entity scan failed', err);
+    }
+
+    const identities = [...sourcesByPubkey.entries()]
+        .map(([pubkey, sources]) => ({ pubkey, sources: [...sources] }));
+    return { identities, entities, signer };
+}
+
+/** The persisted manual pubkeys (hex, validated on write). */
+export async function getManualIdentities() {
+    const stored = await Storage.get(MANUAL_KEY, []);
+    return (Array.isArray(stored) ? stored : []).filter((pk) => typeof pk === 'string' && HEX64.test(pk));
+}
+
+/**
+ * Add a manual identity from user input — an `npub1…` or 64-hex pubkey.
+ *
+ * @returns {Promise<{ok: true, pubkey: string} | {ok: false, error: string}>}
+ */
+export async function addManualIdentity(input) {
+    const raw = String(input || '').trim();
+    if (!raw) return { ok: false, error: 'Paste an npub or 64-char hex pubkey.' };
+    let pubkey = null;
+    if (/^npub1/i.test(raw)) {
+        pubkey = Crypto.npubToHex(raw.toLowerCase());
+        if (!pubkey || !HEX64.test(pubkey)) return { ok: false, error: 'That npub did not decode.' };
+    } else if (HEX64.test(raw.toLowerCase())) {
+        pubkey = raw.toLowerCase();
+    } else {
+        return { ok: false, error: 'Not an npub or 64-char hex pubkey.' };
+    }
+    const existing = await getManualIdentities();
+    if (!existing.includes(pubkey)) {
+        await Storage.set(MANUAL_KEY, [...existing, pubkey]);
+    }
+    return { ok: true, pubkey };
+}
+
+/** Remove a manually-added identity. No-op for pubkeys from other sources. */
+export async function removeManualIdentity(pubkey) {
+    const existing = await getManualIdentities();
+    const next = existing.filter((pk) => pk !== pubkey);
+    if (next.length !== existing.length) await Storage.set(MANUAL_KEY, next);
+}

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -1,0 +1,282 @@
+/* X-Ray portal — "My Archive" (Phase 12).
+ * Shares the token palette with options / reader / side panel. */
+
+:root {
+  --xr-bg:        #1a1a1a;
+  --xr-surface:   #242424;
+  --xr-surface-2: #2e2e2e;
+  --xr-text:      #e6e6e6;
+  --xr-text-dim:  #9a9a9a;
+  --xr-border:    #333;
+  --xr-primary:        #8b5cf6;
+  --xr-primary-hover:  #7c3aed;
+  --xr-accent:   #22d3ee;
+  --xr-success:  #34d399;
+  --xr-warning:  #fbbf24;
+  --xr-danger:   #f87171;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --xr-bg:        #fafafa;
+    --xr-surface:   #ffffff;
+    --xr-surface-2: #f3f4f6;
+    --xr-text:      #1f2937;
+    --xr-text-dim:  #6b7280;
+    --xr-border:    #e5e7eb;
+  }
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--xr-bg);
+  color: var(--xr-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+}
+
+body.xr-portal {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+[hidden] { display: none !important; }
+
+/* ---------------- header ---------------- */
+
+.xr-portal__chrome {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--xr-surface);
+  border-bottom: 1px solid var(--xr-border);
+}
+
+.xr-portal__brand {
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.xr-portal__btn {
+  border: 1px solid var(--xr-border);
+  background: var(--xr-surface-2);
+  color: var(--xr-text);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.xr-portal__btn:hover { border-color: var(--xr-primary); }
+
+.xr-portal__btn--ghost { background: transparent; }
+
+.xr-portal__btn[disabled] { opacity: 0.5; cursor: default; }
+
+/* ---------------- identity strip ---------------- */
+
+.xr-portal__identity {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--xr-border);
+}
+
+.xr-portal__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+  min-width: 240px;
+}
+
+.xr-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border: 1px solid var(--xr-border);
+  border-radius: 999px;
+  background: var(--xr-surface);
+  font-size: 12px;
+}
+
+.xr-chip__key { font-family: ui-monospace, Menlo, monospace; }
+
+.xr-chip__src { color: var(--xr-text-dim); }
+
+.xr-chip__src--signer  { color: var(--xr-success); }
+.xr-chip__src--manual  { color: var(--xr-accent); }
+
+.xr-chip__remove {
+  border: none;
+  background: none;
+  color: var(--xr-text-dim);
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 12px;
+}
+
+.xr-chip__remove:hover { color: var(--xr-danger); }
+
+.xr-chip--entity { border-style: dashed; }
+
+.xr-portal__add {
+  display: flex;
+  gap: 6px;
+}
+
+.xr-portal__add input {
+  width: 280px;
+  padding: 6px 8px;
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  background: var(--xr-bg);
+  color: var(--xr-text);
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px;
+}
+
+/* ---------------- status ---------------- */
+
+.xr-portal__status {
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--xr-text-dim);
+  border-bottom: 1px solid var(--xr-border);
+}
+
+.xr-portal__status--error { color: var(--xr-danger); }
+
+/* ---------------- list ---------------- */
+
+.xr-portal__main { flex: 1; }
+
+.xr-portal__list {
+  list-style: none;
+  margin: 0;
+  padding: 8px 16px 24px;
+  max-width: 980px;
+}
+
+.xr-row {
+  border: 1px solid var(--xr-border);
+  border-radius: 8px;
+  background: var(--xr-surface);
+  margin: 8px 0;
+  padding: 10px 12px;
+}
+
+.xr-row__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.xr-row__kind {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--xr-primary);
+  border: 1px solid var(--xr-border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  white-space: nowrap;
+}
+
+.xr-row__title {
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.xr-row__date {
+  margin-left: auto;
+  color: var(--xr-text-dim);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.xr-row__sub {
+  margin-top: 4px;
+  color: var(--xr-text-dim);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.xr-row__badges {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.xr-badge {
+  font-size: 11px;
+  border-radius: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--xr-border);
+  color: var(--xr-text-dim);
+  white-space: nowrap;
+}
+
+.xr-badge--warn { color: var(--xr-warning); border-color: var(--xr-warning); }
+
+.xr-row details { margin-top: 8px; }
+
+.xr-row summary {
+  cursor: pointer;
+  color: var(--xr-text-dim);
+  font-size: 12px;
+}
+
+.xr-row pre {
+  margin: 8px 0 0;
+  padding: 10px;
+  background: var(--xr-bg);
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 320px;
+  font-size: 11px;
+  font-family: ui-monospace, Menlo, monospace;
+}
+
+/* ---------------- empty state ---------------- */
+
+.xr-portal__empty {
+  margin: 48px auto;
+  max-width: 560px;
+  padding: 24px;
+  border: 1px dashed var(--xr-border);
+  border-radius: 10px;
+  color: var(--xr-text-dim);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.xr-portal__empty h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  color: var(--xr-text);
+}
+
+/* ---------------- footer ---------------- */
+
+.xr-portal__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--xr-border);
+  color: var(--xr-text-dim);
+  font-size: 12px;
+}

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>X-Ray — My Archive</title>
+  <link rel="stylesheet" href="index.css" />
+</head>
+<body class="xr-portal">
+  <header class="xr-portal__chrome">
+    <div class="xr-portal__chrome-left">
+      <span class="xr-portal__brand">🩻 X-Ray — My Archive</span>
+    </div>
+    <div class="xr-portal__chrome-right">
+      <button class="xr-portal__btn" id="xr-refresh" title="Query the relays again">↻ Refresh</button>
+    </div>
+  </header>
+
+  <!-- Identity strip: who "me" is, with provenance chips, plus the
+       manual npub escape hatch (the NIP-07 story — see identity.js). -->
+  <section class="xr-portal__identity" id="xr-identity">
+    <div class="xr-portal__chips" id="xr-identity-chips"></div>
+    <form class="xr-portal__add" id="xr-identity-form">
+      <input type="text" id="xr-identity-input" placeholder="npub1… or hex pubkey" autocomplete="off" />
+      <button type="submit" class="xr-portal__btn xr-portal__btn--ghost">Add identity</button>
+    </form>
+  </section>
+
+  <div class="xr-portal__status" id="xr-status" hidden></div>
+
+  <main class="xr-portal__main">
+    <div class="xr-portal__empty" id="xr-empty" hidden></div>
+    <ol class="xr-portal__list" id="xr-list"></ol>
+  </main>
+
+  <footer class="xr-portal__footer">
+    <span id="xr-footer-relays"></span>
+    <span class="xr-portal__footer-note">The portal asks your configured
+    relays for events signed by your keys. Relays can see that request.</span>
+  </footer>
+
+  <script src="../../dist/portal.bundle.js"></script>
+</body>
+</html>

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -1,0 +1,368 @@
+// X-Ray portal — "My Archive" (Phase 12.1, docs/PORTAL_DESIGN.md).
+//
+// Slice 12.1 is the end-to-end pipe: resolve who "me" is, pull the
+// published corpus off the configured relays through the background
+// pool, collapse replaceable versions, and render a flat newest-first
+// list with per-kind one-line summaries and the raw signed event a
+// click away. Type views, search, caching, the graph, and
+// reconciliation land in later slices on top of this.
+//
+// All DOM here is built with createElement/textContent — no dynamic
+// innerHTML (keeps web-ext's UNSAFE_VAR_ASSIGNMENT warnings from
+// multiplying and makes escaping a non-issue).
+
+import { Storage } from '../shared/storage.js';
+import { Utils } from '../shared/utils.js';
+import { EventBuilder } from '../shared/event-builder.js';
+import { parseClaimEvent } from '../shared/claim-model.js';
+import { parseAssessmentEvent } from '../shared/assessment-model.js';
+import { parseRelationshipEvent } from '../shared/evidence-linker.js';
+import { dedupeReplaceable } from '../shared/nostr-events.js';
+import { resolveIdentities, addManualIdentity, removeManualIdentity } from './identity.js';
+import { fetchCorpus, FALLBACK_RELAYS } from './corpus.js';
+
+const $ = (sel) => document.querySelector(sel);
+
+// Tags written by this extension (current + userscript-era value).
+const OUR_CLIENT_TAGS = new Set(['xray', 'nostr-article-capture']);
+
+const KIND_LABELS = {
+    30023: 'Article',
+    30040: 'Claim',
+    30041: 'Comment',
+    30054: 'Assessment',
+    30055: 'Link',
+    1985:  'Label',
+    0:     'Profile',
+    32125: 'Entity link',
+    32126: 'Account',
+    10002: 'Relay list',
+    30078: 'Entity sync',
+    30050: 'Annotation',
+    30051: 'Fact-check',
+    30052: 'Rating',
+    30053: 'Topic trust',
+    9803:  'Vote'
+};
+
+const state = {
+    identities: [],      // [{pubkey, sources}]
+    entities: [],        // [{pubkey, entityId, name, type}]
+    signer: null,        // {method, pubkey, reason}
+    relays: [],
+    records: [],         // [{event, relays}]
+    relayErrors: {},
+    truncated: false,
+    loading: false
+};
+
+// ------------------------------------------------------------------
+// Small DOM helpers
+// ------------------------------------------------------------------
+
+function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = text;
+    return node;
+}
+
+function clear(node) {
+    while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function shortKey(pubkey) {
+    return pubkey.slice(0, 8) + '…' + pubkey.slice(-4);
+}
+
+// ------------------------------------------------------------------
+// Per-kind one-line summaries (the 12.1 generic rows; richer per-type
+// renderers arrive with the Library slice)
+// ------------------------------------------------------------------
+
+function firstTag(event, name) {
+    const t = (event.tags || []).find((x) => x[0] === name);
+    return t ? t[1] : '';
+}
+
+function truncate(s, n) {
+    const str = String(s || '').trim();
+    return str.length > n ? str.slice(0, n - 1) + '…' : str;
+}
+
+function domainOf(url) {
+    try { return new URL(url).hostname; } catch (_) { return ''; }
+}
+
+/** @returns {{title: string, sub: string}} */
+function summarize(event) {
+    switch (event.kind) {
+        case 30023: {
+            const title = firstTag(event, 'title') || '(untitled capture)';
+            const url = firstTag(event, 'r');
+            return { title, sub: domainOf(url) || url };
+        }
+        case 30040: {
+            const c = parseClaimEvent(event);
+            return { title: truncate(c.text, 140) || '(empty claim)', sub: c.source ? `source: ${c.source}` : '' };
+        }
+        case 30041: {
+            const c = EventBuilder.parseCommentEvent(event);
+            if (!c) return { title: '(unparsable comment)', sub: '' };
+            return { title: truncate(c.text, 140), sub: `${c.author} · ${c.platform}` };
+        }
+        case 30054: {
+            const a = parseAssessmentEvent(event);
+            if (!a) return { title: '(unparsable assessment)', sub: '' };
+            const bits = [];
+            if (a.stance !== null) bits.push(`stance ${a.stance > 0 ? '+' : ''}${a.stance}`);
+            if (a.labels.length) bits.push(a.labels.map((l) => l.label).join(', '));
+            return { title: bits.join(' · ') || '(judgment)', sub: truncate(a.rationale, 120) };
+        }
+        case 30055: {
+            const r = parseRelationshipEvent(event);
+            if (!r) return { title: '(unparsable link)', sub: '' };
+            return { title: r.relationship || '(link)', sub: truncate(r.note, 120) || `${r.urls.length} source(s)` };
+        }
+        case 1985: {
+            const labels = (event.tags || []).filter((t) => t[0] === 'l').map((t) => t[1]);
+            return { title: labels.join(', ') || '(label)', sub: firstTag(event, 'r') };
+        }
+        case 0: {
+            let name = '';
+            let about = '';
+            try {
+                const profile = JSON.parse(event.content || '{}');
+                name = profile.name || '';
+                about = profile.about || '';
+            } catch (_) { /* malformed profile content */ }
+            return { title: name || '(profile)', sub: truncate(about, 120) };
+        }
+        case 32125: {
+            return {
+                title: `${firstTag(event, 'entity-name') || '(entity)'} — ${firstTag(event, 'relationship') || 'related'}`,
+                sub: firstTag(event, 'r')
+            };
+        }
+        case 32126: {
+            const acct = EventBuilder.reconstructPlatformAccount(event);
+            if (!acct) return { title: '(unparsable account)', sub: '' };
+            return {
+                title: `${acct.platform}: ${acct.handle || acct.displayName || acct.stableId}`,
+                sub: acct.linkedEntityId ? `linked to ${acct.linkedEntityId}` : ''
+            };
+        }
+        case 10002: {
+            const relays = (event.tags || []).filter((t) => t[0] === 'r').map((t) => t[1]);
+            return { title: `${relays.length} relay(s) declared`, sub: relays.join('  ') };
+        }
+        case 30078: {
+            return { title: firstTag(event, 'd') || '(entity sync)', sub: 'encrypted — listed, not decrypted' };
+        }
+        default: {
+            const d = firstTag(event, 'd');
+            const r = firstTag(event, 'r');
+            return { title: d || event.id || '(event)', sub: r };
+        }
+    }
+}
+
+// ------------------------------------------------------------------
+// Rendering
+// ------------------------------------------------------------------
+
+function setStatus(text, isError) {
+    const node = $('#xr-status');
+    node.hidden = !text;
+    node.textContent = text || '';
+    node.classList.toggle('xr-portal__status--error', !!isError);
+}
+
+function renderIdentityChips() {
+    const host = $('#xr-identity-chips');
+    clear(host);
+    for (const id of state.identities) {
+        const chip = el('span', 'xr-chip');
+        chip.appendChild(el('span', 'xr-chip__key', shortKey(id.pubkey)));
+        chip.title = id.pubkey;
+        for (const src of id.sources) {
+            chip.appendChild(el('span', `xr-chip__src xr-chip__src--${src}`, src));
+        }
+        if (id.sources.includes('manual')) {
+            const btn = el('button', 'xr-chip__remove', '✕');
+            btn.type = 'button';
+            btn.title = 'Remove this identity';
+            btn.addEventListener('click', async () => {
+                await removeManualIdentity(id.pubkey);
+                await boot();
+            });
+            chip.appendChild(btn);
+        }
+        host.appendChild(chip);
+    }
+    if (state.entities.length > 0) {
+        const chip = el('span', 'xr-chip xr-chip--entity');
+        chip.appendChild(el('span', 'xr-chip__key', `${state.entities.length} entity key(s)`));
+        chip.title = state.entities.map((e) => `${e.name} (${e.type})`).join('\n');
+        host.appendChild(chip);
+    }
+}
+
+function renderEmpty() {
+    const host = $('#xr-empty');
+    clear(host);
+    host.hidden = false;
+    $('#xr-list').hidden = true;
+    host.appendChild(el('h2', null, 'No identity resolved'));
+    const reason = state.signer && state.signer.reason
+        ? `Signing (${state.signer.method}): ${state.signer.reason}`
+        : 'No signing identity, sync key, publish history, or manual identity found.';
+    host.appendChild(el('p', null, reason));
+    host.appendChild(el('p', null,
+        'Paste your npub above, configure signing in Settings, or publish a capture once — then refresh.'));
+}
+
+function renderRows() {
+    const list = $('#xr-list');
+    const empty = $('#xr-empty');
+    empty.hidden = true;
+    list.hidden = false;
+    clear(list);
+
+    const relaysByEventId = new Map(state.records.map((r) => [r.event.id, r.relays]));
+    const display = dedupeReplaceable(state.records.map((r) => r.event))
+        .sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+
+    for (const event of display) {
+        const row = el('li', 'xr-row');
+        const head = el('div', 'xr-row__head');
+        head.appendChild(el('span', 'xr-row__kind', KIND_LABELS[event.kind] || `kind ${event.kind}`));
+
+        const { title, sub } = summarize(event);
+        head.appendChild(el('span', 'xr-row__title', title));
+
+        const badges = el('span', 'xr-row__badges');
+        const relays = relaysByEventId.get(event.id) || [];
+        const relayBadge = el('span', 'xr-badge', `${relays.length} relay${relays.length === 1 ? '' : 's'}`);
+        relayBadge.title = relays.join('\n');
+        badges.appendChild(relayBadge);
+        const client = firstTag(event, 'client');
+        if (client && !OUR_CLIENT_TAGS.has(client)) {
+            badges.appendChild(el('span', 'xr-badge xr-badge--warn', `via ${truncate(client, 24)}`));
+        }
+        head.appendChild(badges);
+
+        if (event.created_at) {
+            head.appendChild(el('span', 'xr-row__date', new Date(event.created_at * 1000).toLocaleString()));
+        }
+        row.appendChild(head);
+        if (sub) row.appendChild(el('div', 'xr-row__sub', sub));
+
+        const details = el('details');
+        details.appendChild(el('summary', null, 'Raw event'));
+        const pre = el('pre');
+        // Serialize lazily — hundreds of large 30023s stringified up
+        // front would make first paint pay for JSON nobody opened.
+        details.addEventListener('toggle', () => {
+            if (details.open && !pre.textContent) {
+                pre.textContent = JSON.stringify(event, null, 2);
+            }
+        }, { once: false });
+        details.appendChild(pre);
+        row.appendChild(details);
+
+        list.appendChild(row);
+    }
+
+    if (display.length === 0) {
+        const host = empty;
+        clear(host);
+        host.hidden = false;
+        list.hidden = true;
+        host.appendChild(el('h2', null, 'Nothing found on the relays'));
+        host.appendChild(el('p', null,
+            'The configured relays returned no events for the resolved identities. '
+            + 'If you publish from another device, add that identity above; otherwise publish a capture and refresh.'));
+    }
+}
+
+function renderFooter() {
+    $('#xr-footer-relays').textContent = state.relays.length
+        ? `Relays: ${state.relays.join('  ')}`
+        : 'No relays configured.';
+}
+
+// ------------------------------------------------------------------
+// Boot + refresh
+// ------------------------------------------------------------------
+
+async function boot() {
+    if (state.loading) return;
+    state.loading = true;
+    $('#xr-refresh').disabled = true;
+    try {
+        setStatus('Resolving identity…');
+        const { identities, entities, signer } = await resolveIdentities();
+        state.identities = identities;
+        state.entities = entities;
+        state.signer = signer;
+        renderIdentityChips();
+
+        const prefs = await Storage.preferences.get() || {};
+        state.relays = Array.isArray(prefs.default_relays) && prefs.default_relays.length > 0
+            ? prefs.default_relays
+            : FALLBACK_RELAYS;
+        renderFooter();
+
+        if (state.identities.length === 0 && state.entities.length === 0) {
+            setStatus('');
+            renderEmpty();
+            return;
+        }
+
+        setStatus(`Querying ${state.relays.length} relay(s)…`);
+        const { records, relayErrors, truncated } = await fetchCorpus({
+            pubkeys: state.identities.map((i) => i.pubkey),
+            entityPubkeys: state.entities.map((e) => e.pubkey),
+            relays: state.relays,
+            onProgress: ({ fetched }) => setStatus(`Querying ${state.relays.length} relay(s)… ${fetched} event(s) so far`)
+        });
+        state.records = records;
+        state.relayErrors = relayErrors;
+        state.truncated = truncated;
+
+        renderRows();
+
+        const failed = Object.keys(relayErrors);
+        const parts = [`${records.length} event(s) from ${state.relays.length - failed.length}/${state.relays.length} relay(s)`];
+        if (failed.length) parts.push(`failed: ${failed.join(', ')}`);
+        if (truncated) parts.push('some relays hit the page ceiling — older events not shown');
+        setStatus(parts.join(' — '), failed.length > 0);
+    } catch (err) {
+        Utils.error('Portal boot failed:', err);
+        setStatus('Portal failed to load: ' + (err && err.message ? err.message : String(err)), true);
+    } finally {
+        state.loading = false;
+        $('#xr-refresh').disabled = false;
+    }
+}
+
+function wireChrome() {
+    $('#xr-refresh').addEventListener('click', () => { boot(); });
+    $('#xr-identity-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const input = $('#xr-identity-input');
+        const result = await addManualIdentity(input.value);
+        if (!result.ok) {
+            setStatus(result.error, true);
+            return;
+        }
+        input.value = '';
+        await boot();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    wireChrome();
+    boot();
+});

--- a/src/shared/assessment-model.js
+++ b/src/shared/assessment-model.js
@@ -34,12 +34,81 @@ import { Utils } from './utils.js';
 import { ClaimModel } from './claim-model.js';
 import { normalize as normalizeUrl } from './metadata/url-normalizer.js';
 import {
-    isValidLabel, isValidStance, isValidSuggestedBy
+    isValidLabel, isValidStance, isValidSuggestedBy,
+    ASSESSMENT_LABEL_NAMESPACE
 } from './assessment-taxonomy.js';
 import {
     isLocalClaimId, parseClaimCoord, canonicalizeClaimRef,
     makeClaimRefCanonicalizer
 } from './claim-ref.js';
+
+// ------------------------------------------------------------------
+// Wire read-back (Phase 12.1)
+// ------------------------------------------------------------------
+
+/**
+ * Inverse of metadata/builders.js `buildAssessmentEvent` — reconstruct
+ * an assessment from a kind-30054 event, for the portal's read-back
+ * path. Pure and defensive in the parseRelationshipEvent style:
+ * returns null for a wrong-kind event or one with no claim coordinate
+ * (structurally unusable); everything else degrades softly — a
+ * malformed stance reads as null, an unparsable label-anchor stays
+ * null. `p` tags disambiguate on the slot-4 role marker: role-less is
+ * the claim's author, 'about' entries are mirrored about-entities.
+ */
+export function parseAssessmentEvent(event) {
+    if (!event || event.kind !== 30054) return null;
+    const tags = event.tags || [];
+    const first = (name) => { const t = tags.find((x) => x[0] === name); return t ? t[1] : ''; };
+    const claimCoord = first('a');
+    if (!claimCoord) return null;
+
+    let stance = null;
+    const stanceRaw = first('stance');
+    if (stanceRaw !== '') {
+        const n = Number(stanceRaw);
+        if (Number.isInteger(n) && isValidStance(n)) stance = n;
+    }
+
+    // Labels in l-tag order under the xray/assessment namespace, one
+    // entry per value (the builder enforces uniqueness; read-side we
+    // just keep the first). label-anchor / label-note attach by value.
+    const labels = [];
+    const seen = new Set();
+    for (const t of tags) {
+        if (t[0] !== 'l' || t[2] !== ASSESSMENT_LABEL_NAMESPACE) continue;
+        if (!t[1] || seen.has(t[1])) continue;
+        seen.add(t[1]);
+        labels.push({ label: t[1], anchor: null, note: null });
+    }
+    for (const t of tags) {
+        if (t[0] === 'label-anchor') {
+            const hit = labels.find((l) => l.label === t[1]);
+            if (hit && t[2]) { try { hit.anchor = JSON.parse(t[2]); } catch (_) { /* stays null */ } }
+        } else if (t[0] === 'label-note') {
+            const hit = labels.find((l) => l.label === t[1]);
+            if (hit && t[2]) hit.note = t[2];
+        }
+    }
+
+    const authorP = tags.find((x) => x[0] === 'p' && !x[3]);
+    const eTag = tags.find((x) => x[0] === 'e');
+    return {
+        id:                first('d') || event.id || '',
+        claimCoord,
+        claimEventId:      (eTag && eTag[1]) || null,
+        claimAuthorPubkey: (authorP && authorP[1]) || null,
+        stance,
+        labels,
+        rationale:         event.content || '',
+        aboutPubkeys:      tags.filter((x) => x[0] === 'p' && x[3] === 'about').map((x) => x[1]),
+        url:               first('r') || null,
+        suggestedBy:       first('suggested-by') || 'user',
+        pubkey:            event.pubkey || '',
+        created_at:        event.created_at || 0,
+        eventId:           event.id || null
+    };
+}
 
 // ------------------------------------------------------------------
 // ID derivation

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -567,6 +567,55 @@ export const EventBuilder = {
     };
   },
 
+  // Inverse of buildCommentEvent (Phase 12.1) — reconstruct a captured
+  // comment from a kind-30041 event, for the portal's read-back path.
+  // Pure and defensive in the parseClaimEvent style: tags first with
+  // content fallback, optional tags become null/0, and anything that
+  // isn't a usable comment (wrong kind, no text anywhere) returns null
+  // so callers can fall back to a generic event row.
+  //
+  // `comment-date` was written in SECONDS by buildCommentEvent (which
+  // normalizes ms upstream), but be tolerant on read: a 13-digit value
+  // from some other writer is treated as ms and converted.
+  parseCommentEvent: (event) => {
+    if (!event || event.kind !== 30041) return null;
+    const tags = event.tags || [];
+    const first = (name) => { const t = tags.find((x) => x[0] === name); return t ? t[1] : ''; };
+    const num = (name) => {
+      const v = first(name);
+      if (v === '') return null;
+      const n = Number(v);
+      return Number.isFinite(n) ? n : null;
+    };
+    const text = first('comment-text') || event.content || '';
+    if (!text) return null;
+    let commentDate = num('comment-date');
+    if (commentDate !== null && commentDate > 10_000_000_000) {
+      commentDate = Math.floor(commentDate / 1000); // ms → s
+    }
+    const commenter = tags.find((x) => x[0] === 'p' && x[3] === 'commenter');
+    const reactions = num('reaction-count');
+    const restacks  = num('restack-count');
+    return {
+      id:              first('d') || event.id || '',
+      text,
+      author:          first('comment-author') || 'Unknown',
+      platform:        first('platform') || '',
+      authorHandle:    first('author-handle') || null,
+      authorUrl:       first('author-url') || null,
+      commentDate,
+      replyTo:         first('reply-to') || null,
+      reactionCount:   reactions === null ? 0 : reactions,
+      restackCount:    restacks === null ? 0 : restacks,
+      commenterPubkey: (commenter && commenter[1]) || null,
+      url:             first('r') || '',
+      title:           first('title') || '',
+      pubkey:          event.pubkey || '',
+      created_at:      event.created_at || 0,
+      eventId:         event.id || null
+    };
+  },
+
   // Build kind 32126 platform account event (Phase 9 identity layer).
   //
   // Consumes a PlatformAccount record from

--- a/src/shared/nostr-events.js
+++ b/src/shared/nostr-events.js
@@ -1,0 +1,62 @@
+// Shared NIP-01 event-set helpers (Phase 12.1).
+//
+// `dedupeReplaceable` started life inside the side panel's network-claims
+// view (Phase 10.4), keyed everything by `kind:pubkey:(d || id)`, and was
+// correct there because its input was kind-30040 only. The portal feeds a
+// mixed corpus through it, so this shared version is NIP-01-class-aware:
+//
+//   - replaceable  (0, 3, 10000–19999)  → latest wins per (kind, pubkey)
+//   - addressable  (30000–39999)        → latest wins per (kind, pubkey, d)
+//   - regular      (everything else)    → every event kept
+//
+// For an all-addressable input this is byte-for-byte the side panel's old
+// behavior (missing `d` still falls back to the event id, so a malformed
+// addressable event never swallows its siblings). Ties on `created_at`
+// keep the first-seen event, and output preserves input order — both
+// properties the old implementation had and callers may lean on.
+
+/** NIP-01 storage class for a kind: 'replaceable' | 'addressable' | 'regular'. */
+export function eventClass(kind) {
+    if (kind === 0 || kind === 3 || (kind >= 10000 && kind < 20000)) return 'replaceable';
+    if (kind >= 30000 && kind < 40000) return 'addressable';
+    return 'regular';
+}
+
+/** Dedupe key for an event, or null when the event is regular (keep all). */
+export function replaceableKey(ev) {
+    if (!ev) return null;
+    const cls = eventClass(ev.kind);
+    if (cls === 'regular') return null;
+    if (cls === 'replaceable') return `${ev.kind}:${ev.pubkey}`;
+    const d = ((ev.tags || []).find((t) => t[0] === 'd') || [])[1] || ev.id;
+    return `${ev.kind}:${ev.pubkey}:${d}`;
+}
+
+/**
+ * Collapse replaceable/addressable events to their latest version,
+ * preserving input order and keeping every regular event.
+ *
+ * @param {Array<object>} events  raw NOSTR events
+ * @returns {Array<object>}
+ */
+export function dedupeReplaceable(events) {
+    const list = Array.isArray(events) ? events : [];
+    const best = new Map(); // key → winning event
+    for (const ev of list) {
+        if (!ev) continue;
+        const key = replaceableKey(ev);
+        if (key === null) continue;
+        const seen = best.get(key);
+        if (!seen || (ev.created_at || 0) > (seen.created_at || 0)) best.set(key, ev);
+    }
+    const out = [];
+    const emitted = new Set();
+    for (const ev of list) {
+        if (!ev) continue;
+        const key = replaceableKey(ev);
+        if (key === null) { out.push(ev); continue; }
+        if (emitted.has(key)) continue;
+        if (best.get(key) === ev) { out.push(ev); emitted.add(key); }
+    }
+    return out;
+}

--- a/src/sidepanel/index.js
+++ b/src/sidepanel/index.js
@@ -25,6 +25,7 @@ import { collectCaseBundle, buildCaseBundleJson, isCaseBundle, importCaseBundle 
 import { accountsForEntity, listUnlinkedAccounts, linkAccountToEntity, unlinkAccount } from '../shared/identity/account-registry.js';
 import { LocalKeyManager } from '../shared/local-key-manager.js';
 import { Crypto } from '../shared/crypto.js';
+import { dedupeReplaceable } from '../shared/nostr-events.js';
 import { pushEntities, pullEntities, clearRemote, pushRelayList, pullRelayList, normalizeRelayUrl } from '../shared/entity-sync.js';
 
 // Reserved key name in LocalKeyManager for the user's primary
@@ -429,17 +430,11 @@ async function loadNetworkClaims(entity) {
     });
 }
 
-/** Latest-wins per (kind, pubkey, d) — NIP-01 addressable semantics. */
-function dedupeReplaceable(events) {
-    const best = new Map();
-    for (const ev of (Array.isArray(events) ? events : [])) {
-        const d = ((ev.tags || []).find((t) => t[0] === 'd') || [])[1] || ev.id;
-        const key = `${ev.kind}:${ev.pubkey}:${d}`;
-        const seen = best.get(key);
-        if (!seen || (ev.created_at || 0) > (seen.created_at || 0)) best.set(key, ev);
-    }
-    return [...best.values()];
-}
+// Replaceable-event dedup now lives in shared/nostr-events.js (Phase
+// 12.1) — the portal needs the same latest-wins collapse, class-aware
+// for its mixed-kind corpus. For this panel's all-30040 input the
+// shared helper is behavior-identical to the local function it
+// replaced.
 
 // Refs for the assess buttons in the network list (claim text stays
 // out of data attributes).

--- a/tests/assessment-model.test.mjs
+++ b/tests/assessment-model.test.mjs
@@ -283,3 +283,99 @@ test('assessment: getByClaimRef returns null for unassessed claims; delete works
     assert.equal(await AssessmentModel.get(a.id), null);
     assert.equal(await AssessmentModel.delete(a.id), false);
 });
+
+// ---------------------------------------------------------------------
+// parseAssessmentEvent — Phase 12.1 read-back (inverse of the 11.2
+// wire builder in metadata/builders.js)
+// ---------------------------------------------------------------------
+
+const { parseAssessmentEvent } = await import('../src/shared/assessment-model.js');
+const { buildAssessmentEvent } = await import('../src/shared/metadata/builders.js');
+
+test('parseAssessmentEvent round-trips buildAssessmentEvent', async () => {
+    const coord = `30040:${PUBKEY_A}:claim_1234567890abcdef`;
+    const anchor = [{ type: 'TextQuoteSelector', exact: 'worth $200,000' }];
+    const { event, dTag } = await buildAssessmentEvent({
+        claimCoord: coord,
+        claimUrl: URL_1,
+        claimEventId: 'e'.repeat(64),
+        stance: -2,
+        labels: [
+            { label: 'misleading', anchor, note: 'numbers do not add up' },
+            { label: 'fallacy/strawman' }
+        ],
+        rationale: 'The two figures cannot both be true.',
+        aboutPubkeys: [PUBKEY_B],
+        suggestedBy: 'llm:claude'
+    });
+    const a = parseAssessmentEvent({ ...event, pubkey: PUBKEY_A, id: 'f'.repeat(64) });
+    assert.ok(a, 'parser must accept its own builder output');
+    assert.equal(a.id, dTag);
+    assert.equal(a.claimCoord, coord);
+    assert.equal(a.claimEventId, 'e'.repeat(64));
+    assert.equal(a.claimAuthorPubkey, PUBKEY_A); // role-less p = claim author
+    assert.equal(a.stance, -2);
+    assert.deepEqual(a.labels.map((l) => l.label), ['misleading', 'fallacy/strawman']);
+    assert.deepEqual(a.labels[0].anchor, anchor);
+    assert.equal(a.labels[0].note, 'numbers do not add up');
+    assert.equal(a.labels[1].anchor, null);
+    assert.equal(a.labels[1].note, null);
+    assert.equal(a.rationale, 'The two figures cannot both be true.');
+    assert.deepEqual(a.aboutPubkeys, [PUBKEY_B]);
+    assert.equal(a.url, URL_1);
+    assert.equal(a.suggestedBy, 'llm:claude');
+    assert.equal(a.pubkey, PUBKEY_A);
+});
+
+test('parseAssessmentEvent: label-only assessment reads stance null', async () => {
+    const { event } = await buildAssessmentEvent({
+        claimCoord: `30040:${PUBKEY_A}:claim_1234567890abcdef`,
+        claimUrl: URL_1,
+        labels: ['misleading']
+    });
+    const a = parseAssessmentEvent(event);
+    assert.equal(a.stance, null);
+    assert.deepEqual(a.labels.map((l) => l.label), ['misleading']);
+});
+
+test('parseAssessmentEvent rejects wrong kind and missing claim coordinate', () => {
+    assert.equal(parseAssessmentEvent(null), null);
+    assert.equal(parseAssessmentEvent({ kind: 30055, tags: [['a', 'x']] }), null);
+    assert.equal(parseAssessmentEvent({ kind: 30054, tags: [['d', 'assess:x']], content: '' }), null);
+});
+
+test('parseAssessmentEvent degrades softly on malformed wire data', () => {
+    const a = parseAssessmentEvent({
+        kind: 30054,
+        tags: [
+            ['a', `30040:${PUBKEY_A}:claim_x`],
+            ['stance', '7'],                                  // out of range
+            ['L', 'xray/assessment'],
+            ['l', 'misleading', 'xray/assessment'],
+            ['l', 'misleading', 'xray/assessment'],           // duplicate — kept once
+            ['l', 'other-ns-label', 'someone/else'],          // foreign namespace — ignored
+            ['label-anchor', 'misleading', '{not json'],      // unparsable — stays null
+            ['label-note', 'unknown-label', 'orphan note']    // no matching label — dropped
+        ],
+        content: ''
+    });
+    assert.equal(a.stance, null);
+    assert.deepEqual(a.labels, [{ label: 'misleading', anchor: null, note: null }]);
+    assert.equal(a.suggestedBy, 'user');
+});
+
+test('buildAssessmentEvent tag vocabulary is pinned (parser contract)', async () => {
+    const { event } = await buildAssessmentEvent({
+        claimCoord: `30040:${PUBKEY_A}:claim_1234567890abcdef`,
+        claimUrl: URL_1,
+        claimEventId: 'e'.repeat(64),
+        stance: 1,
+        labels: [{ label: 'misleading', anchor: [{ type: 'TextQuoteSelector', exact: 'x' }], note: 'n' }],
+        aboutPubkeys: [PUBKEY_B]
+    });
+    const names = [...new Set(event.tags.map((t) => t[0]))].sort();
+    assert.deepEqual(names, [
+        'L', 'a', 'client', 'd', 'e', 'i', 'k', 'l',
+        'label-anchor', 'label-note', 'p', 'r', 'stance', 'suggested-by'
+    ]);
+});

--- a/tests/event-builder.test.mjs
+++ b/tests/event-builder.test.mjs
@@ -237,3 +237,83 @@ test('buildArticleEvent stringifies array section and object language', async ()
     assert.deepEqual(ev.tags.find((t) => t[0] === 'section'), ['section', 'History, Religion']);
     assert.deepEqual(ev.tags.find((t) => t[0] === 'lang'), ['lang', 'en']);
 });
+
+// ------------------------------------------------------------------
+// parseCommentEvent — Phase 12.1 read-back (inverse of buildCommentEvent)
+// ------------------------------------------------------------------
+
+const FULL_COMMENT = {
+    id: 'cmt:substack:98765',
+    text: 'This completely contradicts what he said last week.',
+    authorName: 'Jane Reader',
+    authorHandle: 'janereader',
+    authorUrl: 'https://substack.com/@janereader',
+    platform: 'substack',
+    timestamp: 1749500000000,    // ms — builder normalizes to seconds
+    replyTo: 'cmt:substack:98000',
+    reactionCount: 12,
+    restacks: 3
+};
+const ACCOUNT_PUBKEY = 'c'.repeat(64);
+
+test('parseCommentEvent round-trips buildCommentEvent field-for-field', () => {
+    const ev = EventBuilder.buildCommentEvent(
+        FULL_COMMENT, 'https://example.substack.com/p/post', 'The Post', PUBKEY, ACCOUNT_PUBKEY);
+    const c = EventBuilder.parseCommentEvent(ev);
+    assert.ok(c, 'parser must accept its own builder output');
+    assert.equal(c.id, FULL_COMMENT.id);
+    assert.equal(c.text, FULL_COMMENT.text);
+    assert.equal(c.author, FULL_COMMENT.authorName);
+    assert.equal(c.platform, 'substack');
+    assert.equal(c.authorHandle, FULL_COMMENT.authorHandle);
+    assert.equal(c.authorUrl, FULL_COMMENT.authorUrl);
+    assert.equal(c.commentDate, 1749500000); // ms → s happened at build time
+    assert.equal(c.replyTo, FULL_COMMENT.replyTo);
+    assert.equal(c.reactionCount, 12);
+    assert.equal(c.restackCount, 3);
+    assert.equal(c.commenterPubkey, ACCOUNT_PUBKEY);
+    assert.equal(c.url, 'https://example.substack.com/p/post');
+    assert.equal(c.title, 'The Post');
+    assert.equal(c.pubkey, PUBKEY);
+});
+
+test('parseCommentEvent: minimal comment degrades to nulls and zeros', () => {
+    const ev = EventBuilder.buildCommentEvent(
+        { id: 'cmt:youtube:1', text: 'short', platform: 'youtube' },
+        'https://youtube.com/watch?v=x', 'Video', PUBKEY, null);
+    const c = EventBuilder.parseCommentEvent(ev);
+    assert.equal(c.author, 'Unknown');
+    assert.equal(c.authorHandle, null);
+    assert.equal(c.authorUrl, null);
+    assert.equal(c.commentDate, null);
+    assert.equal(c.replyTo, null);
+    assert.equal(c.reactionCount, 0);
+    assert.equal(c.restackCount, 0);
+    assert.equal(c.commenterPubkey, null);
+});
+
+test('parseCommentEvent rejects wrong kinds and textless events', () => {
+    assert.equal(EventBuilder.parseCommentEvent(null), null);
+    assert.equal(EventBuilder.parseCommentEvent({ kind: 30040, tags: [], content: 'x' }), null);
+    assert.equal(EventBuilder.parseCommentEvent({ kind: 30041, tags: [['d', 'x']], content: '' }), null);
+});
+
+test('parseCommentEvent tolerates a foreign ms-precision comment-date', () => {
+    const c = EventBuilder.parseCommentEvent({
+        kind: 30041,
+        tags: [['d', 'x'], ['comment-text', 'hi'], ['comment-date', '1749500000000']],
+        content: 'hi'
+    });
+    assert.equal(c.commentDate, 1749500000);
+});
+
+test('buildCommentEvent tag vocabulary is pinned (parser contract)', () => {
+    const ev = EventBuilder.buildCommentEvent(
+        FULL_COMMENT, 'https://example.substack.com/p/post', 'The Post', PUBKEY, ACCOUNT_PUBKEY);
+    const names = [...new Set(ev.tags.map((t) => t[0]))].sort();
+    assert.deepEqual(names, [
+        'author-handle', 'author-url', 'client', 'comment-author',
+        'comment-date', 'comment-text', 'd', 'p', 'platform',
+        'r', 'reaction-count', 'reply-to', 'restack-count', 'title'
+    ]);
+});

--- a/tests/nostr-events.test.mjs
+++ b/tests/nostr-events.test.mjs
@@ -1,0 +1,121 @@
+// shared/nostr-events.js tests — Phase 12.1.
+//
+// The shared dedupeReplaceable generalizes the side panel's old
+// all-30040 helper to the portal's mixed corpus, so the NIP-01 class
+// boundaries are pinned here: a kind moving between classes (or a new
+// corpus kind landing in the wrong class) should fail a test, not
+// silently drop or duplicate events.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { eventClass, replaceableKey, dedupeReplaceable } from '../src/shared/nostr-events.js';
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+
+function ev(kind, pubkey, createdAt, { d, id } = {}) {
+    return {
+        id: id || `id_${kind}_${pubkey.slice(0, 4)}_${createdAt}_${d || ''}`,
+        kind,
+        pubkey,
+        created_at: createdAt,
+        tags: d !== undefined ? [['d', d]] : [],
+        content: ''
+    };
+}
+
+// ------------------------------------------------------------------
+// Class pins — every kind the portal queries, in its NIP-01 class
+// ------------------------------------------------------------------
+
+test('eventClass pins the NIP-01 class of every corpus kind', () => {
+    const expected = {
+        0:     'replaceable',
+        3:     'replaceable',
+        10002: 'replaceable',
+        30023: 'addressable',
+        30040: 'addressable',
+        30041: 'addressable',
+        30050: 'addressable',
+        30051: 'addressable',
+        30052: 'addressable',
+        30053: 'addressable',
+        30054: 'addressable',
+        30055: 'addressable',
+        30078: 'addressable',
+        32125: 'addressable',
+        32126: 'addressable',
+        1985:  'regular',
+        9803:  'regular',
+        1:     'regular'
+    };
+    for (const [kind, cls] of Object.entries(expected)) {
+        assert.equal(eventClass(Number(kind)), cls, `kind ${kind}`);
+    }
+});
+
+test('replaceableKey shape per class', () => {
+    assert.equal(replaceableKey(ev(0, PK_A, 1)), `0:${PK_A}`);
+    assert.equal(replaceableKey(ev(30040, PK_A, 1, { d: 'claim_x' })), `30040:${PK_A}:claim_x`);
+    assert.equal(replaceableKey(ev(1985, PK_A, 1)), null);
+    // Addressable with no d falls back to the event id — a malformed
+    // event must never swallow its siblings.
+    const noD = ev(30040, PK_A, 1, { id: 'idX' });
+    assert.equal(replaceableKey(noD), `30040:${PK_A}:idX`);
+});
+
+// ------------------------------------------------------------------
+// dedupeReplaceable behavior
+// ------------------------------------------------------------------
+
+test('addressable: latest wins per (kind, pubkey, d)', () => {
+    const oldV = ev(30040, PK_A, 100, { d: 'claim_x' });
+    const newV = ev(30040, PK_A, 200, { d: 'claim_x' });
+    const other = ev(30040, PK_A, 50, { d: 'claim_y' });
+    const out = dedupeReplaceable([oldV, newV, other]);
+    assert.deepEqual(out.map((e) => e.id), [newV.id, other.id]);
+});
+
+test('addressable: same d under different pubkeys both survive', () => {
+    const a = ev(30040, PK_A, 100, { d: 'claim_x' });
+    const b = ev(30040, PK_B, 100, { d: 'claim_x' });
+    assert.equal(dedupeReplaceable([a, b]).length, 2);
+});
+
+test('replaceable: kind 0 and 10002 collapse per (kind, pubkey) with no d tag', () => {
+    const profile1 = ev(0, PK_A, 100);
+    const profile2 = ev(0, PK_A, 200);
+    const relays1 = ev(10002, PK_A, 100);
+    const relays2 = ev(10002, PK_A, 300);
+    const otherAuthor = ev(0, PK_B, 50);
+    const out = dedupeReplaceable([profile1, profile2, relays1, relays2, otherAuthor]);
+    assert.deepEqual(out.map((e) => e.id), [profile2.id, relays2.id, otherAuthor.id]);
+});
+
+test('regular: every 1985 / 9803 event is kept', () => {
+    const l1 = ev(1985, PK_A, 100);
+    const l2 = ev(1985, PK_A, 100);
+    const v1 = ev(9803, PK_A, 100);
+    assert.equal(dedupeReplaceable([l1, l2, v1]).length, 3);
+});
+
+test('created_at tie keeps the first-seen event', () => {
+    const a = ev(30040, PK_A, 100, { d: 'claim_x', id: 'first' });
+    const b = ev(30040, PK_A, 100, { d: 'claim_x', id: 'second' });
+    const out = dedupeReplaceable([a, b]);
+    assert.deepEqual(out.map((e) => e.id), ['first']);
+});
+
+test('output preserves input order and skips falsy entries', () => {
+    const c1 = ev(30040, PK_A, 100, { d: 'c1' });
+    const label = ev(1985, PK_A, 150);
+    const c2 = ev(30040, PK_A, 200, { d: 'c2' });
+    const out = dedupeReplaceable([c1, null, label, undefined, c2]);
+    assert.deepEqual(out.map((e) => e.id), [c1.id, label.id, c2.id]);
+});
+
+test('non-array input yields an empty array', () => {
+    assert.deepEqual(dedupeReplaceable(null), []);
+    assert.deepEqual(dedupeReplaceable(undefined), []);
+});

--- a/tests/portal-corpus.test.mjs
+++ b/tests/portal-corpus.test.mjs
@@ -1,0 +1,152 @@
+// portal/corpus.js tests — Phase 12.1 (docs/PORTAL_DESIGN.md).
+//
+// The corpus fetcher is wire-adjacent (it speaks `xray:relay:query` to
+// the background pool), so its contract is pinned against a scripted
+// chrome.runtime.sendMessage shim: per-relay addressing for provenance,
+// empty-page (not short-page) pagination, entity-author chunking, and
+// failed relays degrading to an error entry instead of sinking the run.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Scripted relay backend: each test installs a handler that receives
+// (relayUrl, filter) and returns the events for that page.
+let scriptedHandler = null;
+const sentMessages = [];
+
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(_k, cb) { cb({}); },
+            set(_o, cb) { cb && cb(); },
+            remove(_k, cb) { cb && cb(); }
+        }
+    },
+    runtime: {
+        sendMessage(message, cb) {
+            sentMessages.push(message);
+            const relay = message.relays && message.relays[0];
+            try {
+                const result = scriptedHandler(relay, message.filter);
+                if (result && result.error) { cb({ ok: false, error: result.error }); return; }
+                cb({ ok: true, events: result, byRelay: { [relay]: { received: result.length, eose: true } } });
+            } catch (err) {
+                cb({ ok: false, error: err.message });
+            }
+        }
+    }
+};
+
+const { fetchCorpus, CONTENT_KINDS, FALLBACK_RELAYS } = await import('../src/portal/corpus.js');
+
+const PK = 'a'.repeat(64);
+const RELAY_A = 'wss://relay-a.example';
+const RELAY_B = 'wss://relay-b.example';
+
+function ev(id, createdAt, kind = 30040) {
+    return { id, kind, pubkey: PK, created_at: createdAt, tags: [['d', id]], content: '' };
+}
+
+function reset(handler) {
+    scriptedHandler = handler;
+    sentMessages.length = 0;
+}
+
+test('CONTENT_KINDS pins the full corpus kind list from the design note', () => {
+    assert.deepEqual([...CONTENT_KINDS].sort((a, b) => a - b), [
+        1985, 9803, 10002, 30023, 30040, 30041, 30050, 30051, 30052,
+        30053, 30054, 30055, 30078, 32125, 32126
+    ]);
+});
+
+test('FALLBACK_RELAYS mirrors the background hardcoded trio', () => {
+    assert.deepEqual(FALLBACK_RELAYS,
+        ['wss://relay.damus.io', 'wss://nos.lol', 'wss://relay.nostr.band']);
+});
+
+test('per-relay provenance: shared events accumulate both relays', async () => {
+    reset((relay, filter) => {
+        if (filter.until !== undefined) return []; // second page: empty everywhere
+        if (relay === RELAY_A) return [ev('e1', 100), ev('e2', 90)];
+        if (relay === RELAY_B) return [ev('e2', 90), ev('e3', 80)];
+        return [];
+    });
+    const { records, relayErrors } = await fetchCorpus({
+        pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A, RELAY_B]
+    });
+    assert.deepEqual(relayErrors, {});
+    const byId = new Map(records.map((r) => [r.event.id, r.relays.sort()]));
+    assert.deepEqual(byId.get('e1'), [RELAY_A]);
+    assert.deepEqual(byId.get('e2'), [RELAY_A, RELAY_B]);
+    assert.deepEqual(byId.get('e3'), [RELAY_B]);
+});
+
+test('pagination stops on an EMPTY page, not a short one, and pages with until = oldest - 1', async () => {
+    const pagesServed = [];
+    reset((_relay, filter) => {
+        pagesServed.push(filter.until);
+        if (filter.until === undefined) return [ev('p1', 100), ev('p2', 90)];   // short page (relay cap)
+        if (filter.until === 89) return [ev('p3', 50)];                          // older events still there
+        if (filter.until === 49) return [];                                      // genuinely dry
+        throw new Error(`unexpected until ${filter.until}`);
+    });
+    const { records } = await fetchCorpus({ pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A] });
+    assert.deepEqual(pagesServed, [undefined, 89, 49]);
+    assert.equal(records.length, 3);
+});
+
+test('Q1 filter carries authors + the full kind list + a limit', async () => {
+    reset(() => []);
+    await fetchCorpus({ pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A] });
+    assert.equal(sentMessages.length, 1);
+    const { type, filter, relays, timeoutMs } = sentMessages[0];
+    assert.equal(type, 'xray:relay:query');
+    assert.deepEqual(relays, [RELAY_A]);
+    assert.deepEqual(filter.authors, [PK]);
+    assert.deepEqual(filter.kinds, CONTENT_KINDS);
+    assert.ok(filter.limit > 0);
+    assert.ok(timeoutMs > 0);
+});
+
+test('Q2 chunks entity authors at 100 per kind-0 query, separate from Q1', async () => {
+    reset(() => []);
+    const entityPubkeys = Array.from({ length: 250 }, (_, i) =>
+        i.toString(16).padStart(64, '0'));
+    await fetchCorpus({ pubkeys: [PK], entityPubkeys, relays: [RELAY_A] });
+    const q2 = sentMessages.filter((m) => m.filter.kinds.length === 1 && m.filter.kinds[0] === 0);
+    assert.deepEqual(q2.map((m) => m.filter.authors.length), [100, 100, 50]);
+    // entity queries never ride in the Q1 authors list
+    const q1 = sentMessages.find((m) => m.filter.kinds.length > 1);
+    assert.deepEqual(q1.filter.authors, [PK]);
+});
+
+test('a failing relay lands in relayErrors; the healthy relay still delivers', async () => {
+    reset((relay, filter) => {
+        if (relay === RELAY_A) return { error: 'connection refused' };
+        return filter.until === undefined ? [ev('ok1', 10)] : [];
+    });
+    const { records, relayErrors } = await fetchCorpus({
+        pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A, RELAY_B]
+    });
+    assert.deepEqual(Object.keys(relayErrors), [RELAY_A]);
+    assert.match(relayErrors[RELAY_A], /connection refused/);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0].relays, [RELAY_B]);
+});
+
+test('no pubkeys and no entities sends nothing', async () => {
+    reset(() => { throw new Error('should not be called'); });
+    const { records } = await fetchCorpus({ pubkeys: [], entityPubkeys: [], relays: [RELAY_A] });
+    assert.equal(sentMessages.length, 0);
+    assert.deepEqual(records, []);
+});
+
+test('onProgress ticks with a running fetched count', async () => {
+    reset((_relay, filter) => (filter.until === undefined ? [ev('x', 5)] : []));
+    const ticks = [];
+    await fetchCorpus({
+        pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A],
+        onProgress: (p) => ticks.push(p.fetched)
+    });
+    assert.deepEqual(ticks, [1]);
+});

--- a/tests/portal-identity.test.mjs
+++ b/tests/portal-identity.test.mjs
@@ -1,0 +1,160 @@
+// portal/identity.js tests — Phase 12.1 (docs/PORTAL_DESIGN.md).
+//
+// The resolver unions four pubkey sources; these tests drive all of
+// them through the real Storage / LocalKeyManager / models against the
+// standard chrome.storage.local shim. The NIP-07 case pins the design
+// decision: no tab-routing in v1 — the signer source resolves to null
+// with a human-readable reason instead of throwing.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const { Storage } = await import('../src/shared/storage.js');
+const { LocalKeyManager } = await import('../src/shared/local-key-manager.js');
+const { Crypto } = await import('../src/shared/crypto.js');
+const {
+    resolveIdentities, addManualIdentity, removeManualIdentity, getManualIdentities
+} = await import('../src/portal/identity.js');
+
+const SIGNER_PK = 'a'.repeat(64);
+const SYNC_PK = 'b'.repeat(64);
+const HISTORY_PK_1 = 'c'.repeat(64);
+const HISTORY_PK_2 = 'd'.repeat(64);
+const MANUAL_PK = 'e'.repeat(64);
+const ENTITY_PK = 'f'.repeat(64);
+
+async function seedEverything() {
+    _stateStore.clear();
+    LocalKeyManager.keys.clear(); // module-level Map — reset between tests
+    await Storage.set('preferences', { signing_method: 'local', signing_method_configured: true });
+    await Storage.set('local_primary_identity', { pubkey: SIGNER_PK, privateKey: '1'.repeat(64) });
+    await Storage.set('local_keys', {
+        'xray:user': { name: 'xray:user', pubkey: SYNC_PK, privateKey: '2'.repeat(64) },
+        'entity:entity_0123456789abcdef': {
+            name: 'entity:entity_0123456789abcdef', pubkey: ENTITY_PK, privateKey: '3'.repeat(64)
+        }
+    });
+    await Storage.set('article_claims', {
+        claim_x: {
+            id: 'claim_x', text: 'A claim', source_url: 'https://example.com',
+            publishedPubkey: HISTORY_PK_1,
+            publishedPubkeys: [HISTORY_PK_1, HISTORY_PK_2]
+        }
+    });
+    await Storage.set('portal_identities', [MANUAL_PK]);
+    await Storage.set('entities', {
+        entity_0123456789abcdef: {
+            id: 'entity_0123456789abcdef', name: 'Test Person', type: 'person',
+            keyName: 'entity:entity_0123456789abcdef'
+        }
+    });
+}
+
+function sourcesFor(identities, pubkey) {
+    const hit = identities.find((i) => i.pubkey === pubkey);
+    return hit ? [...hit.sources].sort() : null;
+}
+
+test('resolveIdentities unions all four sources with provenance', async () => {
+    await seedEverything();
+    const { identities, entities, signer } = await resolveIdentities();
+
+    assert.equal(signer.method, 'local');
+    assert.equal(signer.pubkey, SIGNER_PK);
+    assert.deepEqual(sourcesFor(identities, SIGNER_PK), ['signer']);
+    assert.deepEqual(sourcesFor(identities, SYNC_PK), ['sync-key']);
+    assert.deepEqual(sourcesFor(identities, HISTORY_PK_1), ['publish-history']);
+    assert.deepEqual(sourcesFor(identities, HISTORY_PK_2), ['publish-history']);
+    assert.deepEqual(sourcesFor(identities, MANUAL_PK), ['manual']);
+    assert.equal(identities.length, 5);
+
+    assert.equal(entities.length, 1);
+    assert.equal(entities[0].pubkey, ENTITY_PK);
+    assert.equal(entities[0].name, 'Test Person');
+    assert.equal(entities[0].type, 'person');
+});
+
+test('a pubkey reachable via several sources gets one entry, merged provenance', async () => {
+    await seedEverything();
+    await Storage.set('portal_identities', [SYNC_PK]); // manual duplicate of the sync key
+    const { identities } = await resolveIdentities();
+    assert.deepEqual(sourcesFor(identities, SYNC_PK), ['manual', 'sync-key']);
+});
+
+test('NIP-07 mode: signer unresolved with a reason, other sources still flow', async () => {
+    await seedEverything();
+    await Storage.set('preferences', { signing_method: 'nip07', signing_method_configured: true });
+    const { identities, signer } = await resolveIdentities();
+    assert.equal(signer.pubkey, null);
+    assert.match(signer.reason, /NIP-07/);
+    assert.equal(sourcesFor(identities, SIGNER_PK), null); // signer source gone
+    assert.deepEqual(sourcesFor(identities, SYNC_PK), ['sync-key']);
+});
+
+test('garbage in storage never reaches the identity set', async () => {
+    await seedEverything();
+    await Storage.set('portal_identities', ['not-a-key', 42, null, MANUAL_PK]);
+    await Storage.set('article_claims', {
+        claim_y: { id: 'claim_y', text: 't', source_url: 'https://x.com', publishedPubkeys: ['xyz', HISTORY_PK_1] }
+    });
+    const { identities } = await resolveIdentities();
+    for (const id of identities) assert.match(id.pubkey, /^[0-9a-f]{64}$/);
+    assert.deepEqual(sourcesFor(identities, MANUAL_PK), ['manual']);
+    assert.deepEqual(sourcesFor(identities, HISTORY_PK_1), ['publish-history']);
+});
+
+test('addManualIdentity accepts npub and hex, rejects junk, dedups', async () => {
+    _stateStore.clear();
+    LocalKeyManager.keys.clear();
+    await Storage.set('preferences', { signing_method: 'local' });
+
+    const npub = Crypto.hexToNpub(MANUAL_PK);
+    assert.ok(npub && npub.startsWith('npub1'), 'test needs a valid npub');
+
+    const viaNpub = await addManualIdentity(npub);
+    assert.deepEqual(viaNpub, { ok: true, pubkey: MANUAL_PK });
+
+    const viaHexDup = await addManualIdentity(MANUAL_PK.toUpperCase());
+    assert.deepEqual(viaHexDup, { ok: true, pubkey: MANUAL_PK });
+    assert.deepEqual(await getManualIdentities(), [MANUAL_PK]); // no dup
+
+    const junk = await addManualIdentity('npub1notreal');
+    assert.equal(junk.ok, false);
+    const empty = await addManualIdentity('   ');
+    assert.equal(empty.ok, false);
+    const shortHex = await addManualIdentity('abc123');
+    assert.equal(shortHex.ok, false);
+});
+
+test('removeManualIdentity removes only the asked-for key', async () => {
+    _stateStore.clear();
+    LocalKeyManager.keys.clear();
+    await Storage.set('portal_identities', [MANUAL_PK, HISTORY_PK_1]);
+    await removeManualIdentity(MANUAL_PK);
+    assert.deepEqual(await getManualIdentities(), [HISTORY_PK_1]);
+    await removeManualIdentity('not-present');
+    assert.deepEqual(await getManualIdentities(), [HISTORY_PK_1]);
+});


### PR DESCRIPTION
First implementation slice of the Phase 12 portal (design: `docs/PORTAL_DESIGN.md`, agreed in #48). This is the end-to-end pipe; Library/search, caching, timeline, graph, and reconciliation build on it in 12.2–12.7.

## What's here

- **Portal page** `src/portal/` — sixth esbuild entry, no manifest change (reader precedent). Opened via the toolbar right-click menu ("Open My Archive") or the new `xray:openPortal` message.
- **Identity resolver** (`portal/identity.js`) — the four-source union with provenance chips: signer (Local/NSecBunker; timeout-bounded), `xray:user` sync key, claims' `publishedPubkeys` history, manual npub/hex (persisted). NIP-07 → honest empty state with guidance, no tab-routing (design Q1 ✅).
- **Corpus fetch** (`portal/corpus.js`) — `xray:relay:query` one relay per REQ so "which relays hold this event" is exact; pagination stops on an *empty* page (a short page may just be the relay's own cap); entity kind-0 profiles in a separate chunked subscription (design Q4 ✅).
- **New parsers** — `EventBuilder.parseCommentEvent` (30041) and `parseAssessmentEvent` (30054 in `assessment-model.js`), round-trip tested against their builders with pinned tag vocabularies.
- **Shared dedupe** — the side panel's `dedupeReplaceable` moved to `shared/nostr-events.js`, now NIP-01-class-aware (the old helper would have kept every version of a kind-0/10002 in a mixed corpus; behavior-identical for the panel's all-30040 input).
- **UI (12.1 scope)** — flat newest-first list, per-kind summaries, relay-count + other-client badges, lazy raw-event JSON. All DOM via `textContent` (no new UNSAFE_VAR_ASSIGNMENT warnings from portal code; the +5 in lint output are pre-existing shared-module warnings now also mapped under the new bundle).

## Gates

build ✅ · 623/623 tests ✅ (34 new) · web-ext lint 0 errors ✅

## Smoke (for the grouped §Phase 12 run later)

`npm run build` → reload extension → toolbar right-click → **Open My Archive** → identity chips render → corpus loads from configured relays → rows summarize per kind → "Raw event" expands the signed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)