### PR TITLE
feat(portal): Library — type tabs, facets, search (Phase 12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,18 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Portal Library — type tabs, facets, search** (Phase 12.2). The
+  portal's flat list grows into a browsable Library: type tabs with
+  live counts (Articles / Claims / Comments / Assessments / Links /
+  Entities / Cases / Accounts / Other), facet selects for platform,
+  source domain, case, and publishing client, a group-by-source toggle,
+  and cross-cutting token-AND search over claim text, comment text,
+  article titles, entity names, assessment labels and rationale, and
+  account handles. Case membership derives from `p` tags matching
+  local case entities — the publish-side complement of the side
+  panel's case dashboard. The item model is a pure module
+  (`src/portal/library.js`) with its own test suite.
+
 - **"My Archive" portal — foundation** (Phase 12.1,
   `docs/PORTAL_DESIGN.md`). A new full-tab extension page
   (`src/portal/`, opened from the toolbar right-click menu or the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -900,8 +900,8 @@ Slices (one PR each):
   identity resolver; corpus queries; **new `parseCommentEvent` (30041)
   + `parseAssessmentEvent` (30054) parsers + tests**; flat event
   list. — #49
-- ⬜ **12.2** Library — type tabs, per-type renderers, facets,
-  cross-cutting search.
+- ✅ **12.2** Library — type tabs, per-type renderers, facets,
+  cross-cutting search. — #50
 - ⬜ **12.3** Cache — IndexedDB `xray-portal`, cache-first render,
   incremental refresh, relay-provenance persistence.
 - ⬜ **12.4** Timeline — density buckets + brush filtering.

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -146,6 +146,100 @@ body.xr-portal {
   font-size: 12px;
 }
 
+/* ---------------- library tabs + facets (12.2) ---------------- */
+
+.xr-portal__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 16px 0;
+}
+
+.xr-tab {
+  border: 1px solid var(--xr-border);
+  border-bottom: none;
+  border-radius: 6px 6px 0 0;
+  background: var(--xr-surface);
+  color: var(--xr-text-dim);
+  padding: 6px 10px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.xr-tab--active {
+  color: var(--xr-text);
+  background: var(--xr-surface-2);
+  border-color: var(--xr-primary);
+}
+
+.xr-tab__count {
+  display: inline-block;
+  min-width: 18px;
+  padding: 0 5px;
+  margin-left: 4px;
+  border-radius: 999px;
+  background: var(--xr-bg);
+  color: var(--xr-text-dim);
+  font-size: 11px;
+  text-align: center;
+}
+
+.xr-portal__facets {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--xr-border);
+  border-bottom: 1px solid var(--xr-border);
+  background: var(--xr-surface);
+}
+
+.xr-portal__facets input[type="search"] {
+  flex: 1;
+  min-width: 200px;
+  padding: 6px 10px;
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  background: var(--xr-bg);
+  color: var(--xr-text);
+  font-size: 13px;
+}
+
+.xr-portal__facets select {
+  max-width: 220px;
+  padding: 5px 8px;
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  background: var(--xr-bg);
+  color: var(--xr-text);
+  font-size: 12px;
+}
+
+.xr-portal__group-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--xr-text-dim);
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.xr-portal__group-head {
+  margin: 16px 0 4px;
+  padding: 0 2px 4px;
+  border-bottom: 1px solid var(--xr-border);
+  color: var(--xr-text-dim);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  list-style: none;
+}
+
+.xr-badge--case { color: var(--xr-accent); border-color: var(--xr-accent); }
+
 /* ---------------- status ---------------- */
 
 .xr-portal__status {

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -26,6 +26,25 @@
     </form>
   </section>
 
+  <!-- Library chrome (Phase 12.2): type tabs + facet bar + search.
+       Hidden until a corpus is loaded. -->
+  <nav class="xr-portal__tabs" id="xr-tabs" aria-label="Type filter" hidden></nav>
+
+  <div class="xr-portal__facets" id="xr-facets" hidden>
+    <input type="search" id="xr-search" placeholder="Search everything…" autocomplete="off" />
+    <select id="xr-facet-platform" title="Filter by platform"></select>
+    <select id="xr-facet-domain" title="Filter by source domain"></select>
+    <select id="xr-facet-case" title="Filter by case"></select>
+    <select id="xr-facet-client" title="Filter by publishing client">
+      <option value="all">All clients</option>
+      <option value="ours">X-Ray only</option>
+      <option value="other">Other clients</option>
+    </select>
+    <label class="xr-portal__group-toggle" title="Group the list by source domain">
+      <input type="checkbox" id="xr-group-domain" /> Group by source
+    </label>
+  </div>
+
   <div class="xr-portal__status" id="xr-status" hidden></div>
 
   <main class="xr-portal__main">

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -1,11 +1,11 @@
-// X-Ray portal — "My Archive" (Phase 12.1, docs/PORTAL_DESIGN.md).
+// X-Ray portal — "My Archive" (Phase 12, docs/PORTAL_DESIGN.md).
 //
-// Slice 12.1 is the end-to-end pipe: resolve who "me" is, pull the
-// published corpus off the configured relays through the background
-// pool, collapse replaceable versions, and render a flat newest-first
-// list with per-kind one-line summaries and the raw signed event a
-// click away. Type views, search, caching, the graph, and
-// reconciliation land in later slices on top of this.
+// View layer only: identity chips, the Library (type tabs + facets +
+// cross-cutting search, Phase 12.2), and the flat row list with raw
+// events a click away. The item model, filtering, and search live in
+// ./library.js; identity resolution in ./identity.js; relay fetch in
+// ./corpus.js. Caching (12.3), the timeline (12.4), entity/case views
+// (12.5), and reconciliation (12.6) land on top of this.
 //
 // All DOM here is built with createElement/textContent — no dynamic
 // innerHTML (keeps web-ext's UNSAFE_VAR_ASSIGNMENT warnings from
@@ -13,44 +13,25 @@
 
 import { Storage } from '../shared/storage.js';
 import { Utils } from '../shared/utils.js';
-import { EventBuilder } from '../shared/event-builder.js';
-import { parseClaimEvent } from '../shared/claim-model.js';
-import { parseAssessmentEvent } from '../shared/assessment-model.js';
-import { parseRelationshipEvent } from '../shared/evidence-linker.js';
 import { dedupeReplaceable } from '../shared/nostr-events.js';
 import { resolveIdentities, addManualIdentity, removeManualIdentity } from './identity.js';
 import { fetchCorpus, FALLBACK_RELAYS } from './corpus.js';
+import {
+    buildItems, applyFilters, typeCounts, facetValues, isOtherClient,
+    kindLabel, TYPE_DEFS, EMPTY_FILTERS
+} from './library.js';
 
 const $ = (sel) => document.querySelector(sel);
-
-// Tags written by this extension (current + userscript-era value).
-const OUR_CLIENT_TAGS = new Set(['xray', 'nostr-article-capture']);
-
-const KIND_LABELS = {
-    30023: 'Article',
-    30040: 'Claim',
-    30041: 'Comment',
-    30054: 'Assessment',
-    30055: 'Link',
-    1985:  'Label',
-    0:     'Profile',
-    32125: 'Entity link',
-    32126: 'Account',
-    10002: 'Relay list',
-    30078: 'Entity sync',
-    30050: 'Annotation',
-    30051: 'Fact-check',
-    30052: 'Rating',
-    30053: 'Topic trust',
-    9803:  'Vote'
-};
 
 const state = {
     identities: [],      // [{pubkey, sources}]
     entities: [],        // [{pubkey, entityId, name, type}]
     signer: null,        // {method, pubkey, reason}
     relays: [],
-    records: [],         // [{event, relays}]
+    records: [],         // [{event, relays}] — raw, pre-dedupe
+    items: [],           // library items (deduped, parsed, sorted)
+    filters: { ...EMPTY_FILTERS },
+    groupByDomain: false,
     relayErrors: {},
     truncated: false,
     loading: false
@@ -75,100 +56,13 @@ function shortKey(pubkey) {
     return pubkey.slice(0, 8) + '…' + pubkey.slice(-4);
 }
 
-// ------------------------------------------------------------------
-// Per-kind one-line summaries (the 12.1 generic rows; richer per-type
-// renderers arrive with the Library slice)
-// ------------------------------------------------------------------
-
-function firstTag(event, name) {
-    const t = (event.tags || []).find((x) => x[0] === name);
-    return t ? t[1] : '';
-}
-
 function truncate(s, n) {
     const str = String(s || '').trim();
     return str.length > n ? str.slice(0, n - 1) + '…' : str;
 }
 
-function domainOf(url) {
-    try { return new URL(url).hostname; } catch (_) { return ''; }
-}
-
-/** @returns {{title: string, sub: string}} */
-function summarize(event) {
-    switch (event.kind) {
-        case 30023: {
-            const title = firstTag(event, 'title') || '(untitled capture)';
-            const url = firstTag(event, 'r');
-            return { title, sub: domainOf(url) || url };
-        }
-        case 30040: {
-            const c = parseClaimEvent(event);
-            return { title: truncate(c.text, 140) || '(empty claim)', sub: c.source ? `source: ${c.source}` : '' };
-        }
-        case 30041: {
-            const c = EventBuilder.parseCommentEvent(event);
-            if (!c) return { title: '(unparsable comment)', sub: '' };
-            return { title: truncate(c.text, 140), sub: `${c.author} · ${c.platform}` };
-        }
-        case 30054: {
-            const a = parseAssessmentEvent(event);
-            if (!a) return { title: '(unparsable assessment)', sub: '' };
-            const bits = [];
-            if (a.stance !== null) bits.push(`stance ${a.stance > 0 ? '+' : ''}${a.stance}`);
-            if (a.labels.length) bits.push(a.labels.map((l) => l.label).join(', '));
-            return { title: bits.join(' · ') || '(judgment)', sub: truncate(a.rationale, 120) };
-        }
-        case 30055: {
-            const r = parseRelationshipEvent(event);
-            if (!r) return { title: '(unparsable link)', sub: '' };
-            return { title: r.relationship || '(link)', sub: truncate(r.note, 120) || `${r.urls.length} source(s)` };
-        }
-        case 1985: {
-            const labels = (event.tags || []).filter((t) => t[0] === 'l').map((t) => t[1]);
-            return { title: labels.join(', ') || '(label)', sub: firstTag(event, 'r') };
-        }
-        case 0: {
-            let name = '';
-            let about = '';
-            try {
-                const profile = JSON.parse(event.content || '{}');
-                name = profile.name || '';
-                about = profile.about || '';
-            } catch (_) { /* malformed profile content */ }
-            return { title: name || '(profile)', sub: truncate(about, 120) };
-        }
-        case 32125: {
-            return {
-                title: `${firstTag(event, 'entity-name') || '(entity)'} — ${firstTag(event, 'relationship') || 'related'}`,
-                sub: firstTag(event, 'r')
-            };
-        }
-        case 32126: {
-            const acct = EventBuilder.reconstructPlatformAccount(event);
-            if (!acct) return { title: '(unparsable account)', sub: '' };
-            return {
-                title: `${acct.platform}: ${acct.handle || acct.displayName || acct.stableId}`,
-                sub: acct.linkedEntityId ? `linked to ${acct.linkedEntityId}` : ''
-            };
-        }
-        case 10002: {
-            const relays = (event.tags || []).filter((t) => t[0] === 'r').map((t) => t[1]);
-            return { title: `${relays.length} relay(s) declared`, sub: relays.join('  ') };
-        }
-        case 30078: {
-            return { title: firstTag(event, 'd') || '(entity sync)', sub: 'encrypted — listed, not decrypted' };
-        }
-        default: {
-            const d = firstTag(event, 'd');
-            const r = firstTag(event, 'r');
-            return { title: d || event.id || '(event)', sub: r };
-        }
-    }
-}
-
 // ------------------------------------------------------------------
-// Rendering
+// Header / identity / status
 // ------------------------------------------------------------------
 
 function setStatus(text, isError) {
@@ -208,88 +102,160 @@ function renderIdentityChips() {
     }
 }
 
-function renderEmpty() {
+function renderEmpty(heading, lines) {
     const host = $('#xr-empty');
     clear(host);
     host.hidden = false;
     $('#xr-list').hidden = true;
-    host.appendChild(el('h2', null, 'No identity resolved'));
-    const reason = state.signer && state.signer.reason
-        ? `Signing (${state.signer.method}): ${state.signer.reason}`
-        : 'No signing identity, sync key, publish history, or manual identity found.';
-    host.appendChild(el('p', null, reason));
-    host.appendChild(el('p', null,
-        'Paste your npub above, configure signing in Settings, or publish a capture once — then refresh.'));
-}
-
-function renderRows() {
-    const list = $('#xr-list');
-    const empty = $('#xr-empty');
-    empty.hidden = true;
-    list.hidden = false;
-    clear(list);
-
-    const relaysByEventId = new Map(state.records.map((r) => [r.event.id, r.relays]));
-    const display = dedupeReplaceable(state.records.map((r) => r.event))
-        .sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
-
-    for (const event of display) {
-        const row = el('li', 'xr-row');
-        const head = el('div', 'xr-row__head');
-        head.appendChild(el('span', 'xr-row__kind', KIND_LABELS[event.kind] || `kind ${event.kind}`));
-
-        const { title, sub } = summarize(event);
-        head.appendChild(el('span', 'xr-row__title', title));
-
-        const badges = el('span', 'xr-row__badges');
-        const relays = relaysByEventId.get(event.id) || [];
-        const relayBadge = el('span', 'xr-badge', `${relays.length} relay${relays.length === 1 ? '' : 's'}`);
-        relayBadge.title = relays.join('\n');
-        badges.appendChild(relayBadge);
-        const client = firstTag(event, 'client');
-        if (client && !OUR_CLIENT_TAGS.has(client)) {
-            badges.appendChild(el('span', 'xr-badge xr-badge--warn', `via ${truncate(client, 24)}`));
-        }
-        head.appendChild(badges);
-
-        if (event.created_at) {
-            head.appendChild(el('span', 'xr-row__date', new Date(event.created_at * 1000).toLocaleString()));
-        }
-        row.appendChild(head);
-        if (sub) row.appendChild(el('div', 'xr-row__sub', sub));
-
-        const details = el('details');
-        details.appendChild(el('summary', null, 'Raw event'));
-        const pre = el('pre');
-        // Serialize lazily — hundreds of large 30023s stringified up
-        // front would make first paint pay for JSON nobody opened.
-        details.addEventListener('toggle', () => {
-            if (details.open && !pre.textContent) {
-                pre.textContent = JSON.stringify(event, null, 2);
-            }
-        }, { once: false });
-        details.appendChild(pre);
-        row.appendChild(details);
-
-        list.appendChild(row);
-    }
-
-    if (display.length === 0) {
-        const host = empty;
-        clear(host);
-        host.hidden = false;
-        list.hidden = true;
-        host.appendChild(el('h2', null, 'Nothing found on the relays'));
-        host.appendChild(el('p', null,
-            'The configured relays returned no events for the resolved identities. '
-            + 'If you publish from another device, add that identity above; otherwise publish a capture and refresh.'));
-    }
+    host.appendChild(el('h2', null, heading));
+    for (const line of lines) host.appendChild(el('p', null, line));
 }
 
 function renderFooter() {
     $('#xr-footer-relays').textContent = state.relays.length
         ? `Relays: ${state.relays.join('  ')}`
         : 'No relays configured.';
+}
+
+// ------------------------------------------------------------------
+// Library: tabs + facets + rows (Phase 12.2)
+// ------------------------------------------------------------------
+
+function renderTabs() {
+    const host = $('#xr-tabs');
+    host.hidden = false;
+    clear(host);
+    // Counts respect search + facets so the tab numbers answer "what
+    // would I see if I clicked this" — type itself excluded, of course.
+    const counted = applyFilters(state.items, { ...state.filters, type: 'all' });
+    const counts = typeCounts(counted);
+
+    const defs = [{ key: 'all', label: 'All' }, ...TYPE_DEFS];
+    for (const def of defs) {
+        const count = counts[def.key] || 0;
+        if (count === 0 && def.key !== 'all' && state.filters.type !== def.key) continue;
+        const btn = el('button', 'xr-tab', `${def.label} `);
+        btn.type = 'button';
+        btn.appendChild(el('span', 'xr-tab__count', String(count)));
+        btn.classList.toggle('xr-tab--active', state.filters.type === def.key);
+        btn.addEventListener('click', () => {
+            state.filters.type = def.key;
+            renderLibrary();
+        });
+        host.appendChild(btn);
+    }
+}
+
+function fillFacetSelect(select, values, selected, allLabel) {
+    clear(select);
+    const allOpt = el('option', null, allLabel);
+    allOpt.value = '';
+    select.appendChild(allOpt);
+    for (const { value, count } of values) {
+        const opt = el('option', null, `${truncate(value, 40)} (${count})`);
+        opt.value = value;
+        select.appendChild(opt);
+    }
+    select.value = values.some((v) => v.value === selected) ? selected : '';
+    select.hidden = values.length === 0;
+}
+
+function renderFacets() {
+    const host = $('#xr-facets');
+    host.hidden = false;
+    // Options reflect the current type + search + client cut, ignoring
+    // the value selects themselves (standard faceting, kept simple).
+    const base = applyFilters(state.items, { ...state.filters, platform: '', domain: '', caseName: '' });
+    fillFacetSelect($('#xr-facet-platform'), facetValues(base, 'platform'), state.filters.platform, 'All platforms');
+    fillFacetSelect($('#xr-facet-domain'), facetValues(base, 'domain'), state.filters.domain, 'All sources');
+    fillFacetSelect($('#xr-facet-case'), facetValues(base, 'cases'), state.filters.caseName, 'All cases');
+    $('#xr-facet-client').value = state.filters.client;
+    // Sync any select whose remembered value vanished from the options.
+    state.filters.platform = $('#xr-facet-platform').value;
+    state.filters.domain = $('#xr-facet-domain').value;
+    state.filters.caseName = $('#xr-facet-case').value;
+}
+
+function buildRow(item) {
+    const row = el('li', 'xr-row');
+    const head = el('div', 'xr-row__head');
+    head.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
+    head.appendChild(el('span', 'xr-row__title', truncate(item.title, 160)));
+
+    const badges = el('span', 'xr-row__badges');
+    const relayBadge = el('span', 'xr-badge', `${item.relays.length} relay${item.relays.length === 1 ? '' : 's'}`);
+    relayBadge.title = item.relays.join('\n');
+    badges.appendChild(relayBadge);
+    if (isOtherClient(item)) {
+        badges.appendChild(el('span', 'xr-badge xr-badge--warn', `via ${truncate(item.client, 24)}`));
+    }
+    for (const caseName of item.cases) {
+        badges.appendChild(el('span', 'xr-badge xr-badge--case', truncate(caseName, 32)));
+    }
+    head.appendChild(badges);
+
+    if (item.created_at) {
+        head.appendChild(el('span', 'xr-row__date', new Date(item.created_at * 1000).toLocaleString()));
+    }
+    row.appendChild(head);
+    if (item.sub) row.appendChild(el('div', 'xr-row__sub', truncate(item.sub, 240)));
+
+    const details = el('details');
+    details.appendChild(el('summary', null, 'Raw event'));
+    const pre = el('pre');
+    // Serialize lazily — hundreds of large 30023s stringified up front
+    // would make first paint pay for JSON nobody opened.
+    details.addEventListener('toggle', () => {
+        if (details.open && !pre.textContent) {
+            pre.textContent = JSON.stringify(item.event, null, 2);
+        }
+    });
+    details.appendChild(pre);
+    row.appendChild(details);
+    return row;
+}
+
+function renderRows(visible) {
+    const list = $('#xr-list');
+    const empty = $('#xr-empty');
+    empty.hidden = true;
+    list.hidden = false;
+    clear(list);
+
+    if (visible.length === 0) {
+        if (state.items.length === 0) {
+            renderEmpty('Nothing found on the relays', [
+                'The configured relays returned no events for the resolved identities. '
+                + 'If you publish from another device, add that identity above; otherwise publish a capture and refresh.'
+            ]);
+        } else {
+            renderEmpty('No matches', ['Nothing matches the current search and filters.']);
+        }
+        return;
+    }
+
+    if (state.groupByDomain) {
+        const groups = new Map(); // domain → items (insertion order = newest first)
+        for (const item of visible) {
+            const key = item.domain || '(no source URL)';
+            if (!groups.has(key)) groups.set(key, []);
+            groups.get(key).push(item);
+        }
+        for (const [domain, items] of groups) {
+            const header = el('li', 'xr-portal__group-head', `${domain} `);
+            header.appendChild(el('span', 'xr-tab__count', String(items.length)));
+            list.appendChild(header);
+            for (const item of items) list.appendChild(buildRow(item));
+        }
+    } else {
+        for (const item of visible) list.appendChild(buildRow(item));
+    }
+}
+
+function renderLibrary() {
+    renderTabs();
+    renderFacets();
+    renderRows(applyFilters(state.items, state.filters));
 }
 
 // ------------------------------------------------------------------
@@ -316,7 +282,13 @@ async function boot() {
 
         if (state.identities.length === 0 && state.entities.length === 0) {
             setStatus('');
-            renderEmpty();
+            const reason = state.signer && state.signer.reason
+                ? `Signing (${state.signer.method}): ${state.signer.reason}`
+                : 'No signing identity, sync key, publish history, or manual identity found.';
+            renderEmpty('No identity resolved', [
+                reason,
+                'Paste your npub above, configure signing in Settings, or publish a capture once — then refresh.'
+            ]);
             return;
         }
 
@@ -331,10 +303,17 @@ async function boot() {
         state.relayErrors = relayErrors;
         state.truncated = truncated;
 
-        renderRows();
+        // Latest version per replaceable address, then the item model.
+        const liveEvents = dedupeReplaceable(records.map((r) => r.event));
+        const liveIds = new Set(liveEvents.map((e) => e.id));
+        const entityIndex = {};
+        for (const e of state.entities) entityIndex[e.pubkey] = e;
+        state.items = buildItems(records.filter((r) => liveIds.has(r.event.id)), { entityIndex });
+
+        renderLibrary();
 
         const failed = Object.keys(relayErrors);
-        const parts = [`${records.length} event(s) from ${state.relays.length - failed.length}/${state.relays.length} relay(s)`];
+        const parts = [`${state.items.length} item(s) from ${state.relays.length - failed.length}/${state.relays.length} relay(s)`];
         if (failed.length) parts.push(`failed: ${failed.join(', ')}`);
         if (truncated) parts.push('some relays hit the page ceiling — older events not shown');
         setStatus(parts.join(' — '), failed.length > 0);
@@ -349,6 +328,7 @@ async function boot() {
 
 function wireChrome() {
     $('#xr-refresh').addEventListener('click', () => { boot(); });
+
     $('#xr-identity-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const input = $('#xr-identity-input');
@@ -359,6 +339,33 @@ function wireChrome() {
         }
         input.value = '';
         await boot();
+    });
+
+    let searchTimer = null;
+    $('#xr-search').addEventListener('input', (e) => {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(() => {
+            state.filters.query = e.target.value;
+            renderLibrary();
+        }, 150);
+    });
+
+    const facetWiring = [
+        ['#xr-facet-platform', 'platform'],
+        ['#xr-facet-domain', 'domain'],
+        ['#xr-facet-case', 'caseName'],
+        ['#xr-facet-client', 'client']
+    ];
+    for (const [sel, field] of facetWiring) {
+        $(sel).addEventListener('change', (e) => {
+            state.filters[field] = e.target.value || (field === 'client' ? 'all' : '');
+            renderLibrary();
+        });
+    }
+
+    $('#xr-group-domain').addEventListener('change', (e) => {
+        state.groupByDomain = e.target.checked;
+        renderLibrary();
     });
 }
 

--- a/src/portal/library.js
+++ b/src/portal/library.js
@@ -1,0 +1,325 @@
+// Portal library model (Phase 12.2, docs/PORTAL_DESIGN.md).
+//
+// Pure functions from fetched relay records to the browsable item
+// model the Library view renders: per-type parsing (on the Phase 12.1
+// parsers), facet extraction (platform / source domain / case /
+// client), and cross-cutting search over a per-item haystack. No DOM,
+// no chrome.* — index.js owns the view, this module owns the shape.
+//
+// "Case" is local knowledge: a claim/assessment/article belongs to a
+// case when one of its `p` tags is the pubkey of a local entity of
+// type 'case' (a case IS an entity — Phase 11). Callers pass the
+// entity index from identity resolution; on a machine that doesn't
+// hold the case entity, the facet is simply absent — by design, the
+// portal never invents structure the local registry can't confirm.
+
+import { parseClaimEvent } from '../shared/claim-model.js';
+import { parseAssessmentEvent } from '../shared/assessment-model.js';
+import { parseRelationshipEvent } from '../shared/evidence-linker.js';
+import { EventBuilder } from '../shared/event-builder.js';
+
+// Tags written by this extension (current + userscript-era value).
+export const OUR_CLIENT_TAGS = new Set(['xray', 'nostr-article-capture']);
+
+// Tab order for the Library. 'other' catches 1985 label mirrors,
+// 10002 relay lists, 30078 sync blobs, 32125 entity↔article links,
+// and the dormant metadata kinds — listed, lightly summarized,
+// never dropped.
+export const TYPE_DEFS = [
+    { key: 'article',    label: 'Articles' },
+    { key: 'claim',      label: 'Claims' },
+    { key: 'comment',    label: 'Comments' },
+    { key: 'assessment', label: 'Assessments' },
+    { key: 'link',       label: 'Links' },
+    { key: 'entity',     label: 'Entities' },
+    { key: 'case',       label: 'Cases' },
+    { key: 'account',    label: 'Accounts' },
+    { key: 'other',      label: 'Other' }
+];
+
+const KIND_LABELS = {
+    30023: 'Article',
+    30040: 'Claim',
+    30041: 'Comment',
+    30054: 'Assessment',
+    30055: 'Link',
+    1985:  'Label',
+    0:     'Profile',
+    32125: 'Entity link',
+    32126: 'Account',
+    10002: 'Relay list',
+    30078: 'Entity sync',
+    30050: 'Annotation',
+    30051: 'Fact-check',
+    30052: 'Rating',
+    30053: 'Topic trust',
+    9803:  'Vote'
+};
+
+export function kindLabel(kind) {
+    return KIND_LABELS[kind] || `kind ${kind}`;
+}
+
+function firstTag(event, name) {
+    const t = (event.tags || []).find((x) => x[0] === name);
+    return t ? t[1] : '';
+}
+
+function tagValues(event, name) {
+    return (event.tags || []).filter((x) => x[0] === name).map((x) => x[1]);
+}
+
+function domainOf(url) {
+    try { return new URL(url).hostname; } catch (_) { return ''; }
+}
+
+/**
+ * Build one library item from one fetched record.
+ *
+ * @param {{event: object, relays: string[]}} record
+ * @param {Object<string, {entityId: string, name: string, type: string}>} entityIndex
+ *        local entity registry keyed by entity PUBKEY
+ * @returns {object} item
+ */
+function buildItem(record, entityIndex) {
+    const event = record.event;
+    const url = firstTag(event, 'r');
+    const pTags = tagValues(event, 'p');
+
+    let typeKey = 'other';
+    let title = '';
+    let sub = '';
+    const haystack = [];
+
+    switch (event.kind) {
+        case 30023: {
+            typeKey = 'article';
+            title = firstTag(event, 'title') || '(untitled capture)';
+            sub = domainOf(url) || url;
+            haystack.push(title, sub, url, ...tagValues(event, 't'), firstTag(event, 'author'));
+            break;
+        }
+        case 30040: {
+            typeKey = 'claim';
+            const c = parseClaimEvent(event);
+            const entityNames = (event.tags || [])
+                .filter((x) => x[0] === 'entity' && x[2] === 'about')
+                .map((x) => x[1]);
+            title = c.text || '(empty claim)';
+            const bits = [];
+            if (c.source) bits.push(`source: ${c.source}`);
+            if (entityNames.length) bits.push(`about ${entityNames.join(', ')}`);
+            if (c.isKey) bits.push('key claim');
+            sub = bits.join(' · ');
+            haystack.push(c.text, c.source, ...entityNames, c.title);
+            break;
+        }
+        case 30041: {
+            const c = EventBuilder.parseCommentEvent(event);
+            if (c) {
+                typeKey = 'comment';
+                title = c.text;
+                sub = [c.author, c.platform, c.authorHandle ? `@${c.authorHandle}` : '']
+                    .filter(Boolean).join(' · ');
+                haystack.push(c.text, c.author, c.authorHandle, c.platform, c.title);
+            }
+            break;
+        }
+        case 30054: {
+            const a = parseAssessmentEvent(event);
+            if (a) {
+                typeKey = 'assessment';
+                const bits = [];
+                if (a.stance !== null) bits.push(`stance ${a.stance > 0 ? '+' : ''}${a.stance}`);
+                if (a.labels.length) bits.push(a.labels.map((l) => l.label).join(', '));
+                title = bits.join(' · ') || '(judgment)';
+                sub = a.rationale;
+                haystack.push(a.rationale, ...a.labels.map((l) => l.label), a.claimCoord);
+            }
+            break;
+        }
+        case 30055: {
+            const r = parseRelationshipEvent(event);
+            if (r) {
+                typeKey = 'link';
+                title = r.relationship || '(link)';
+                sub = r.note || r.urls.join('  ');
+                haystack.push(r.relationship, r.note, ...r.urls);
+            }
+            break;
+        }
+        case 0: {
+            let profile = {};
+            try { profile = JSON.parse(event.content || '{}'); } catch (_) { /* malformed */ }
+            const known = entityIndex[event.pubkey];
+            typeKey = known && known.type === 'case' ? 'case' : 'entity';
+            title = profile.name || (known && known.name) || '(profile)';
+            sub = profile.about || '';
+            haystack.push(title, sub, profile.nip05, known && known.type);
+            break;
+        }
+        case 32126: {
+            const acct = EventBuilder.reconstructPlatformAccount(event);
+            if (acct) {
+                typeKey = 'account';
+                title = `${acct.platform}: ${acct.handle || acct.displayName || acct.stableId}`;
+                sub = [acct.displayName, acct.linkedEntityId ? `linked to ${acct.linkedEntityId}` : '']
+                    .filter(Boolean).join(' · ');
+                haystack.push(acct.platform, acct.handle, acct.displayName, acct.stableId);
+            }
+            break;
+        }
+        case 1985: {
+            const labels = (event.tags || []).filter((t) => t[0] === 'l').map((t) => t[1]);
+            title = `Labels: ${labels.join(', ') || '(none)'}`;
+            sub = url;
+            haystack.push(...labels);
+            break;
+        }
+        case 10002: {
+            const relays = tagValues(event, 'r');
+            title = `${relays.length} relay(s) declared`;
+            sub = relays.join('  ');
+            haystack.push(...relays);
+            break;
+        }
+        case 30078: {
+            title = firstTag(event, 'd') || '(entity sync)';
+            sub = 'encrypted — listed, not decrypted';
+            haystack.push(title);
+            break;
+        }
+        case 32125: {
+            title = `${firstTag(event, 'entity-name') || '(entity)'} — ${firstTag(event, 'relationship') || 'related'}`;
+            sub = url;
+            haystack.push(firstTag(event, 'entity-name'), firstTag(event, 'relationship'));
+            break;
+        }
+        default: {
+            title = firstTag(event, 'd') || event.id || '(event)';
+            sub = url;
+            break;
+        }
+    }
+
+    // Unparsable events of a known kind degrade to 'other' with a
+    // generic summary rather than disappearing.
+    if (!title) {
+        title = firstTag(event, 'd') || event.id || '(event)';
+        sub = sub || url;
+    }
+
+    // Case membership: any p-tag that is a local case-entity pubkey.
+    const cases = [];
+    for (const pk of pTags) {
+        const known = entityIndex[pk];
+        if (known && known.type === 'case' && !cases.includes(known.name)) cases.push(known.name);
+    }
+    // A case's own profile belongs to its case facet too.
+    if (typeKey === 'case') {
+        const self = entityIndex[event.pubkey];
+        if (self && !cases.includes(self.name)) cases.push(self.name);
+    }
+
+    const domain = domainOf(url);
+    // Accounts carry their platform under 'account-platform' (32126);
+    // everything else that has one uses the plain 'platform' tag.
+    const platform = event.kind === 32126
+        ? firstTag(event, 'account-platform')
+        : firstTag(event, 'platform');
+    const client = firstTag(event, 'client');
+    haystack.push(domain, platform, kindLabel(event.kind));
+
+    return {
+        id: event.id,
+        event,
+        relays: record.relays || [],
+        kind: event.kind,
+        typeKey,
+        title,
+        sub,
+        url,
+        domain,
+        platform,
+        client,
+        cases,
+        created_at: event.created_at || 0,
+        searchText: haystack.filter(Boolean).join(' ').toLowerCase()
+    };
+}
+
+/**
+ * Records → items, newest first.
+ *
+ * @param {Array<{event: object, relays: string[]}>} records
+ * @param {{entityIndex?: object}} [opts]
+ */
+export function buildItems(records, { entityIndex = {} } = {}) {
+    const list = Array.isArray(records) ? records : [];
+    return list
+        .filter((r) => r && r.event)
+        .map((r) => buildItem(r, entityIndex))
+        .sort((a, b) => b.created_at - a.created_at);
+}
+
+/** True when the event came from another NOSTR client (badge-worthy). */
+export function isOtherClient(item) {
+    return !!item.client && !OUR_CLIENT_TAGS.has(item.client);
+}
+
+export const EMPTY_FILTERS = Object.freeze({
+    type: 'all',
+    platform: '',
+    domain: '',
+    caseName: '',
+    client: 'all',   // 'all' | 'ours' | 'other'
+    query: ''
+});
+
+/**
+ * Apply the Library filters. Search is token-AND over the haystack:
+ * every whitespace-separated token must appear as a substring.
+ */
+export function applyFilters(items, filters) {
+    const f = { ...EMPTY_FILTERS, ...(filters || {}) };
+    const tokens = f.query.toLowerCase().split(/\s+/).filter(Boolean);
+    return (Array.isArray(items) ? items : []).filter((item) => {
+        if (f.type !== 'all' && item.typeKey !== f.type) return false;
+        if (f.platform && item.platform !== f.platform) return false;
+        if (f.domain && item.domain !== f.domain) return false;
+        if (f.caseName && !item.cases.includes(f.caseName)) return false;
+        if (f.client === 'ours' && isOtherClient(item)) return false;
+        if (f.client === 'other' && !isOtherClient(item)) return false;
+        for (const token of tokens) {
+            if (!item.searchText.includes(token)) return false;
+        }
+        return true;
+    });
+}
+
+/** Per-type counts (for the tab badges), over already-filtered items. */
+export function typeCounts(items) {
+    const counts = { all: 0 };
+    for (const def of TYPE_DEFS) counts[def.key] = 0;
+    for (const item of (Array.isArray(items) ? items : [])) {
+        counts.all++;
+        if (counts[item.typeKey] !== undefined) counts[item.typeKey]++;
+    }
+    return counts;
+}
+
+/**
+ * Distinct values of a facet field with counts, most frequent first.
+ * `field` is 'platform' | 'domain' | 'cases' (array-valued).
+ */
+export function facetValues(items, field) {
+    const counts = new Map();
+    for (const item of (Array.isArray(items) ? items : [])) {
+        const raw = item[field];
+        const values = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+        for (const v of values) counts.set(v, (counts.get(v) || 0) + 1);
+    }
+    return [...counts.entries()]
+        .map(([value, count]) => ({ value, count }))
+        .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+}

--- a/tests/portal-library.test.mjs
+++ b/tests/portal-library.test.mjs
@@ -1,0 +1,186 @@
+// portal/library.js tests — Phase 12.2 (docs/PORTAL_DESIGN.md).
+//
+// The Library item model is pure, so these tests drive it with
+// hand-built events per kind: typeKey routing (including case-vs-entity
+// via the local entity index), facet extraction, token-AND search, and
+// the filter semantics the view leans on.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Parsers imported by library.js transitively touch Storage, which
+// probes chrome.storage.local at module load.
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const {
+    buildItems, applyFilters, typeCounts, facetValues, isOtherClient,
+    kindLabel, TYPE_DEFS, EMPTY_FILTERS, OUR_CLIENT_TAGS
+} = await import('../src/portal/library.js');
+
+const USER_PK = 'a'.repeat(64);
+const CASE_PK = 'b'.repeat(64);
+const PERSON_PK = 'c'.repeat(64);
+
+const ENTITY_INDEX = {
+    [CASE_PK]:   { entityId: 'entity_case000000000', name: 'Dehlin excommunication', type: 'case' },
+    [PERSON_PK]: { entityId: 'entity_person0000000', name: 'John Dehlin', type: 'person' }
+};
+
+let nextId = 0;
+function rec(kind, tags, content = '', createdAt = 1000) {
+    return {
+        event: { id: `ev${nextId++}`, kind, pubkey: USER_PK, created_at: createdAt, tags, content },
+        relays: ['wss://relay-a.example']
+    };
+}
+
+function corpus() {
+    nextId = 0;
+    return [
+        rec(30023, [
+            ['d', 'abc'], ['title', 'The Big Story'], ['r', 'https://example.substack.com/p/big'],
+            ['platform', 'substack'], ['t', 'history'], ['client', 'xray'], ['p', CASE_PK, '', 'about']
+        ], '# md', 500),
+        rec(30040, [
+            ['d', 'claim_1'], ['r', 'https://youtube.com/watch?v=x'], ['title', 'Video'],
+            ['entity', 'John Dehlin', 'about'], ['p', PERSON_PK, '', 'about'], ['p', CASE_PK, '', 'about'],
+            ['source', 'LDS Newsroom'], ['key', 'true'], ['client', 'xray']
+        ], 'The church said X about him.', 900),
+        rec(30041, [
+            ['d', 'cmt:youtube:1'], ['r', 'https://youtube.com/watch?v=x'], ['title', 'Video'],
+            ['comment-text', 'this aged badly'], ['comment-author', 'Watcher'], ['platform', 'youtube'],
+            ['client', 'xray']
+        ], 'this aged badly', 800),
+        rec(30054, [
+            ['d', 'assess:1'], ['a', `30040:${USER_PK}:claim_1`], ['r', 'https://youtube.com/watch?v=x'],
+            ['stance', '-2'], ['L', 'xray/assessment'], ['l', 'misleading', 'xray/assessment'],
+            ['p', CASE_PK, '', 'about'], ['client', 'xray']
+        ], 'Contradicts the 2015 statement.', 700),
+        rec(30055, [
+            ['d', 'rel:1'], ['a', `30040:${USER_PK}:claim_1`, '', 'source'],
+            ['a', `30040:${USER_PK}:claim_2`, '', 'target'], ['relationship', 'contradicts'],
+            ['r', 'https://youtube.com/watch?v=x'], ['client', 'xray']
+        ], 'They cannot both be true.', 600),
+        rec(0, [], JSON.stringify({ name: 'Dehlin excommunication', about: 'Case profile' }), 400),
+        rec(32126, [
+            ['d', 'youtube:UC123'], ['p', 'd'.repeat(64), '', 'account'],
+            ['account-platform', 'youtube'], ['account-id', 'UC123'],
+            ['account-username', 'mormonstories'], ['client', 'xray']
+        ], '', 300),
+        rec(10002, [['r', 'wss://relay.damus.io'], ['r', 'wss://nos.lol']], '', 200),
+        rec(30023, [
+            ['d', 'hab'], ['title', 'Posted from Habla'], ['r', 'https://habla.news/a'],
+            ['client', 'habla.news']
+        ], '', 100)
+    ];
+}
+
+// The kind-0 case profile is signed by the CASE entity's key.
+function corpusWithCaseProfile() {
+    const records = corpus();
+    records[5].event.pubkey = CASE_PK;
+    return records;
+}
+
+test('buildItems routes every corpus kind to its type, newest first', () => {
+    const items = buildItems(corpusWithCaseProfile(), { entityIndex: ENTITY_INDEX });
+    assert.deepEqual(items.map((i) => i.typeKey),
+        ['claim', 'comment', 'assessment', 'link', 'article', 'case', 'account', 'other', 'article']);
+    assert.deepEqual(items.map((i) => i.created_at),
+        [900, 800, 700, 600, 500, 400, 300, 200, 100]);
+});
+
+test('a kind-0 profile is a case only when the local registry says so', () => {
+    const asCase = buildItems(corpusWithCaseProfile(), { entityIndex: ENTITY_INDEX });
+    assert.equal(asCase.find((i) => i.kind === 0).typeKey, 'case');
+    // Same corpus, no local registry → plain entity profile.
+    const asEntity = buildItems(corpusWithCaseProfile(), { entityIndex: {} });
+    assert.equal(asEntity.find((i) => i.kind === 0).typeKey, 'entity');
+});
+
+test('case facet derives from p-tags ∩ local case entities', () => {
+    const items = buildItems(corpusWithCaseProfile(), { entityIndex: ENTITY_INDEX });
+    const inCase = items.filter((i) => i.cases.includes('Dehlin excommunication'));
+    assert.deepEqual(inCase.map((i) => i.typeKey).sort(),
+        ['article', 'assessment', 'case', 'claim']);
+    // The person p-tag does NOT create a case facet.
+    const claim = items.find((i) => i.typeKey === 'claim');
+    assert.deepEqual(claim.cases, ['Dehlin excommunication']);
+});
+
+test('claim items carry entity names, source, and key-claim in the haystack', () => {
+    const items = buildItems(corpus(), { entityIndex: ENTITY_INDEX });
+    const claim = items.find((i) => i.typeKey === 'claim');
+    assert.match(claim.sub, /LDS Newsroom/);
+    assert.match(claim.sub, /John Dehlin/);
+    assert.match(claim.sub, /key claim/);
+    assert.ok(claim.searchText.includes('john dehlin'));
+});
+
+test('search is token-AND over the haystack', () => {
+    const items = buildItems(corpus(), { entityIndex: ENTITY_INDEX });
+    // 'dehlin' hits the claim (entity name) AND the profile (JSON name).
+    assert.equal(applyFilters(items, { query: 'dehlin' }).length, 2);
+    assert.equal(applyFilters(items, { query: 'dehlin church' }).length, 1);
+    assert.equal(applyFilters(items, { query: 'dehlin zebra' }).length, 0);
+    assert.equal(applyFilters(items, { query: '  ' }).length, items.length);
+});
+
+test('filters: type, platform, domain, case, client', () => {
+    const items = buildItems(corpusWithCaseProfile(), { entityIndex: ENTITY_INDEX });
+    assert.equal(applyFilters(items, { type: 'comment' }).length, 1);
+    assert.equal(applyFilters(items, { platform: 'youtube' }).length, 2); // comment + account
+    assert.equal(applyFilters(items, { domain: 'youtube.com' }).length, 4); // claim + comment + assessment + link
+    assert.equal(applyFilters(items, { caseName: 'Dehlin excommunication' }).length, 4);
+    const other = applyFilters(items, { client: 'other' });
+    assert.deepEqual(other.map((i) => i.title), ['Posted from Habla']);
+    // 'ours' keeps untagged events (no client tag ≠ foreign client).
+    assert.equal(applyFilters(items, { client: 'ours' }).length, items.length - 1);
+});
+
+test('typeCounts and facetValues drive the tab badges and selects', () => {
+    const items = buildItems(corpusWithCaseProfile(), { entityIndex: ENTITY_INDEX });
+    const counts = typeCounts(items);
+    assert.equal(counts.all, items.length);
+    assert.equal(counts.article, 2);
+    assert.equal(counts.case, 1);
+    assert.equal(counts.other, 1); // the 10002 relay list
+
+    const domains = facetValues(items, 'domain');
+    assert.equal(domains[0].value, 'youtube.com');
+    assert.ok(domains[0].count >= 3);
+    const cases = facetValues(items, 'cases');
+    assert.deepEqual(cases, [{ value: 'Dehlin excommunication', count: 4 }]);
+});
+
+test('isOtherClient: badge only when a client tag exists and is not ours', () => {
+    const items = buildItems(corpus(), { entityIndex: {} });
+    const habla = items.find((i) => i.client === 'habla.news');
+    const relayList = items.find((i) => i.kind === 10002); // no client tag
+    assert.equal(isOtherClient(habla), true);
+    assert.equal(isOtherClient(relayList), false);
+    assert.ok(OUR_CLIENT_TAGS.has('xray') && OUR_CLIENT_TAGS.has('nostr-article-capture'));
+});
+
+test('EMPTY_FILTERS and TYPE_DEFS are pinned', () => {
+    assert.deepEqual(EMPTY_FILTERS,
+        { type: 'all', platform: '', domain: '', caseName: '', client: 'all', query: '' });
+    assert.deepEqual(TYPE_DEFS.map((d) => d.key),
+        ['article', 'claim', 'comment', 'assessment', 'link', 'entity', 'case', 'account', 'other']);
+    assert.equal(kindLabel(30040), 'Claim');
+    assert.equal(kindLabel(12345), 'kind 12345');
+});
+
+test('malformed events degrade to other-typed generic items, never vanish', () => {
+    const broken = [
+        rec(30041, [['d', 'x']], ''),                       // textless comment
+        rec(30054, [['d', 'assess:x']], 'no a tag'),        // assessment without coordinate
+        rec(0, [], 'not json at all')
+    ];
+    const items = buildItems(broken, { entityIndex: {} });
+    assert.equal(items.length, 3);
+    for (const item of items) assert.ok(item.title.length > 0);
+    assert.deepEqual(items.map((i) => i.typeKey).sort(), ['entity', 'other', 'other']);
+});


### PR DESCRIPTION
Second Phase 12 slice (design: `docs/PORTAL_DESIGN.md` #48; foundation: #49). The flat list becomes the Library.

- **Pure item model** (`src/portal/library.js`): per-type parsing on the 12.1 parsers, facets (platform / domain / case / client), search haystacks, filters/counts. Case membership = `p` tags ∩ local case entities (a case IS an entity — Phase 11); absent registry → absent facet, never invented.
- **View**: type tabs with live counts, facet selects, group-by-source toggle, debounced token-AND search. All DOM still `textContent`-built.
- **Model fix found by tests**: 32126 accounts facet their platform from `account-platform`, not the generic `platform` tag.

Gates: build ✅ · 633/633 tests ✅ (10 new) · web-ext lint 0 errors ✅

Smoke: open portal → tabs show per-type counts → type a name in search and watch claims/comments/entities filter → pick a domain facet → toggle "Group by source".

🤖 Generated with [Claude Code](https://claude.com/claude-code)