### PR TITLE
feat(portal): IndexedDB cache + incremental refresh (Phase 12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Portal cache — instant open, incremental refresh** (Phase 12.3).
+  The portal now renders from a local IndexedDB cache (`xray-portal`,
+  a separate database from the archive — derived data, droppable and
+  rebuildable) and refreshes in the background: incremental `since`
+  queries with a one-hour clock-skew overlap, write-time supersession
+  so the store only ever holds the newest version per replaceable
+  address, relay-provenance sets merged across syncs, a "+N new"
+  status diff, and a **Full resync** button that drops the cache and
+  re-fetches everything. The sync cursor only advances when at least
+  one relay answered, so a dead-network refresh can't eat the window.
+
 - **Portal Library — type tabs, facets, search** (Phase 12.2). The
   portal's flat list grows into a browsable Library: type tabs with
   live counts (Articles / Claims / Comments / Assessments / Links /

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -902,8 +902,8 @@ Slices (one PR each):
   list. — #49
 - ✅ **12.2** Library — type tabs, per-type renderers, facets,
   cross-cutting search. — #50
-- ⬜ **12.3** Cache — IndexedDB `xray-portal`, cache-first render,
-  incremental refresh, relay-provenance persistence.
+- ✅ **12.3** Cache — IndexedDB `xray-portal`, cache-first render,
+  incremental refresh, relay-provenance persistence. — #51
 - ⬜ **12.4** Timeline — density buckets + brush filtering.
 - ⬜ **12.5** Entity & case views — radial spokes graph + case
   dashboard.

--- a/src/portal/corpus.js
+++ b/src/portal/corpus.js
@@ -115,6 +115,8 @@ function chunk(list, size) {
  * @param {string[]} opts.pubkeys        the user's resolved author pubkeys
  * @param {string[]} opts.entityPubkeys  entity pubkeys (kind-0 authors)
  * @param {string[]} opts.relays         relay URLs (callers resolve config/fallback)
+ * @param {number}   [opts.since]        epoch seconds — incremental refresh window
+ *                                       (callers subtract their clock-skew overlap)
  * @param {function} [opts.onProgress]   ({fetched}) per page, for the status line
  * @returns {Promise<{
  *   records: Array<{event: object, relays: string[]}>,
@@ -122,7 +124,7 @@ function chunk(list, size) {
  *   truncated: boolean
  * }>}
  */
-export async function fetchCorpus({ pubkeys = [], entityPubkeys = [], relays = [], onProgress } = {}) {
+export async function fetchCorpus({ pubkeys = [], entityPubkeys = [], relays = [], since, onProgress } = {}) {
     const byId = new Map(); // event id → { event, relays:Set }
     const relayErrors = {};
     let truncated = false;
@@ -136,14 +138,17 @@ export async function fetchCorpus({ pubkeys = [], entityPubkeys = [], relays = [
         if (typeof onProgress === 'function') onProgress({ fetched: byId.size });
     };
 
+    const sinceFilter = Number.isFinite(since) && since > 0 ? { since } : {};
+
     await Promise.all(relays.map(async (url) => {
         if (pubkeys.length > 0) {
-            const r = await backfillRelay(url, { authors: pubkeys, kinds: CONTENT_KINDS }, collect, tick);
+            const r = await backfillRelay(url,
+                { authors: pubkeys, kinds: CONTENT_KINDS, ...sinceFilter }, collect, tick);
             if (!r.ok) relayErrors[url] = r.error;
             if (r.truncated) truncated = true;
         }
         for (const authors of chunk(entityPubkeys, ENTITY_AUTHOR_CHUNK)) {
-            const r = await backfillRelay(url, { authors, kinds: [0] }, collect, tick);
+            const r = await backfillRelay(url, { authors, kinds: [0], ...sinceFilter }, collect, tick);
             if (!r.ok) relayErrors[url] = relayErrors[url] || r.error;
             if (r.truncated) truncated = true;
         }

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -12,7 +12,9 @@
       <span class="xr-portal__brand">🩻 X-Ray — My Archive</span>
     </div>
     <div class="xr-portal__chrome-right">
-      <button class="xr-portal__btn" id="xr-refresh" title="Query the relays again">↻ Refresh</button>
+      <button class="xr-portal__btn" id="xr-refresh" title="Fetch what's new since the last sync">↻ Refresh</button>
+      <button class="xr-portal__btn xr-portal__btn--ghost" id="xr-resync"
+              title="Drop the local cache and re-fetch everything from the relays">Full resync</button>
     </div>
   </header>
 

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -13,9 +13,9 @@
 
 import { Storage } from '../shared/storage.js';
 import { Utils } from '../shared/utils.js';
-import { dedupeReplaceable } from '../shared/nostr-events.js';
 import { resolveIdentities, addManualIdentity, removeManualIdentity } from './identity.js';
 import { fetchCorpus, FALLBACK_RELAYS } from './corpus.js';
+import { saveRecords, loadRecords, getMeta, setMeta, clearAll } from './portal-cache.js';
 import {
     buildItems, applyFilters, typeCounts, facetValues, isOtherClient,
     kindLabel, TYPE_DEFS, EMPTY_FILTERS
@@ -259,13 +259,37 @@ function renderLibrary() {
 }
 
 // ------------------------------------------------------------------
-// Boot + refresh
+// Boot + refresh (cache-first since 12.3: render what we have, then
+// refresh incrementally in the background and re-render the union)
 // ------------------------------------------------------------------
 
-async function boot() {
+// Clock-skew overlap for incremental refresh: re-ask for the last hour
+// before the recorded sync point so a relay whose clock trails ours
+// can't hide an event in the seam. Duplicates merge by event id.
+const SYNC_OVERLAP_SECONDS = 3600;
+
+function rebuildItems(records) {
+    state.records = records;
+    const entityIndex = {};
+    for (const e of state.entities) entityIndex[e.pubkey] = e;
+    // The cache stores only the latest version per replaceable address,
+    // so records arrive pre-deduped.
+    state.items = buildItems(records, { entityIndex });
+}
+
+function setBusy(busy) {
+    state.loading = busy;
+    $('#xr-refresh').disabled = busy;
+    $('#xr-resync').disabled = busy;
+}
+
+/**
+ * @param {{full?: boolean}} [opts]  full=true drops the sync cursor
+ *        (the cache itself is cleared by the Resync handler first)
+ */
+async function boot({ full = false } = {}) {
     if (state.loading) return;
-    state.loading = true;
-    $('#xr-refresh').disabled = true;
+    setBusy(true);
     try {
         setStatus('Resolving identity…');
         const { identities, entities, signer } = await resolveIdentities();
@@ -280,40 +304,63 @@ async function boot() {
             : FALLBACK_RELAYS;
         renderFooter();
 
+        // Cache first: anything we already hold renders immediately.
+        const cached = await loadRecords();
+        if (cached.length > 0) {
+            rebuildItems(cached);
+            renderLibrary();
+            setStatus(`${state.items.length} item(s) from cache — refreshing…`);
+        }
+
         if (state.identities.length === 0 && state.entities.length === 0) {
-            setStatus('');
-            const reason = state.signer && state.signer.reason
-                ? `Signing (${state.signer.method}): ${state.signer.reason}`
-                : 'No signing identity, sync key, publish history, or manual identity found.';
-            renderEmpty('No identity resolved', [
-                reason,
-                'Paste your npub above, configure signing in Settings, or publish a capture once — then refresh.'
-            ]);
+            if (cached.length === 0) {
+                setStatus('');
+                const reason = state.signer && state.signer.reason
+                    ? `Signing (${state.signer.method}): ${state.signer.reason}`
+                    : 'No signing identity, sync key, publish history, or manual identity found.';
+                renderEmpty('No identity resolved', [
+                    reason,
+                    'Paste your npub above, configure signing in Settings, or publish a capture once — then refresh.'
+                ]);
+            } else {
+                setStatus(`${state.items.length} cached item(s) — no identity resolved, refresh skipped`, true);
+            }
             return;
         }
 
-        setStatus(`Querying ${state.relays.length} relay(s)…`);
+        // Incremental unless asked for a full pass or never synced.
+        const sync = full ? null : await getMeta('sync');
+        const since = sync && Number.isFinite(sync.lastSyncAt)
+            ? sync.lastSyncAt - SYNC_OVERLAP_SECONDS
+            : undefined;
+        const fetchStartedAt = Math.floor(Date.now() / 1000);
+
+        setStatus(`Querying ${state.relays.length} relay(s)${since ? ' for new events' : ''}…`);
         const { records, relayErrors, truncated } = await fetchCorpus({
             pubkeys: state.identities.map((i) => i.pubkey),
             entityPubkeys: state.entities.map((e) => e.pubkey),
             relays: state.relays,
+            since,
             onProgress: ({ fetched }) => setStatus(`Querying ${state.relays.length} relay(s)… ${fetched} event(s) so far`)
         });
-        state.records = records;
         state.relayErrors = relayErrors;
         state.truncated = truncated;
 
-        // Latest version per replaceable address, then the item model.
-        const liveEvents = dedupeReplaceable(records.map((r) => r.event));
-        const liveIds = new Set(liveEvents.map((e) => e.id));
-        const entityIndex = {};
-        for (const e of state.entities) entityIndex[e.pubkey] = e;
-        state.items = buildItems(records.filter((r) => liveIds.has(r.event.id)), { entityIndex });
-
+        const stats = await saveRecords(records);
+        rebuildItems(await loadRecords());
         renderLibrary();
 
         const failed = Object.keys(relayErrors);
-        const parts = [`${state.items.length} item(s) from ${state.relays.length - failed.length}/${state.relays.length} relay(s)`];
+        // Only advance the cursor when at least one relay answered in
+        // full — an all-failed refresh must not eat the window.
+        if (failed.length < state.relays.length) {
+            await setMeta('sync', { lastSyncAt: fetchStartedAt });
+        }
+
+        const parts = [`${state.items.length} item(s)`];
+        if (stats.added > 0) parts.push(`+${stats.added} new`);
+        if (stats.superseded > 0) parts.push(`${stats.superseded} replaced by newer versions`);
+        parts.push(`${state.relays.length - failed.length}/${state.relays.length} relay(s)`);
         if (failed.length) parts.push(`failed: ${failed.join(', ')}`);
         if (truncated) parts.push('some relays hit the page ceiling — older events not shown');
         setStatus(parts.join(' — '), failed.length > 0);
@@ -321,13 +368,22 @@ async function boot() {
         Utils.error('Portal boot failed:', err);
         setStatus('Portal failed to load: ' + (err && err.message ? err.message : String(err)), true);
     } finally {
-        state.loading = false;
-        $('#xr-refresh').disabled = false;
+        setBusy(false);
     }
 }
 
 function wireChrome() {
     $('#xr-refresh').addEventListener('click', () => { boot(); });
+
+    $('#xr-resync').addEventListener('click', async () => {
+        if (state.loading) return;
+        try {
+            await clearAll();
+        } catch (err) {
+            Utils.error('Portal resync: cache clear failed', err);
+        }
+        boot({ full: true });
+    });
 
     $('#xr-identity-form').addEventListener('submit', async (e) => {
         e.preventDefault();

--- a/src/portal/portal-cache.js
+++ b/src/portal/portal-cache.js
@@ -1,0 +1,185 @@
+// Portal corpus cache (Phase 12.3, docs/PORTAL_DESIGN.md).
+//
+// IndexedDB `xray-portal` — deliberately a SEPARATE database from
+// `xray-archive`: this cache is derived data, droppable and rebuildable
+// from the relays at any time, while the archive holds precious local
+// captures; coupling their schema versions and eviction stories buys
+// nothing (recorded in JOURNAL 2026-06-10). Same open/upgrade/req
+// idioms as archive-cache.js.
+//
+// One `events` row per LIVE event: raw signed event + the relay set
+// that returned it + bookkeeping. Replaceable/addressable supersession
+// happens at WRITE time keyed on the shared replaceableKey — the store
+// only ever holds the newest version per address, so readers render
+// straight from `loadRecords()` with no further dedupe. Raw events are
+// the stored truth; parsing happens on read (parsers are cheap and
+// cached data stays valid across parser evolution).
+
+import { replaceableKey } from '../shared/nostr-events.js';
+
+const DB_NAME = 'xray-portal';
+const DB_VERSION = 1;
+const EVENTS_STORE = 'events';
+const META_STORE = 'meta';
+
+function idb() {
+    const target = globalThis.indexedDB || (typeof self !== 'undefined' && self.indexedDB);
+    if (!target) throw new Error('portal-cache: no indexedDB in this context');
+    return target;
+}
+
+function req(request) {
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror   = () => reject(request.error);
+    });
+}
+
+function txDone(transaction) {
+    return new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror    = () => reject(transaction.error);
+        transaction.onabort    = () => reject(transaction.error || new Error('transaction aborted'));
+    });
+}
+
+let _dbPromise = null;
+
+export function openPortalDb() {
+    if (_dbPromise) return _dbPromise;
+    _dbPromise = new Promise((resolve, reject) => {
+        let open;
+        try { open = idb().open(DB_NAME, DB_VERSION); }
+        catch (err) { reject(err); return; }
+
+        open.onupgradeneeded = () => {
+            const db = open.result;
+            if (!db.objectStoreNames.contains(EVENTS_STORE)) {
+                const store = db.createObjectStore(EVENTS_STORE, { keyPath: 'id' });
+                store.createIndex('kind',       'kind',       { unique: false });
+                store.createIndex('pubkey',     'pubkey',     { unique: false });
+                store.createIndex('created_at', 'created_at', { unique: false });
+                // addr is null for regular events; IDB indexes skip
+                // rows whose key value is absent, so store '' instead.
+                store.createIndex('addr',       'addr',       { unique: false });
+            }
+            if (!db.objectStoreNames.contains(META_STORE)) {
+                db.createObjectStore(META_STORE, { keyPath: 'key' });
+            }
+        };
+        open.onsuccess = () => resolve(open.result);
+        open.onerror   = () => reject(open.error);
+    });
+    return _dbPromise;
+}
+
+/** For tests — drop the memoized handle so the next open re-runs. */
+export function _resetForTests() {
+    _dbPromise = null;
+}
+
+function rowFromRecord(record, now) {
+    const event = record.event;
+    const dTag = (((event.tags || []).find((t) => t[0] === 'd')) || [])[1] || '';
+    return {
+        id: event.id,
+        kind: event.kind,
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        dTag,
+        addr: replaceableKey(event) || '',
+        event,
+        relays: [...new Set(record.relays || [])],
+        firstSeenAt: now,
+        lastSeenAt: now
+    };
+}
+
+/**
+ * Upsert fetched records. Per record:
+ *   - same event id already cached → merge the relay sets, bump lastSeenAt
+ *   - replaceable/addressable with a CACHED NEWER version at the same
+ *     address → incoming is stale, skipped
+ *   - replaceable/addressable superseding an older cached version →
+ *     older row(s) deleted, incoming inserted
+ *
+ * @param {Array<{event: object, relays: string[]}>} records
+ * @param {{now?: number}} [opts]  epoch seconds for bookkeeping (tests pass fixed values)
+ * @returns {Promise<{added: number, updated: number, superseded: number, skippedStale: number}>}
+ */
+export async function saveRecords(records, { now = Math.floor(Date.now() / 1000) } = {}) {
+    const db = await openPortalDb();
+    const transaction = db.transaction([EVENTS_STORE], 'readwrite');
+    const store = transaction.objectStore(EVENTS_STORE);
+    const addrIndex = store.index('addr');
+    const stats = { added: 0, updated: 0, superseded: 0, skippedStale: 0 };
+
+    for (const record of (Array.isArray(records) ? records : [])) {
+        if (!record || !record.event || !record.event.id) continue;
+        const event = record.event;
+
+        const existing = await req(store.get(event.id));
+        if (existing) {
+            const merged = new Set([...(existing.relays || []), ...(record.relays || [])]);
+            existing.relays = [...merged];
+            existing.lastSeenAt = now;
+            await req(store.put(existing));
+            stats.updated++;
+            continue;
+        }
+
+        const addr = replaceableKey(event) || '';
+        if (addr) {
+            const siblings = await req(addrIndex.getAll(addr));
+            const newer = siblings.find((row) => (row.created_at || 0) >= (event.created_at || 0));
+            if (newer) { stats.skippedStale++; continue; }
+            for (const row of siblings) {
+                await req(store.delete(row.id));
+                stats.superseded++;
+            }
+        }
+
+        await req(store.put(rowFromRecord(record, now)));
+        stats.added++;
+    }
+
+    await txDone(transaction);
+    return stats;
+}
+
+/**
+ * Everything cached, in the {event, relays} record shape the library
+ * model consumes. Already latest-per-address by construction.
+ */
+export async function loadRecords() {
+    const db = await openPortalDb();
+    const rows = await req(db.transaction([EVENTS_STORE]).objectStore(EVENTS_STORE).getAll());
+    return rows.map((row) => ({ event: row.event, relays: row.relays || [] }));
+}
+
+export async function countEvents() {
+    const db = await openPortalDb();
+    return await req(db.transaction([EVENTS_STORE]).objectStore(EVENTS_STORE).count());
+}
+
+export async function getMeta(key) {
+    const db = await openPortalDb();
+    const row = await req(db.transaction([META_STORE]).objectStore(META_STORE).get(key));
+    return row ? row.value : null;
+}
+
+export async function setMeta(key, value) {
+    const db = await openPortalDb();
+    const transaction = db.transaction([META_STORE], 'readwrite');
+    transaction.objectStore(META_STORE).put({ key, value });
+    await txDone(transaction);
+}
+
+/** Wipe everything — the Resync path. The cache is derived; this is safe. */
+export async function clearAll() {
+    const db = await openPortalDb();
+    const transaction = db.transaction([EVENTS_STORE, META_STORE], 'readwrite');
+    transaction.objectStore(EVENTS_STORE).clear();
+    transaction.objectStore(META_STORE).clear();
+    await txDone(transaction);
+}

--- a/tests/portal-cache.test.mjs
+++ b/tests/portal-cache.test.mjs
@@ -1,0 +1,141 @@
+// portal/portal-cache.js tests — Phase 12.3 (docs/PORTAL_DESIGN.md).
+//
+// fake-indexeddb gives us a real-enough IDB in Node (same harness as
+// archive-cache.test.mjs). The load-bearing behavior is write-time
+// supersession: the store only ever holds the newest version per
+// replaceable address, so readers never re-dedupe.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Install fake-indexeddb BEFORE the cache module is imported so the
+// module's `globalThis.indexedDB` lookup lands on the fake.
+await import('fake-indexeddb/auto');
+
+const {
+    openPortalDb, saveRecords, loadRecords, countEvents,
+    getMeta, setMeta, clearAll
+} = await import('../src/portal/portal-cache.js');
+
+const PK = 'a'.repeat(64);
+const NOW = 1_750_000_000;
+
+function rec(id, kind, createdAt, { d, relays = ['wss://relay-a.example'] } = {}) {
+    return {
+        event: {
+            id, kind, pubkey: PK, created_at: createdAt,
+            tags: d !== undefined ? [['d', d]] : [],
+            content: ''
+        },
+        relays
+    };
+}
+
+// Wipe through the API on the live connection (the archive-cache test
+// pattern) — deleteDatabase would block forever behind the module's
+// open handle.
+async function resetStore() {
+    await clearAll();
+}
+
+test('save + load round-trips events and relay sets', async () => {
+    await resetStore();
+    const stats = await saveRecords([
+        rec('e1', 30040, 100, { d: 'claim_x' }),
+        rec('e2', 1985, 90, { relays: ['wss://relay-b.example'] })
+    ], { now: NOW });
+    assert.deepEqual(stats, { added: 2, updated: 0, superseded: 0, skippedStale: 0 });
+
+    const records = await loadRecords();
+    assert.equal(records.length, 2);
+    const e1 = records.find((r) => r.event.id === 'e1');
+    assert.equal(e1.event.kind, 30040);
+    assert.deepEqual(e1.relays, ['wss://relay-a.example']);
+    assert.equal(await countEvents(), 2);
+});
+
+test('same event id from another relay merges the relay sets', async () => {
+    await resetStore();
+    await saveRecords([rec('e1', 30040, 100, { d: 'claim_x' })], { now: NOW });
+    const stats = await saveRecords(
+        [rec('e1', 30040, 100, { d: 'claim_x', relays: ['wss://relay-b.example'] })],
+        { now: NOW + 10 });
+    assert.equal(stats.updated, 1);
+    const [record] = await loadRecords();
+    assert.deepEqual(record.relays.sort(),
+        ['wss://relay-a.example', 'wss://relay-b.example']);
+    assert.equal(await countEvents(), 1);
+});
+
+test('addressable: newer version supersedes, older incoming is skipped', async () => {
+    await resetStore();
+    await saveRecords([rec('old', 30040, 100, { d: 'claim_x' })], { now: NOW });
+
+    const newerIn = await saveRecords([rec('new', 30040, 200, { d: 'claim_x' })], { now: NOW });
+    assert.equal(newerIn.superseded, 1);
+    assert.equal(newerIn.added, 1);
+    let records = await loadRecords();
+    assert.deepEqual(records.map((r) => r.event.id), ['new']);
+
+    const staleIn = await saveRecords([rec('stale', 30040, 50, { d: 'claim_x' })], { now: NOW });
+    assert.equal(staleIn.skippedStale, 1);
+    records = await loadRecords();
+    assert.deepEqual(records.map((r) => r.event.id), ['new']);
+});
+
+test('replaceable kind 0 collapses per (kind, pubkey) — no d tag involved', async () => {
+    await resetStore();
+    await saveRecords([rec('p1', 0, 100)], { now: NOW });
+    await saveRecords([rec('p2', 0, 200)], { now: NOW });
+    const records = await loadRecords();
+    assert.deepEqual(records.map((r) => r.event.id), ['p2']);
+});
+
+test('regular kinds never supersede each other', async () => {
+    await resetStore();
+    await saveRecords([rec('l1', 1985, 100), rec('l2', 1985, 200)], { now: NOW });
+    assert.equal(await countEvents(), 2);
+});
+
+test('equal created_at at the same address keeps the cached version', async () => {
+    await resetStore();
+    await saveRecords([rec('first', 30040, 100, { d: 'claim_x' })], { now: NOW });
+    const stats = await saveRecords([rec('second', 30040, 100, { d: 'claim_x' })], { now: NOW });
+    assert.equal(stats.skippedStale, 1);
+    const records = await loadRecords();
+    assert.deepEqual(records.map((r) => r.event.id), ['first']);
+});
+
+test('meta: get/set round-trip, missing key is null', async () => {
+    await resetStore();
+    assert.equal(await getMeta('sync'), null);
+    await setMeta('sync', { lastSyncAt: NOW });
+    assert.deepEqual(await getMeta('sync'), { lastSyncAt: NOW });
+    await setMeta('sync', { lastSyncAt: NOW + 5 });
+    assert.deepEqual(await getMeta('sync'), { lastSyncAt: NOW + 5 });
+});
+
+test('clearAll wipes events and meta — the Resync path', async () => {
+    await resetStore();
+    await saveRecords([rec('e1', 30040, 100, { d: 'claim_x' })], { now: NOW });
+    await setMeta('sync', { lastSyncAt: NOW });
+    await clearAll();
+    assert.equal(await countEvents(), 0);
+    assert.equal(await getMeta('sync'), null);
+    assert.deepEqual(await loadRecords(), []);
+});
+
+test('malformed records are ignored, not fatal', async () => {
+    await resetStore();
+    const stats = await saveRecords([null, {}, { event: { kind: 1 } },
+        rec('ok', 30040, 100, { d: 'claim_x' })], { now: NOW });
+    assert.equal(stats.added, 1);
+    assert.equal(await countEvents(), 1);
+});
+
+test('openPortalDb is memoized and reusable across calls', async () => {
+    await resetStore();
+    const a = await openPortalDb();
+    const b = await openPortalDb();
+    assert.equal(a, b);
+});

--- a/tests/portal-corpus.test.mjs
+++ b/tests/portal-corpus.test.mjs
@@ -150,3 +150,16 @@ test('onProgress ticks with a running fetched count', async () => {
     });
     assert.deepEqual(ticks, [1]);
 });
+
+test('since (12.3 incremental refresh) rides into both query classes', async () => {
+    reset(() => []);
+    await fetchCorpus({
+        pubkeys: [PK], entityPubkeys: ['b'.repeat(64)], relays: [RELAY_A], since: 1234
+    });
+    assert.equal(sentMessages.length, 2);
+    for (const m of sentMessages) assert.equal(m.filter.since, 1234);
+    // No since → no since key in the filter at all.
+    reset(() => []);
+    await fetchCorpus({ pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A] });
+    assert.ok(!('since' in sentMessages[0].filter));
+});


### PR DESCRIPTION
Third Phase 12 slice (design: `docs/PORTAL_DESIGN.md` #48; foundation #49; Library #50). Querying the whole corpus on every open is too slow at scale — so: render from cache instantly, refresh in the background, reconcile.

- **`src/portal/portal-cache.js`** — IndexedDB `xray-portal` v1: `events` (keyPath `id`, indexes kind/pubkey/created_at/addr) + `meta` (sync cursor). Separate DB from `xray-archive` by design — derived data with a different lifecycle. Supersession happens at **write time** on the shared `replaceableKey`, so the store only ever holds the newest version per address and readers render straight from `loadRecords()`.
- **Incremental refresh** — `since = lastSyncAt − 3600` (clock-skew overlap; duplicates merge by id), cursor advances only when ≥1 relay answered. Status line reports `+N new`.
- **Full resync** — drops cache + cursor, full windowed backfill.
- Relay-provenance sets merge across syncs (feeds 12.6 reconciliation).

Test-harness gotcha worth knowing: `indexedDB.deleteDatabase` deadlocks behind the module's open connection under fake-indexeddb — tests reset through `clearAll()` on the live handle (the archive-cache pattern).

Gates: build ✅ · 644/644 tests ✅ (11 new) · web-ext lint 0 errors ✅

Smoke: open portal (instant from cache) → publish something → ↻ Refresh shows "+1 new" → Full resync rebuilds identical state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)