### PR TITLE
feat(portal): timeline — density + brush filtering (Phase 12.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Portal timeline — publish-date density + brush filtering**
+  (Phase 12.4). A density strip over the corpus's `created_at` (UTC
+  day buckets, rolling up to Monday-anchored weeks past 180 days, gap
+  days rendered as gaps) sits above the Library; capture sessions show
+  as spikes. Dragging across bars — or clicking one — brushes a time
+  range that filters the list below (after-inclusive /
+  before-exclusive, one filtering path with tabs/facets/search); a
+  chip shows the active range and clears it.
+
 - **Portal cache — instant open, incremental refresh** (Phase 12.3).
   The portal now renders from a local IndexedDB cache (`xray-portal`,
   a separate database from the archive — derived data, droppable and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -904,7 +904,7 @@ Slices (one PR each):
   cross-cutting search. — #50
 - ✅ **12.3** Cache — IndexedDB `xray-portal`, cache-first render,
   incremental refresh, relay-provenance persistence. — #51
-- ⬜ **12.4** Timeline — density buckets + brush filtering.
+- ✅ **12.4** Timeline — density buckets + brush filtering. — #52
 - ⬜ **12.5** Entity & case views — radial spokes graph + case
   dashboard.
 - ⬜ **12.6** Inspector & reconciliation — raw events, per-relay

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -240,6 +240,48 @@ body.xr-portal {
 
 .xr-badge--case { color: var(--xr-accent); border-color: var(--xr-accent); }
 
+/* ---------------- timeline (12.4) ---------------- */
+
+.xr-portal__timeline {
+  padding: 8px 16px 4px;
+  border-bottom: 1px solid var(--xr-border);
+}
+
+.xr-portal__timeline-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.xr-portal__timeline-label {
+  color: var(--xr-text-dim);
+  font-size: 12px;
+}
+
+.xr-portal__timeline-clear {
+  border: 1px solid var(--xr-accent);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--xr-accent);
+  font-size: 12px;
+  padding: 2px 10px;
+  cursor: pointer;
+}
+
+.xr-portal__timeline-svg {
+  display: block;
+  width: 100%;
+  height: 56px;
+  cursor: crosshair;
+}
+
+.xr-tl-bar { fill: var(--xr-primary); opacity: 0.75; }
+.xr-tl-bar:hover { opacity: 1; }
+.xr-tl-bar--active { fill: var(--xr-accent); opacity: 1; }
+.xr-tl-bar--empty { fill: var(--xr-border); opacity: 0.4; }
+
 /* ---------------- status ---------------- */
 
 .xr-portal__status {

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -47,6 +47,10 @@
     </label>
   </div>
 
+  <!-- Publish-date density (Phase 12.4). Drag across bars to brush a
+       range; the Library below filters to it. -->
+  <section class="xr-portal__timeline" id="xr-timeline" hidden></section>
+
   <div class="xr-portal__status" id="xr-status" hidden></div>
 
   <main class="xr-portal__main">

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -20,6 +20,7 @@ import {
     buildItems, applyFilters, typeCounts, facetValues, isOtherClient,
     kindLabel, TYPE_DEFS, EMPTY_FILTERS
 } from './library.js';
+import { buildBuckets, brushRange } from './timeline.js';
 
 const $ = (sel) => document.querySelector(sel);
 
@@ -252,9 +253,113 @@ function renderRows(visible) {
     }
 }
 
+// ------------------------------------------------------------------
+// Timeline (Phase 12.4): publish-date density + brush-to-filter
+// ------------------------------------------------------------------
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const TL_BAR_W = 6;     // viewBox units per bucket (4 bar + 2 gap)
+const TL_HEIGHT = 56;
+
+function svgEl(tag, attrs) {
+    const node = document.createElementNS(SVG_NS, tag);
+    for (const [k, v] of Object.entries(attrs || {})) node.setAttribute(k, String(v));
+    return node;
+}
+
+function fmtDay(ts) {
+    return new Date(ts * 1000).toLocaleDateString();
+}
+
+function renderTimeline() {
+    const host = $('#xr-timeline');
+    clear(host);
+    if (state.items.length === 0) { host.hidden = true; return; }
+    host.hidden = false;
+
+    // Density reflects every filter EXCEPT the brush itself, so the
+    // bars show where the current cut lives in time.
+    const base = applyFilters(state.items, { ...state.filters, after: 0, before: 0 });
+    const { bucket, buckets } = buildBuckets(base);
+    if (buckets.length === 0) { host.hidden = true; return; }
+
+    const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+    const brushed = state.filters.after || state.filters.before;
+
+    const head = el('div', 'xr-portal__timeline-head');
+    head.appendChild(el('span', 'xr-portal__timeline-label',
+        `${fmtDay(buckets[0].start)} – ${fmtDay(buckets[buckets.length - 1].end - 1)} · ${bucket} buckets`));
+    if (brushed) {
+        const chip = el('button', 'xr-portal__timeline-clear',
+            `✕ ${fmtDay(state.filters.after)} – ${fmtDay(state.filters.before - 1)}`);
+        chip.type = 'button';
+        chip.title = 'Clear the time filter';
+        chip.addEventListener('click', () => {
+            state.filters.after = 0;
+            state.filters.before = 0;
+            renderLibrary();
+        });
+        head.appendChild(chip);
+    }
+    host.appendChild(head);
+
+    const svg = svgEl('svg', {
+        viewBox: `0 0 ${buckets.length * TL_BAR_W} ${TL_HEIGHT}`,
+        preserveAspectRatio: 'none',
+        class: 'xr-portal__timeline-svg'
+    });
+
+    buckets.forEach((b, i) => {
+        const h = b.count === 0 ? 0 : Math.max(2, Math.round((b.count / maxCount) * (TL_HEIGHT - 4)));
+        const inBrush = brushed
+            && b.start >= (state.filters.after || -Infinity)
+            && b.end <= (state.filters.before || Infinity);
+        const bar = svgEl('rect', {
+            x: i * TL_BAR_W,
+            y: TL_HEIGHT - h,
+            width: TL_BAR_W - 2,
+            height: Math.max(h, 0.5),  // zero-count buckets stay hoverable
+            'data-index': i,
+            class: 'xr-tl-bar'
+                + (inBrush ? ' xr-tl-bar--active' : '')
+                + (b.count === 0 ? ' xr-tl-bar--empty' : '')
+        });
+        const tip = document.createElementNS(SVG_NS, 'title');
+        tip.textContent = `${fmtDay(b.start)} — ${b.count} item(s)`;
+        bar.appendChild(tip);
+        svg.appendChild(bar);
+    });
+
+    // Drag-to-brush: indices come from the bars' data attributes; a
+    // plain click selects the single bucket.
+    let dragStart = null;
+    const indexFromEvent = (e) => {
+        const idx = e.target && e.target.getAttribute && e.target.getAttribute('data-index');
+        return idx === null || idx === undefined ? null : Number(idx);
+    };
+    svg.addEventListener('mousedown', (e) => {
+        const idx = indexFromEvent(e);
+        if (idx !== null) { dragStart = idx; e.preventDefault(); }
+    });
+    svg.addEventListener('mouseup', (e) => {
+        if (dragStart === null) return;
+        const idx = indexFromEvent(e);
+        const range = brushRange(buckets, dragStart, idx === null ? dragStart : idx);
+        dragStart = null;
+        if (!range) return;
+        state.filters.after = range.after;
+        state.filters.before = range.before;
+        renderLibrary();
+    });
+    svg.addEventListener('mouseleave', () => { dragStart = null; });
+
+    host.appendChild(svg);
+}
+
 function renderLibrary() {
     renderTabs();
     renderFacets();
+    renderTimeline();
     renderRows(applyFilters(state.items, state.filters));
 }
 

--- a/src/portal/library.js
+++ b/src/portal/library.js
@@ -273,7 +273,9 @@ export const EMPTY_FILTERS = Object.freeze({
     domain: '',
     caseName: '',
     client: 'all',   // 'all' | 'ours' | 'other'
-    query: ''
+    query: '',
+    after: 0,        // epoch seconds, inclusive — 0 = unset (timeline brush)
+    before: 0        // epoch seconds, exclusive — 0 = unset
 });
 
 /**
@@ -288,6 +290,8 @@ export function applyFilters(items, filters) {
         if (f.platform && item.platform !== f.platform) return false;
         if (f.domain && item.domain !== f.domain) return false;
         if (f.caseName && !item.cases.includes(f.caseName)) return false;
+        if (f.after && item.created_at < f.after) return false;
+        if (f.before && item.created_at >= f.before) return false;
         if (f.client === 'ours' && isOtherClient(item)) return false;
         if (f.client === 'other' && !isOtherClient(item)) return false;
         for (const token of tokens) {

--- a/src/portal/timeline.js
+++ b/src/portal/timeline.js
@@ -1,0 +1,81 @@
+// Portal timeline model (Phase 12.4, docs/PORTAL_DESIGN.md).
+//
+// Pure bucketing over event `created_at`: day buckets, rolling up to
+// weeks when the corpus spans long enough that day bars would smear
+// into noise. The view brushes a [start, end) range that lands in the
+// Library filters (`after`/`before`), so the timeline and the list
+// stay one filtering path.
+//
+// All bucket boundaries are UTC — deterministic in tests and stable
+// across machines; the view layer is free to LABEL buckets in local
+// time, but the math here never consults the host timezone.
+
+const DAY = 86400;
+const WEEK = 7 * DAY;
+
+// Beyond this many day-buckets, roll up to weeks.
+const DAY_BUCKET_CEILING = 180;
+
+/** 'day' | 'week' for a corpus spanning `spanSeconds`. */
+export function chooseBucket(spanSeconds) {
+    return spanSeconds > DAY_BUCKET_CEILING * DAY ? 'week' : 'day';
+}
+
+/** Floor an epoch-seconds timestamp to its UTC bucket start. */
+export function bucketStart(ts, bucket) {
+    if (bucket === 'week') {
+        // ISO-ish weeks anchored on Monday: epoch day 0 (1970-01-01)
+        // was a Thursday — three days after a Monday — so (days + 3) % 7
+        // is the Monday-based weekday index to subtract.
+        const days = Math.floor(ts / DAY);
+        const weekStartDay = days - ((days + 3) % 7);
+        return weekStartDay * DAY;
+    }
+    return Math.floor(ts / DAY) * DAY;
+}
+
+/**
+ * Bucket the items (any objects carrying `created_at` epoch seconds).
+ * Returns a DENSE series — empty buckets included, so the view renders
+ * gaps as gaps rather than splicing active days together.
+ *
+ * @param {Array<{created_at: number}>} items
+ * @param {{bucket?: 'day'|'week'}} [opts]  omit to auto-choose
+ * @returns {{bucket: string, buckets: Array<{start: number, end: number, count: number}>}}
+ */
+export function buildBuckets(items, { bucket } = {}) {
+    const stamps = (Array.isArray(items) ? items : [])
+        .map((i) => i && i.created_at)
+        .filter((t) => Number.isFinite(t) && t > 0);
+    if (stamps.length === 0) return { bucket: bucket || 'day', buckets: [] };
+
+    const min = Math.min(...stamps);
+    const max = Math.max(...stamps);
+    const chosen = bucket || chooseBucket(max - min);
+    const size = chosen === 'week' ? WEEK : DAY;
+
+    const first = bucketStart(min, chosen);
+    const counts = new Map();
+    for (const t of stamps) {
+        const start = bucketStart(t, chosen);
+        counts.set(start, (counts.get(start) || 0) + 1);
+    }
+
+    const buckets = [];
+    for (let start = first; start <= max; start += size) {
+        buckets.push({ start, end: start + size, count: counts.get(start) || 0 });
+    }
+    return { bucket: chosen, buckets };
+}
+
+/**
+ * Normalize a drag across bucket indices into the [after, before)
+ * filter pair the Library consumes. Indices may arrive reversed
+ * (right-to-left drag) and are clamped to the series.
+ */
+export function brushRange(buckets, indexA, indexB) {
+    if (!Array.isArray(buckets) || buckets.length === 0) return null;
+    let a = Math.max(0, Math.min(buckets.length - 1, Math.min(indexA, indexB)));
+    let b = Math.max(0, Math.min(buckets.length - 1, Math.max(indexA, indexB)));
+    return { after: buckets[a].start, before: buckets[b].end };
+}

--- a/tests/portal-library.test.mjs
+++ b/tests/portal-library.test.mjs
@@ -166,7 +166,7 @@ test('isOtherClient: badge only when a client tag exists and is not ours', () =>
 
 test('EMPTY_FILTERS and TYPE_DEFS are pinned', () => {
     assert.deepEqual(EMPTY_FILTERS,
-        { type: 'all', platform: '', domain: '', caseName: '', client: 'all', query: '' });
+        { type: 'all', platform: '', domain: '', caseName: '', client: 'all', query: '', after: 0, before: 0 });
     assert.deepEqual(TYPE_DEFS.map((d) => d.key),
         ['article', 'claim', 'comment', 'assessment', 'link', 'entity', 'case', 'account', 'other']);
     assert.equal(kindLabel(30040), 'Claim');

--- a/tests/portal-timeline.test.mjs
+++ b/tests/portal-timeline.test.mjs
@@ -1,0 +1,96 @@
+// portal/timeline.js tests — Phase 12.4 (docs/PORTAL_DESIGN.md).
+//
+// Bucket math is UTC and pure; these pins keep the day/week rollup
+// boundary, the dense (gap-preserving) series, and the brush→filter
+// mapping honest. The applyFilters time-range semantics the brush
+// lands in are pinned here too (after inclusive, before exclusive).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const { chooseBucket, bucketStart, buildBuckets, brushRange } = await import('../src/portal/timeline.js');
+const { applyFilters } = await import('../src/portal/library.js');
+
+const DAY = 86400;
+
+test('chooseBucket: day up to 180 days, week beyond', () => {
+    assert.equal(chooseBucket(0), 'day');
+    assert.equal(chooseBucket(180 * DAY), 'day');
+    assert.equal(chooseBucket(180 * DAY + 1), 'week');
+});
+
+test('bucketStart floors to UTC day / Monday-anchored week', () => {
+    // 2026-06-10T15:30:00Z (a Wednesday)
+    const ts = Date.UTC(2026, 5, 10, 15, 30) / 1000;
+    assert.equal(bucketStart(ts, 'day'), Date.UTC(2026, 5, 10) / 1000);
+    assert.equal(bucketStart(ts, 'week'), Date.UTC(2026, 5, 8) / 1000); // Monday 06-08
+    // Epoch day itself (Thursday) anchors to the preceding Monday
+    // (1969-12-29, three days earlier).
+    assert.equal(bucketStart(0, 'week'), -3 * DAY);
+});
+
+test('buildBuckets: dense series with gap days at zero', () => {
+    const d0 = Date.UTC(2026, 5, 1) / 1000;
+    const items = [
+        { created_at: d0 + 100 },
+        { created_at: d0 + 200 },
+        { created_at: d0 + 2 * DAY + 5 }   // skips June 2 entirely
+    ];
+    const { bucket, buckets } = buildBuckets(items);
+    assert.equal(bucket, 'day');
+    assert.deepEqual(buckets.map((b) => b.count), [2, 0, 1]);
+    assert.equal(buckets[0].start, d0);
+    assert.equal(buckets[1].count, 0);
+    assert.equal(buckets[2].start, d0 + 2 * DAY);
+    for (const b of buckets) assert.equal(b.end - b.start, DAY);
+});
+
+test('buildBuckets: long spans roll up to weeks automatically', () => {
+    const d0 = Date.UTC(2025, 0, 6) / 1000; // a Monday
+    const items = [
+        { created_at: d0 },
+        { created_at: d0 + 300 * DAY }
+    ];
+    const { bucket, buckets } = buildBuckets(items);
+    assert.equal(bucket, 'week');
+    for (const b of buckets) assert.equal(b.end - b.start, 7 * DAY);
+    assert.equal(buckets[0].count, 1);
+    assert.equal(buckets[buckets.length - 1].count, 1);
+});
+
+test('buildBuckets: empty/garbage input yields an empty series', () => {
+    assert.deepEqual(buildBuckets([]).buckets, []);
+    assert.deepEqual(buildBuckets([{ created_at: 0 }, {}, null]).buckets, []);
+});
+
+test('brushRange normalizes reversed drags and clamps to the series', () => {
+    const { buckets } = buildBuckets([
+        { created_at: 1000 * DAY + 10 },
+        { created_at: 1002 * DAY + 10 }
+    ], { bucket: 'day' });
+    assert.equal(buckets.length, 3);
+    const forward = brushRange(buckets, 0, 1);
+    const reversed = brushRange(buckets, 1, 0);
+    assert.deepEqual(forward, reversed);
+    assert.equal(forward.after, buckets[0].start);
+    assert.equal(forward.before, buckets[1].end);
+    const clamped = brushRange(buckets, -5, 99);
+    assert.deepEqual(clamped, { after: buckets[0].start, before: buckets[2].end });
+    assert.equal(brushRange([], 0, 0), null);
+});
+
+test('applyFilters time range: after inclusive, before exclusive', () => {
+    const items = [
+        { typeKey: 'claim', created_at: 100, cases: [], searchText: '', platform: '', domain: '', client: '' },
+        { typeKey: 'claim', created_at: 200, cases: [], searchText: '', platform: '', domain: '', client: '' },
+        { typeKey: 'claim', created_at: 300, cases: [], searchText: '', platform: '', domain: '', client: '' }
+    ];
+    assert.equal(applyFilters(items, { after: 200, before: 0 }).length, 2);
+    assert.equal(applyFilters(items, { after: 0, before: 300 }).length, 2);
+    assert.deepEqual(applyFilters(items, { after: 200, before: 300 }).map((i) => i.created_at), [200]);
+    assert.equal(applyFilters(items, {}).length, 3);
+});


### PR DESCRIPTION
Fourth Phase 12 slice (design `docs/PORTAL_DESIGN.md` #48; prior slices #49–#51).

- **Pure bucket math** (`src/portal/timeline.js`): UTC day buckets → Monday-anchored week rollup past 180 days; dense series so gaps render as gaps; `brushRange()` maps a (possibly reversed) drag to the Library's `[after, before)` filter pair.
- **One filtering path**: `applyFilters` gains `after`/`before`, so the brush composes with tabs, facets, and search; the strip's density reflects every filter except the brush itself.
- **View**: SVG bars, drag-to-brush or click-a-bucket, hover counts, active-range chip with clear.

Gates: build ✅ · 651/651 tests ✅ (7 new) · web-ext lint 0 errors ✅

Smoke: open portal → density strip shows capture-session spikes → drag across a spike → list filters to that range → chip clears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)