### PR TITLE
feat(portal): entity spokes graph + case dashboard (Phase 12.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,23 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Portal entity spokes graph + case dashboard** (Phase 12.5). The
+  "explore visually" surface, per the agreed design: a hand-rolled
+  SVG **ego graph** — focused entity centered, deterministic radial
+  layout with type sectors (claims about it, claims it sourced,
+  co-tagged entities, containing cases, linked platform accounts),
+  spoke and mention edges, **⚠ contradiction edges** drawn hot with
+  ghost endpoints when the counterpart claim lives outside the ego
+  set, claim nodes tinted by their latest assessment stance, per-type
+  "+K more" overflow nodes that expand on click, drag-pan, wheel-zoom,
+  and locate-by-text pulse. Clicking a co-tagged entity refocuses;
+  clicking a case opens the new **case dashboard** — the publish-side
+  complement of the side panel's local one: artifact rollup by type, a
+  publish-density strip, the people/orgs tagged alongside, and the
+  case's claims with stance and ⚠ contradicted badges. Entity and
+  case rows in the Library link straight in. No graph dependency
+  added; the bundle stays vanilla SVG.
+
 - **Portal timeline — publish-date density + brush filtering**
   (Phase 12.4). A density strip over the corpus's `created_at` (UTC
   day buckets, rolling up to Monday-anchored weeks past 180 days, gap

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -905,8 +905,8 @@ Slices (one PR each):
 - ✅ **12.3** Cache — IndexedDB `xray-portal`, cache-first render,
   incremental refresh, relay-provenance persistence. — #51
 - ✅ **12.4** Timeline — density buckets + brush filtering. — #52
-- ⬜ **12.5** Entity & case views — radial spokes graph + case
-  dashboard.
+- ✅ **12.5** Entity & case views — radial spokes graph + case
+  dashboard. — #53
 - ⬜ **12.6** Inspector & reconciliation — raw events, per-relay
   holdings, ledger diff (confirmed / missing / remote-only), privacy
   footer.

--- a/src/portal/case-view.js
+++ b/src/portal/case-view.js
@@ -1,0 +1,197 @@
+// Portal case dashboard (Phase 12.5, docs/PORTAL_DESIGN.md).
+//
+// The publish-side complement of the side panel's local case dashboard
+// (Phase 11.5): for one case entity, the published artifacts grouped
+// and badged — counts per kind, the case's claims with stance/⚠
+// affordances, the people and orgs tagged alongside, and a mini
+// publish-density strip. A case IS an entity, so "its items" are the
+// library items whose case facet carries this case's name.
+
+import { el, svgEl, clear, truncate } from './dom.js';
+import { kindLabel, TYPE_DEFS } from './library.js';
+import { buildBuckets } from './timeline.js';
+
+function latestAssessmentByCoord(items) {
+    const map = new Map();
+    for (const item of items) {
+        if (item.typeKey !== 'assessment' || !item.claimCoord) continue;
+        const seen = map.get(item.claimCoord);
+        if (!seen || item.created_at > seen.created_at) map.set(item.claimCoord, item);
+    }
+    return map;
+}
+
+function contradictedCoords(items) {
+    const out = new Set();
+    for (const item of items) {
+        if (item.typeKey !== 'link' || item.relationship !== 'contradicts') continue;
+        if (item.sourceCoord) out.add(item.sourceCoord);
+        if (item.targetCoord) out.add(item.targetCoord);
+    }
+    return out;
+}
+
+/**
+ * @param {HTMLElement} host
+ * @param {object} params
+ * @param {Array}  params.items        ALL library items
+ * @param {object} params.entityIndex  pubkey → {entityId, name, type}
+ * @param {string} params.casePubkey
+ * @param {object} params.callbacks    {onBack(), onFocusEntity(pubkey), onOpenGraph(pubkey)}
+ */
+export function renderCaseView(host, params) {
+    const { items, entityIndex, casePubkey, callbacks } = params;
+    clear(host);
+
+    const caseEnt = entityIndex[casePubkey];
+    const caseName = caseEnt ? caseEnt.name : null;
+
+    const head = el('div', 'xr-view__head');
+    const back = el('button', 'xr-portal__btn xr-portal__btn--ghost', '← Library');
+    back.type = 'button';
+    back.addEventListener('click', () => callbacks.onBack());
+    head.appendChild(back);
+    head.appendChild(el('span', 'xr-view__title', caseName || 'Unknown case'));
+    head.appendChild(el('span', 'xr-badge', 'case'));
+    const graphBtn = el('button', 'xr-portal__btn', 'Spokes graph');
+    graphBtn.type = 'button';
+    graphBtn.addEventListener('click', () => callbacks.onOpenGraph(casePubkey));
+    head.appendChild(graphBtn);
+    host.appendChild(head);
+
+    if (!caseName) {
+        host.appendChild(el('p', 'xr-view__empty',
+            'This case isn\'t in the local entity registry, so its published artifacts can\'t be clustered here.'));
+        return;
+    }
+
+    // Everything published under this case + relationship links whose
+    // endpoints are case claims (links carry no p-tags of their own).
+    const caseItems = items.filter((i) => i.cases.includes(caseName));
+    const caseClaimCoords = new Set(caseItems.filter((i) => i.claimCoord && i.typeKey === 'claim').map((i) => i.claimCoord));
+    const caseLinks = items.filter((i) => i.typeKey === 'link'
+        && ((i.sourceCoord && caseClaimCoords.has(i.sourceCoord)) || (i.targetCoord && caseClaimCoords.has(i.targetCoord))));
+    const everything = [...caseItems, ...caseLinks.filter((l) => !caseItems.includes(l))];
+
+    // --- artifact rollup ---
+    const rollup = el('div', 'xr-case__rollup');
+    const counts = new Map();
+    for (const item of everything) counts.set(item.typeKey, (counts.get(item.typeKey) || 0) + 1);
+    for (const def of TYPE_DEFS) {
+        const n = counts.get(def.key) || 0;
+        if (n === 0) continue;
+        rollup.appendChild(el('span', 'xr-badge', `${def.label}: ${n}`));
+    }
+    host.appendChild(rollup);
+
+    // --- publish-density strip ---
+    const { buckets } = buildBuckets(everything);
+    if (buckets.length > 1) {
+        const maxCount = Math.max(...buckets.map((b) => b.count), 1);
+        const strip = svgEl('svg', {
+            class: 'xr-case__strip',
+            viewBox: `0 0 ${buckets.length * 6} 32`,
+            preserveAspectRatio: 'none'
+        });
+        buckets.forEach((b, i) => {
+            const h = b.count === 0 ? 0 : Math.max(2, Math.round((b.count / maxCount) * 28));
+            const bar = svgEl('rect', {
+                x: i * 6, y: 32 - h, width: 4, height: Math.max(h, 0.5),
+                class: b.count === 0 ? 'xr-tl-bar xr-tl-bar--empty' : 'xr-tl-bar'
+            });
+            const tip = svgEl('title', {});
+            tip.textContent = `${new Date(b.start * 1000).toLocaleDateString()} — ${b.count} item(s)`;
+            bar.appendChild(tip);
+            strip.appendChild(bar);
+        });
+        host.appendChild(strip);
+    }
+
+    // --- members: people/orgs tagged alongside the case ---
+    const members = new Map(); // pubkey → {name, type, count}
+    for (const item of caseItems) {
+        if (item.typeKey !== 'claim') continue;
+        for (const t of (item.event.tags || [])) {
+            if (t[0] !== 'p' || t[1] === casePubkey) continue;
+            const ent = entityIndex[t[1]];
+            if (!ent || ent.type === 'case') continue;
+            const cur = members.get(t[1]) || { name: ent.name, type: ent.type, count: 0 };
+            cur.count++;
+            members.set(t[1], cur);
+        }
+    }
+    if (members.size > 0) {
+        const section = el('div', 'xr-case__members');
+        section.appendChild(el('h3', 'xr-case__heading', 'People & organizations'));
+        const wrap = el('div', 'xr-portal__chips');
+        for (const [pk, m] of [...members.entries()].sort((a, b) => b[1].count - a[1].count)) {
+            const chip = el('button', 'xr-chip xr-chip--clickable', `${m.name} · ${m.count}`);
+            chip.type = 'button';
+            chip.title = `${m.type} — open spokes graph`;
+            chip.addEventListener('click', () => callbacks.onFocusEntity(pk));
+            wrap.appendChild(chip);
+        }
+        section.appendChild(wrap);
+        host.appendChild(section);
+    }
+
+    // --- claims with stance/⚠ badges ---
+    const assessments = latestAssessmentByCoord(items);
+    const contradicted = contradictedCoords(items);
+    const claims = caseItems.filter((i) => i.typeKey === 'claim');
+    const section = el('div', 'xr-case__claims');
+    section.appendChild(el('h3', 'xr-case__heading', `Claims (${claims.length})`));
+    const list = el('ol', 'xr-portal__list');
+    for (const item of claims) {
+        const row = el('li', 'xr-row');
+        const headRow = el('div', 'xr-row__head');
+        headRow.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
+        headRow.appendChild(el('span', 'xr-row__title', truncate(item.title, 160)));
+        const badges = el('span', 'xr-row__badges');
+        const assessment = item.claimCoord ? assessments.get(item.claimCoord) : null;
+        if (assessment && assessment.stance !== null && assessment.stance !== undefined) {
+            const cls = assessment.stance > 0 ? 'xr-badge--agree' : (assessment.stance < 0 ? 'xr-badge--disagree' : '');
+            badges.appendChild(el('span', `xr-badge ${cls}`,
+                `stance ${assessment.stance > 0 ? '+' : ''}${assessment.stance}`));
+        }
+        if (assessment && assessment.labelCount > 0) {
+            badges.appendChild(el('span', 'xr-badge', `${assessment.labelCount} label(s)`));
+        }
+        if (item.claimCoord && contradicted.has(item.claimCoord)) {
+            badges.appendChild(el('span', 'xr-badge xr-badge--warn', '⚠ contradicted'));
+        }
+        headRow.appendChild(badges);
+        if (item.created_at) {
+            headRow.appendChild(el('span', 'xr-row__date', new Date(item.created_at * 1000).toLocaleString()));
+        }
+        row.appendChild(headRow);
+        if (item.sub) row.appendChild(el('div', 'xr-row__sub', truncate(item.sub, 240)));
+        list.appendChild(row);
+    }
+    if (claims.length === 0) {
+        list.appendChild(el('li', 'xr-view__empty', 'No published claims reference this case yet.'));
+    }
+    section.appendChild(list);
+    host.appendChild(section);
+
+    // --- the rest of the artifacts, compact ---
+    const rest = everything.filter((i) => i.typeKey !== 'claim');
+    if (rest.length > 0) {
+        const other = el('div', 'xr-case__rest');
+        other.appendChild(el('h3', 'xr-case__heading', `Other artifacts (${rest.length})`));
+        const ul = el('ol', 'xr-portal__list');
+        for (const item of rest) {
+            const row = el('li', 'xr-row');
+            const headRow = el('div', 'xr-row__head');
+            headRow.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
+            headRow.appendChild(el('span', 'xr-row__title', truncate(item.title, 160)));
+            if (item.created_at) {
+                headRow.appendChild(el('span', 'xr-row__date', new Date(item.created_at * 1000).toLocaleString()));
+            }
+            row.appendChild(headRow);
+            ul.appendChild(row);
+        }
+        other.appendChild(ul);
+        host.appendChild(other);
+    }
+}

--- a/src/portal/dom.js
+++ b/src/portal/dom.js
@@ -1,0 +1,33 @@
+// Tiny DOM helpers shared by the portal views (Phase 12.5).
+//
+// Everything is createElement/textContent — the portal builds no
+// dynamic innerHTML anywhere (escaping stays a non-issue and web-ext's
+// UNSAFE_VAR_ASSIGNMENT warnings don't multiply).
+
+export const SVG_NS = 'http://www.w3.org/2000/svg';
+
+export function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = text;
+    return node;
+}
+
+export function svgEl(tag, attrs) {
+    const node = document.createElementNS(SVG_NS, tag);
+    for (const [k, v] of Object.entries(attrs || {})) node.setAttribute(k, String(v));
+    return node;
+}
+
+export function clear(node) {
+    while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+export function truncate(s, n) {
+    const str = String(s || '').trim();
+    return str.length > n ? str.slice(0, n - 1) + '…' : str;
+}
+
+export function shortKey(pubkey) {
+    return pubkey.slice(0, 8) + '…' + pubkey.slice(-4);
+}

--- a/src/portal/entity-view.js
+++ b/src/portal/entity-view.js
@@ -1,0 +1,235 @@
+// Portal entity spokes view (Phase 12.5, docs/PORTAL_DESIGN.md).
+//
+// Renders the ego graph from graph.js as hand-rolled SVG: spokes from
+// the focused entity, claim nodes tinted by their latest assessment
+// stance, ⚠ contradiction edges drawn hot (with ghost endpoints when
+// the counterpart claim isn't in the ego set), pan via drag, zoom via
+// wheel, locate-by-text pulse. Clicking an entity or case node
+// refocuses; clicking a claim/account opens a detail card below.
+//
+// All state that must survive a re-render (expanded sectors, the
+// detail selection) lives in the params the router passes back in.
+
+import { el, svgEl, clear, truncate, shortKey } from './dom.js';
+import { buildEgoGraph, layoutEgoGraph } from './graph.js';
+import { kindLabel } from './library.js';
+
+const SIZE = 720;
+
+function stanceClass(node) {
+    if (node.stance === null || node.stance === undefined) return '';
+    if (node.stance > 0) return ' xr-gnode--agree';
+    if (node.stance < 0) return ' xr-gnode--disagree';
+    return ' xr-gnode--neutral';
+}
+
+const NODE_RADIUS = {
+    claim: 7, 'sourced-claim': 7, entity: 9, case: 11, account: 8,
+    'ghost-claim': 6, more: 9
+};
+
+/**
+ * @param {HTMLElement} host
+ * @param {object} params
+ * @param {Array}   params.items         library items
+ * @param {object}  params.entityIndex   pubkey → {entityId, name, type}
+ * @param {string}  params.focusPubkey
+ * @param {Set}     params.expandedTypes
+ * @param {object}  params.callbacks     {onFocusEntity(pubkey), onOpenCase(pubkey),
+ *                                        onBack(), onExpand(type)}
+ */
+export function renderEntityView(host, params) {
+    const { items, entityIndex, focusPubkey, expandedTypes, callbacks } = params;
+    clear(host);
+
+    const graph = buildEgoGraph(items, { focusPubkey, entityIndex, expandedTypes });
+    const positions = layoutEgoGraph(graph, { size: SIZE });
+
+    // --- header ---
+    const head = el('div', 'xr-view__head');
+    const back = el('button', 'xr-portal__btn xr-portal__btn--ghost', '← Library');
+    back.type = 'button';
+    back.addEventListener('click', () => callbacks.onBack());
+    head.appendChild(back);
+    const title = el('span', 'xr-view__title', graph.focus.name);
+    title.title = focusPubkey;
+    head.appendChild(title);
+    head.appendChild(el('span', 'xr-badge', graph.focus.type));
+    const c = graph.counts;
+    head.appendChild(el('span', 'xr-view__counts',
+        `${c.claimsAbout} claim(s) · ${c.entities} co-tagged · ${c.cases} case(s) · ${c.accounts} account(s)`
+        + (c.claimsSourced ? ` · sourced ${c.claimsSourced}` : '')));
+
+    const locate = el('input', 'xr-view__locate');
+    locate.type = 'search';
+    locate.placeholder = 'Locate in graph…';
+    head.appendChild(locate);
+    host.appendChild(head);
+
+    if (graph.nodes.length === 0) {
+        host.appendChild(el('p', 'xr-view__empty',
+            'Nothing published references this entity yet — no claims, accounts, or cases found in the corpus.'));
+        return;
+    }
+
+    // --- svg ---
+    const view = { x: 0, y: 0, w: SIZE, h: SIZE };
+    const svg = svgEl('svg', { class: 'xr-view__svg', viewBox: `0 0 ${SIZE} ${SIZE}` });
+    const applyView = () => svg.setAttribute('viewBox', `${view.x} ${view.y} ${view.w} ${view.h}`);
+
+    const edgeLayer = svgEl('g', {});
+    const nodeLayer = svgEl('g', {});
+    svg.appendChild(edgeLayer);
+    svg.appendChild(nodeLayer);
+
+    for (const edge of graph.edges) {
+        const from = positions[edge.from];
+        const to = positions[edge.to];
+        if (!from || !to) continue;
+        const cls = edge.kind === 'relationship'
+            ? (edge.warn ? 'xr-gedge xr-gedge--warn' : 'xr-gedge xr-gedge--rel')
+            : (edge.kind === 'mention' ? 'xr-gedge xr-gedge--mention' : 'xr-gedge');
+        const line = svgEl('line', { x1: from.x, y1: from.y, x2: to.x, y2: to.y, class: cls });
+        if (edge.relationship) {
+            const tip = svgEl('title', {});
+            tip.textContent = edge.relationship;
+            line.appendChild(tip);
+        }
+        edgeLayer.appendChild(line);
+        if (edge.warn) {
+            const mark = svgEl('text', {
+                x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 - 4,
+                class: 'xr-gedge__warnmark', 'text-anchor': 'middle'
+            });
+            mark.textContent = '⚠';
+            edgeLayer.appendChild(mark);
+        }
+    }
+
+    const nodeEls = new Map();
+    const drawNode = (id, nodeType, label, extraClass, titleText) => {
+        const pos = positions[id];
+        if (!pos) return null;
+        const g = svgEl('g', { class: `xr-gnode xr-gnode--${nodeType}${extraClass || ''}`, 'data-id': id });
+        const circle = svgEl('circle', { cx: pos.x, cy: pos.y, r: NODE_RADIUS[nodeType] || 7 });
+        const tip = svgEl('title', {});
+        tip.textContent = titleText || label;
+        circle.appendChild(tip);
+        g.appendChild(circle);
+        const text = svgEl('text', {
+            x: pos.x, y: pos.y + (NODE_RADIUS[nodeType] || 7) + 11,
+            'text-anchor': 'middle', class: 'xr-gnode__label'
+        });
+        text.textContent = truncate(label, 28);
+        g.appendChild(text);
+        nodeLayer.appendChild(g);
+        nodeEls.set(id, g);
+        return g;
+    };
+
+    // focus node
+    const focusG = svgEl('g', { class: 'xr-gnode xr-gnode--focus' });
+    const fc = positions.focus;
+    const focusCircle = svgEl('circle', { cx: fc.x, cy: fc.y, r: 16 });
+    const focusTip = svgEl('title', {});
+    focusTip.textContent = `${graph.focus.name} (${graph.focus.type})`;
+    focusCircle.appendChild(focusTip);
+    focusG.appendChild(focusCircle);
+    const focusText = svgEl('text', { x: fc.x, y: fc.y + 32, 'text-anchor': 'middle', class: 'xr-gnode__label xr-gnode__label--focus' });
+    focusText.textContent = truncate(graph.focus.name, 30);
+    focusG.appendChild(focusText);
+    nodeLayer.appendChild(focusG);
+
+    for (const node of graph.nodes) {
+        const extra = node.nodeType === 'claim' ? stanceClass(node) : '';
+        const tip = node.labelCount
+            ? `${node.label}\n${node.labelCount} label(s) on latest assessment`
+            : node.label;
+        drawNode(node.id, node.nodeType, node.label, extra, tip);
+    }
+
+    // --- interactions ---
+    nodeLayer.addEventListener('click', (e) => {
+        const g = e.target.closest && e.target.closest('.xr-gnode[data-id]');
+        if (!g) return;
+        const id = g.getAttribute('data-id');
+        const node = graph.nodes.find((n) => n.id === id);
+        if (!node) return;
+        if (node.nodeType === 'entity') callbacks.onFocusEntity(node.pubkey);
+        else if (node.nodeType === 'case') callbacks.onOpenCase(node.pubkey);
+        else if (node.nodeType === 'more') callbacks.onExpand(node.forType);
+        else renderDetail(node);
+    });
+
+    // Pan: drag anywhere that isn't a node; Zoom: wheel.
+    let panFrom = null;
+    svg.addEventListener('mousedown', (e) => {
+        if (e.target.closest && e.target.closest('.xr-gnode')) return;
+        panFrom = { mx: e.clientX, my: e.clientY, x: view.x, y: view.y };
+        e.preventDefault();
+    });
+    svg.addEventListener('mousemove', (e) => {
+        if (!panFrom) return;
+        const scale = view.w / svg.clientWidth;
+        view.x = panFrom.x - (e.clientX - panFrom.mx) * scale;
+        view.y = panFrom.y - (e.clientY - panFrom.my) * scale;
+        applyView();
+    });
+    svg.addEventListener('mouseup', () => { panFrom = null; });
+    svg.addEventListener('mouseleave', () => { panFrom = null; });
+    svg.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        const factor = e.deltaY > 0 ? 1.15 : 1 / 1.15;
+        const newW = Math.min(SIZE * 3, Math.max(SIZE / 8, view.w * factor));
+        const ratio = newW / view.w;
+        view.x += (view.w - newW) / 2;
+        view.y += (view.h - view.h * ratio) / 2;
+        view.w = newW;
+        view.h = view.h * ratio;
+        applyView();
+    }, { passive: false });
+
+    // Locate: pulse the first matching node.
+    locate.addEventListener('input', () => {
+        const q = locate.value.trim().toLowerCase();
+        for (const g of nodeEls.values()) g.classList.remove('xr-gnode--pulse');
+        if (!q) return;
+        const hit = graph.nodes.find((n) => (n.label || '').toLowerCase().includes(q));
+        if (hit && nodeEls.has(hit.id)) nodeEls.get(hit.id).classList.add('xr-gnode--pulse');
+    });
+
+    host.appendChild(svg);
+
+    // --- detail card (claim / account / ghost) ---
+    const detail = el('div', 'xr-view__detail');
+    host.appendChild(detail);
+
+    function renderDetail(node) {
+        clear(detail);
+        if (node.item) {
+            const card = el('div', 'xr-row');
+            const headRow = el('div', 'xr-row__head');
+            headRow.appendChild(el('span', 'xr-row__kind', kindLabel(node.item.kind)));
+            headRow.appendChild(el('span', 'xr-row__title', truncate(node.item.title, 200)));
+            if (node.item.created_at) {
+                headRow.appendChild(el('span', 'xr-row__date',
+                    new Date(node.item.created_at * 1000).toLocaleString()));
+            }
+            card.appendChild(headRow);
+            if (node.item.sub) card.appendChild(el('div', 'xr-row__sub', truncate(node.item.sub, 300)));
+            const details = el('details');
+            details.appendChild(el('summary', null, 'Raw event'));
+            const pre = el('pre');
+            details.addEventListener('toggle', () => {
+                if (details.open && !pre.textContent) pre.textContent = JSON.stringify(node.item.event, null, 2);
+            });
+            details.appendChild(pre);
+            card.appendChild(details);
+            detail.appendChild(card);
+        } else if (node.nodeType === 'ghost-claim') {
+            detail.appendChild(el('p', 'xr-view__empty',
+                `Linked claim ${shortKey(node.coord.split(':')[1] || '')}:${node.coord.split(':')[2] || ''} isn't in this entity's spokes — `
+                + 'it lives on another entity (or another author). Its relationship edge is shown so the contradiction stays visible.'));
+        }
+    }
+}

--- a/src/portal/graph.js
+++ b/src/portal/graph.js
@@ -1,0 +1,280 @@
+// Portal ego graph (Phase 12.5, docs/PORTAL_DESIGN.md).
+//
+// The signed-off graph design: an entity-centric SPOKES view, not a
+// free-floating force graph. One focused entity at the center;
+// one-hop ring nodes grouped by type; deterministic radial layout
+// (same data ⇒ same picture, no physics to tune). Pure module — the
+// SVG lives in entity-view.js.
+//
+// Node sources, all from library items:
+//   claim          — 30040 whose `p …about` includes the focus pubkey
+//   sourced-claim  — 30040 whose `p …source` includes it
+//   entity         — co-tagged about-entities on those claims (local registry)
+//   case           — case entities clustering those claims
+//   account        — 32126 whose linked-entity is the focus entity id
+//   ghost-claim    — a 30055 endpoint outside the visible claim set;
+//                    rendered so a ⚠ contradiction is never hidden
+//   more           — per-type overflow ("+K more"), expandable
+//
+// Assessments don't become nodes — they DECORATE their claim (stance,
+// label count), newest per coordinate wins.
+
+const TAU = Math.PI * 2;
+
+function pTagRoles(event, pubkey) {
+    const roles = new Set();
+    for (const t of (event.tags || [])) {
+        if (t[0] === 'p' && t[1] === pubkey) roles.add(t[3] || '');
+    }
+    return roles;
+}
+
+function newestFirst(a, b) { return b.created_at - a.created_at; }
+
+/**
+ * @param {Array<object>} items       library items (buildItems output)
+ * @param {object} opts
+ * @param {string} opts.focusPubkey   the centered entity's pubkey
+ * @param {object} opts.entityIndex   pubkey → {entityId, name, type}
+ * @param {Set<string>} [opts.expandedTypes]  sectors the user expanded
+ * @param {number} [opts.sectorCap=24]
+ * @returns {{focus, nodes: Array, edges: Array, counts: object}}
+ */
+export function buildEgoGraph(items, { focusPubkey, entityIndex = {}, expandedTypes = new Set(), sectorCap = 24 } = {}) {
+    const list = Array.isArray(items) ? items : [];
+    const known = entityIndex[focusPubkey];
+    const profileItem = list.find((i) => i.kind === 0 && i.event.pubkey === focusPubkey) || null;
+    let profileName = '';
+    if (profileItem) {
+        try { profileName = JSON.parse(profileItem.event.content || '{}').name || ''; } catch (_) { /* ignore */ }
+    }
+    const focus = {
+        pubkey: focusPubkey,
+        name: (known && known.name) || profileName || focusPubkey.slice(0, 12) + '…',
+        type: (known && known.type) || 'entity',
+        entityId: (known && known.entityId) || null,
+        profileItem
+    };
+
+    const claimsAbout = [];
+    const claimsSourced = [];
+    for (const item of list) {
+        if (item.typeKey !== 'claim') continue;
+        const roles = pTagRoles(item.event, focusPubkey);
+        if (roles.has('about') || roles.has('')) claimsAbout.push(item);
+        else if (roles.has('source')) claimsSourced.push(item);
+    }
+    claimsAbout.sort(newestFirst);
+    claimsSourced.sort(newestFirst);
+
+    const accounts = list
+        .filter((i) => i.typeKey === 'account' && focus.entityId && i.linkedEntityId === focus.entityId)
+        .sort(newestFirst);
+
+    // Latest assessment per claim coordinate.
+    const assessmentByCoord = new Map();
+    for (const item of list) {
+        if (item.typeKey !== 'assessment' || !item.claimCoord) continue;
+        const seen = assessmentByCoord.get(item.claimCoord);
+        if (!seen || item.created_at > seen.created_at) assessmentByCoord.set(item.claimCoord, item);
+    }
+
+    // Co-tagged entities + containing cases, counted across the about-claims.
+    const coTagged = new Map(); // pubkey → {entity, count}
+    const caseNames = new Map(); // name → count
+    for (const claim of claimsAbout) {
+        for (const t of (claim.event.tags || [])) {
+            if (t[0] !== 'p' || t[1] === focusPubkey) continue;
+            const ent = entityIndex[t[1]];
+            if (!ent) continue;
+            if (ent.type === 'case') continue; // cases get their own ring via item.cases
+            const cur = coTagged.get(t[1]) || { entity: ent, pubkey: t[1], count: 0 };
+            cur.count++;
+            coTagged.set(t[1], cur);
+        }
+        for (const name of claim.cases) caseNames.set(name, (caseNames.get(name) || 0) + 1);
+    }
+    const casePubkeyByName = {};
+    for (const [pk, ent] of Object.entries(entityIndex)) {
+        if (ent.type === 'case') casePubkeyByName[ent.name] = pk;
+    }
+
+    const nodes = [];
+    const edges = [];
+    const nodeIds = new Set();
+    const addNode = (node) => {
+        if (nodeIds.has(node.id)) return false;
+        nodeIds.add(node.id);
+        nodes.push(node);
+        return true;
+    };
+
+    const capList = (typeKey, fullList) =>
+        expandedTypes.has(typeKey) ? fullList : fullList.slice(0, sectorCap);
+
+    // --- claims about the focus ---
+    const keptClaims = capList('claim', claimsAbout);
+    const claimNodeByCoord = new Map();
+    for (const item of keptClaims) {
+        const id = `claim:${item.claimCoord || item.id}`;
+        const assessment = item.claimCoord ? assessmentByCoord.get(item.claimCoord) : null;
+        addNode({
+            id, nodeType: 'claim', label: item.title, item,
+            stance: assessment ? assessment.stance : null,
+            labelCount: assessment ? assessment.labelCount : 0
+        });
+        if (item.claimCoord) claimNodeByCoord.set(item.claimCoord, id);
+        edges.push({ from: 'focus', to: id, kind: 'spoke' });
+    }
+    if (claimsAbout.length > keptClaims.length) {
+        addNode({ id: 'more:claim', nodeType: 'more', forType: 'claim', label: `+${claimsAbout.length - keptClaims.length} more` });
+        edges.push({ from: 'focus', to: 'more:claim', kind: 'spoke' });
+    }
+
+    // --- claims the focus is the source of ---
+    const keptSourced = capList('sourced-claim', claimsSourced);
+    for (const item of keptSourced) {
+        const id = `claim:${item.claimCoord || item.id}`;
+        if (!addNode({ id, nodeType: 'sourced-claim', label: item.title, item, stance: null, labelCount: 0 })) continue;
+        if (item.claimCoord) claimNodeByCoord.set(item.claimCoord, id);
+        edges.push({ from: 'focus', to: id, kind: 'spoke', role: 'source' });
+    }
+    if (claimsSourced.length > keptSourced.length) {
+        addNode({ id: 'more:sourced-claim', nodeType: 'more', forType: 'sourced-claim', label: `+${claimsSourced.length - keptSourced.length} more` });
+        edges.push({ from: 'focus', to: 'more:sourced-claim', kind: 'spoke' });
+    }
+
+    // --- co-tagged entities (ranked by shared-claim count) ---
+    const rankedEntities = [...coTagged.values()].sort((a, b) => b.count - a.count);
+    const keptEntities = capList('entity', rankedEntities);
+    for (const { entity, pubkey, count } of keptEntities) {
+        const id = `entity:${pubkey}`;
+        addNode({ id, nodeType: 'entity', label: entity.name, pubkey, entityType: entity.type, count });
+        // Wire the entity to the claims it shares with the focus.
+        for (const claim of keptClaims) {
+            if (pTagRoles(claim.event, pubkey).size > 0 && claim.claimCoord && claimNodeByCoord.has(claim.claimCoord)) {
+                edges.push({ from: claimNodeByCoord.get(claim.claimCoord), to: id, kind: 'mention' });
+            }
+        }
+    }
+    if (rankedEntities.length > keptEntities.length) {
+        addNode({ id: 'more:entity', nodeType: 'more', forType: 'entity', label: `+${rankedEntities.length - keptEntities.length} more` });
+    }
+
+    // --- cases clustering these claims ---
+    for (const [name, count] of [...caseNames.entries()].sort((a, b) => b[1] - a[1])) {
+        const pk = casePubkeyByName[name];
+        if (!pk) continue;
+        const id = `case:${pk}`;
+        addNode({ id, nodeType: 'case', label: name, pubkey: pk, count });
+        edges.push({ from: 'focus', to: id, kind: 'spoke' });
+    }
+
+    // --- linked platform accounts ---
+    const keptAccounts = capList('account', accounts);
+    for (const item of keptAccounts) {
+        const id = `account:${item.id}`;
+        addNode({ id, nodeType: 'account', label: item.title, item });
+        edges.push({ from: 'focus', to: id, kind: 'spoke' });
+    }
+
+    // --- 30055 relationships among visible claims (+ ghosts) ---
+    for (const item of list) {
+        if (item.typeKey !== 'link' || !item.sourceCoord || !item.targetCoord) continue;
+        const srcVisible = claimNodeByCoord.get(item.sourceCoord);
+        const tgtVisible = claimNodeByCoord.get(item.targetCoord);
+        if (!srcVisible && !tgtVisible) continue;
+        const warn = item.relationship === 'contradicts';
+        const endpoint = (coord, visibleId) => {
+            if (visibleId) return visibleId;
+            const ghostId = `ghost:${coord}`;
+            addNode({ id: ghostId, nodeType: 'ghost-claim', label: coord.split(':')[2] || coord, coord });
+            return ghostId;
+        };
+        edges.push({
+            from: endpoint(item.sourceCoord, srcVisible),
+            to: endpoint(item.targetCoord, tgtVisible),
+            kind: 'relationship',
+            relationship: item.relationship,
+            warn,
+            item
+        });
+    }
+
+    return {
+        focus,
+        nodes,
+        edges,
+        counts: {
+            claimsAbout: claimsAbout.length,
+            claimsSourced: claimsSourced.length,
+            entities: rankedEntities.length,
+            cases: caseNames.size,
+            accounts: accounts.length
+        }
+    };
+}
+
+// Sector allocation (degrees, 0° = east, clockwise in SVG space) and
+// ring radius per node type. Deterministic by construction.
+const SECTORS = {
+    'claim':         { start: -80, end: 80,  radius: 0.42 },
+    'entity':        { start: 95,  end: 175, radius: 0.46 },
+    'case':          { start: 182, end: 232, radius: 0.34 },
+    'account':       { start: 238, end: 280, radius: 0.30 },
+    'sourced-claim': { start: 286, end: 352, radius: 0.42 }
+};
+const GHOST_RADIUS = 0.58;
+
+/**
+ * Deterministic radial layout. Nodes spread evenly within their
+ * type's sector with a small alternating radial stagger so adjacent
+ * labels don't sit on one circle; ghosts hang outside the claim that
+ * references them.
+ *
+ * @returns {Object<string, {x: number, y: number}>} including 'focus'
+ */
+export function layoutEgoGraph(graph, { size = 720 } = {}) {
+    const cx = size / 2;
+    const cy = size / 2;
+    const positions = { focus: { x: cx, y: cy } };
+
+    const byType = new Map();
+    for (const node of graph.nodes) {
+        const type = node.nodeType === 'more' ? node.forType : node.nodeType;
+        if (node.nodeType === 'ghost-claim') continue; // placed after their anchors
+        if (!byType.has(type)) byType.set(type, []);
+        byType.get(type).push(node);
+    }
+
+    for (const [type, nodes] of byType) {
+        const sector = SECTORS[type] || SECTORS.claim;
+        const span = sector.end - sector.start;
+        nodes.forEach((node, i) => {
+            const angle = (sector.start + ((i + 0.5) / nodes.length) * span) * (TAU / 360);
+            const stagger = (i % 2 === 0 ? 0 : 0.05) + (node.nodeType === 'more' ? 0.08 : 0);
+            const r = (sector.radius + stagger) * size;
+            positions[node.id] = {
+                x: cx + r * Math.cos(angle),
+                y: cy + r * Math.sin(angle)
+            };
+        });
+    }
+
+    // Ghosts: just beyond the claim that links to them (first edge wins).
+    for (const node of graph.nodes) {
+        if (node.nodeType !== 'ghost-claim') continue;
+        const edge = graph.edges.find((e) =>
+            e.kind === 'relationship' && (e.from === node.id || e.to === node.id));
+        const anchorId = edge ? (edge.from === node.id ? edge.to : edge.from) : null;
+        const anchor = (anchorId && positions[anchorId]) || { x: cx, y: cy };
+        const dx = anchor.x - cx;
+        const dy = anchor.y - cy;
+        const len = Math.hypot(dx, dy) || 1;
+        positions[node.id] = {
+            x: cx + (dx / len) * GHOST_RADIUS * size,
+            y: cy + (dy / len) * GHOST_RADIUS * size
+        };
+    }
+    return positions;
+}

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -386,6 +386,134 @@ body.xr-portal {
   font-family: ui-monospace, Menlo, monospace;
 }
 
+/* ---------------- entity & case views (12.5) ---------------- */
+
+.xr-portal__view {
+  padding: 8px 16px 24px;
+  max-width: 980px;
+}
+
+.xr-view__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.xr-view__title {
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.xr-view__counts {
+  color: var(--xr-text-dim);
+  font-size: 12px;
+}
+
+.xr-view__locate {
+  margin-left: auto;
+  padding: 5px 8px;
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  background: var(--xr-bg);
+  color: var(--xr-text);
+  font-size: 12px;
+}
+
+.xr-view__empty {
+  color: var(--xr-text-dim);
+  padding: 16px 4px;
+}
+
+.xr-view__svg {
+  display: block;
+  width: 100%;
+  height: 560px;
+  border: 1px solid var(--xr-border);
+  border-radius: 10px;
+  background: var(--xr-surface);
+  cursor: grab;
+}
+
+.xr-view__svg:active { cursor: grabbing; }
+
+.xr-view__detail { margin-top: 10px; }
+
+/* graph nodes */
+.xr-gnode { cursor: pointer; }
+.xr-gnode circle { fill: var(--xr-surface-2); stroke: var(--xr-border); stroke-width: 1.5; }
+.xr-gnode--focus circle { fill: var(--xr-primary); stroke: var(--xr-primary-hover); }
+.xr-gnode--claim circle { stroke: var(--xr-primary); }
+.xr-gnode--sourced-claim circle { stroke: var(--xr-primary); stroke-dasharray: 3 2; }
+.xr-gnode--entity circle { stroke: var(--xr-accent); }
+.xr-gnode--case circle { fill: var(--xr-accent); fill-opacity: 0.25; stroke: var(--xr-accent); }
+.xr-gnode--account circle { stroke: var(--xr-success); }
+.xr-gnode--ghost-claim circle { stroke: var(--xr-warning); stroke-dasharray: 2 2; fill: transparent; }
+.xr-gnode--more circle { stroke: var(--xr-text-dim); stroke-dasharray: 2 3; fill: transparent; }
+.xr-gnode--agree circle { fill: var(--xr-success); fill-opacity: 0.45; }
+.xr-gnode--disagree circle { fill: var(--xr-danger); fill-opacity: 0.45; }
+.xr-gnode--neutral circle { fill: var(--xr-warning); fill-opacity: 0.3; }
+.xr-gnode:hover circle { stroke-width: 3; }
+
+.xr-gnode__label {
+  fill: var(--xr-text-dim);
+  font-size: 10px;
+  pointer-events: none;
+}
+
+.xr-gnode__label--focus { fill: var(--xr-text); font-size: 12px; font-weight: 600; }
+
+@keyframes xr-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
+.xr-gnode--pulse circle {
+  stroke: var(--xr-warning);
+  stroke-width: 4;
+  animation: xr-pulse 0.9s ease-in-out infinite;
+}
+
+/* graph edges */
+.xr-gedge { stroke: var(--xr-border); stroke-width: 1; }
+.xr-gedge--mention { stroke: var(--xr-accent); stroke-opacity: 0.35; }
+.xr-gedge--rel { stroke: var(--xr-text-dim); stroke-width: 1.5; }
+.xr-gedge--warn { stroke: var(--xr-danger); stroke-width: 2; stroke-dasharray: 5 3; }
+.xr-gedge__warnmark { fill: var(--xr-danger); font-size: 13px; }
+
+/* case dashboard */
+.xr-case__rollup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 0 8px;
+}
+
+.xr-case__strip {
+  display: block;
+  width: 100%;
+  height: 32px;
+  margin: 4px 0 8px;
+}
+
+.xr-case__heading {
+  margin: 16px 0 6px;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--xr-text-dim);
+}
+
+.xr-chip--clickable { cursor: pointer; }
+.xr-chip--clickable:hover { border-color: var(--xr-accent); }
+
+.xr-badge--agree { color: var(--xr-success); border-color: var(--xr-success); }
+.xr-badge--disagree { color: var(--xr-danger); border-color: var(--xr-danger); }
+.xr-badge--action { cursor: pointer; color: var(--xr-primary); border-color: var(--xr-primary); background: transparent; }
+.xr-badge--action:hover { background: var(--xr-surface-2); }
+button.xr-badge--case { cursor: pointer; background: transparent; }
+
 /* ---------------- empty state ---------------- */
 
 .xr-portal__empty {

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -56,6 +56,9 @@
   <main class="xr-portal__main">
     <div class="xr-portal__empty" id="xr-empty" hidden></div>
     <ol class="xr-portal__list" id="xr-list"></ol>
+    <!-- Entity spokes graph / case dashboard (Phase 12.5).
+         Populated by entity-view.js / case-view.js via the router. -->
+    <section class="xr-portal__view" id="xr-view" hidden></section>
   </main>
 
   <footer class="xr-portal__footer">

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -21,46 +21,28 @@ import {
     kindLabel, TYPE_DEFS, EMPTY_FILTERS
 } from './library.js';
 import { buildBuckets, brushRange } from './timeline.js';
+import { el, svgEl, clear, truncate, shortKey } from './dom.js';
+import { renderEntityView } from './entity-view.js';
+import { renderCaseView } from './case-view.js';
 
 const $ = (sel) => document.querySelector(sel);
 
 const state = {
     identities: [],      // [{pubkey, sources}]
     entities: [],        // [{pubkey, entityId, name, type}]
+    entityIndex: {},     // pubkey → {entityId, name, type}
     signer: null,        // {method, pubkey, reason}
     relays: [],
     records: [],         // [{event, relays}] — raw, pre-dedupe
     items: [],           // library items (deduped, parsed, sorted)
     filters: { ...EMPTY_FILTERS },
     groupByDomain: false,
+    view: { name: 'library' },   // | {name:'entity', pubkey} | {name:'case', pubkey}
+    expandedTypes: new Set(),    // graph sectors the user expanded
     relayErrors: {},
     truncated: false,
     loading: false
 };
-
-// ------------------------------------------------------------------
-// Small DOM helpers
-// ------------------------------------------------------------------
-
-function el(tag, className, text) {
-    const node = document.createElement(tag);
-    if (className) node.className = className;
-    if (text !== undefined && text !== null) node.textContent = text;
-    return node;
-}
-
-function clear(node) {
-    while (node.firstChild) node.removeChild(node.firstChild);
-}
-
-function shortKey(pubkey) {
-    return pubkey.slice(0, 8) + '…' + pubkey.slice(-4);
-}
-
-function truncate(s, n) {
-    const str = String(s || '').trim();
-    return str.length > n ? str.slice(0, n - 1) + '…' : str;
-}
 
 // ------------------------------------------------------------------
 // Header / identity / status
@@ -177,6 +159,13 @@ function renderFacets() {
     state.filters.caseName = $('#xr-facet-case').value;
 }
 
+function casePubkeyFor(name) {
+    for (const [pk, ent] of Object.entries(state.entityIndex)) {
+        if (ent.type === 'case' && ent.name === name) return pk;
+    }
+    return null;
+}
+
 function buildRow(item) {
     const row = el('li', 'xr-row');
     const head = el('div', 'xr-row__head');
@@ -191,7 +180,27 @@ function buildRow(item) {
         badges.appendChild(el('span', 'xr-badge xr-badge--warn', `via ${truncate(item.client, 24)}`));
     }
     for (const caseName of item.cases) {
-        badges.appendChild(el('span', 'xr-badge xr-badge--case', truncate(caseName, 32)));
+        const pk = casePubkeyFor(caseName);
+        const badge = el(pk ? 'button' : 'span', 'xr-badge xr-badge--case', truncate(caseName, 32));
+        if (pk) {
+            badge.type = 'button';
+            badge.title = 'Open the case dashboard';
+            badge.addEventListener('click', () => viewCallbacks.onOpenCase(pk));
+        }
+        badges.appendChild(badge);
+    }
+    if ((item.typeKey === 'entity' || item.typeKey === 'case') && item.event.pubkey) {
+        const btn = el('button', 'xr-badge xr-badge--action',
+            item.typeKey === 'case' ? '☰ Dashboard' : '✳ Spokes');
+        btn.type = 'button';
+        btn.title = item.typeKey === 'case'
+            ? 'Open this case\'s published-artifact dashboard'
+            : 'Open this entity\'s spokes graph';
+        btn.addEventListener('click', () => {
+            if (item.typeKey === 'case') viewCallbacks.onOpenCase(item.event.pubkey);
+            else viewCallbacks.onFocusEntity(item.event.pubkey);
+        });
+        badges.appendChild(btn);
     }
     head.appendChild(badges);
 
@@ -257,15 +266,8 @@ function renderRows(visible) {
 // Timeline (Phase 12.4): publish-date density + brush-to-filter
 // ------------------------------------------------------------------
 
-const SVG_NS = 'http://www.w3.org/2000/svg';
 const TL_BAR_W = 6;     // viewBox units per bucket (4 bar + 2 gap)
 const TL_HEIGHT = 56;
-
-function svgEl(tag, attrs) {
-    const node = document.createElementNS(SVG_NS, tag);
-    for (const [k, v] of Object.entries(attrs || {})) node.setAttribute(k, String(v));
-    return node;
-}
 
 function fmtDay(ts) {
     return new Date(ts * 1000).toLocaleDateString();
@@ -324,7 +326,7 @@ function renderTimeline() {
                 + (inBrush ? ' xr-tl-bar--active' : '')
                 + (b.count === 0 ? ' xr-tl-bar--empty' : '')
         });
-        const tip = document.createElementNS(SVG_NS, 'title');
+        const tip = svgEl('title', {});
         tip.textContent = `${fmtDay(b.start)} — ${b.count} item(s)`;
         bar.appendChild(tip);
         svg.appendChild(bar);
@@ -364,6 +366,51 @@ function renderLibrary() {
 }
 
 // ------------------------------------------------------------------
+// View router (Phase 12.5): library | entity spokes | case dashboard
+// ------------------------------------------------------------------
+
+function libraryChromeVisible(visible) {
+    $('#xr-tabs').hidden = !visible;
+    $('#xr-facets').hidden = !visible;
+    $('#xr-timeline').hidden = !visible || state.items.length === 0;
+    $('#xr-list').hidden = !visible;
+    $('#xr-empty').hidden = true;
+    $('#xr-view').hidden = visible;
+}
+
+const viewCallbacks = {
+    onBack: () => { state.view = { name: 'library' }; render(); },
+    onFocusEntity: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); render(); },
+    onOpenCase: (pubkey) => { state.view = { name: 'case', pubkey }; render(); },
+    onOpenGraph: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); render(); },
+    onExpand: (type) => { state.expandedTypes.add(type); render(); }
+};
+
+function render() {
+    if (state.view.name === 'entity') {
+        libraryChromeVisible(false);
+        renderEntityView($('#xr-view'), {
+            items: state.items,
+            entityIndex: state.entityIndex,
+            focusPubkey: state.view.pubkey,
+            expandedTypes: state.expandedTypes,
+            callbacks: viewCallbacks
+        });
+    } else if (state.view.name === 'case') {
+        libraryChromeVisible(false);
+        renderCaseView($('#xr-view'), {
+            items: state.items,
+            entityIndex: state.entityIndex,
+            casePubkey: state.view.pubkey,
+            callbacks: viewCallbacks
+        });
+    } else {
+        libraryChromeVisible(true);
+        renderLibrary();
+    }
+}
+
+// ------------------------------------------------------------------
 // Boot + refresh (cache-first since 12.3: render what we have, then
 // refresh incrementally in the background and re-render the union)
 // ------------------------------------------------------------------
@@ -375,11 +422,11 @@ const SYNC_OVERLAP_SECONDS = 3600;
 
 function rebuildItems(records) {
     state.records = records;
-    const entityIndex = {};
-    for (const e of state.entities) entityIndex[e.pubkey] = e;
+    state.entityIndex = {};
+    for (const e of state.entities) state.entityIndex[e.pubkey] = e;
     // The cache stores only the latest version per replaceable address,
     // so records arrive pre-deduped.
-    state.items = buildItems(records, { entityIndex });
+    state.items = buildItems(records, { entityIndex: state.entityIndex });
 }
 
 function setBusy(busy) {
@@ -413,7 +460,7 @@ async function boot({ full = false } = {}) {
         const cached = await loadRecords();
         if (cached.length > 0) {
             rebuildItems(cached);
-            renderLibrary();
+            render();
             setStatus(`${state.items.length} item(s) from cache — refreshing…`);
         }
 
@@ -453,7 +500,7 @@ async function boot({ full = false } = {}) {
 
         const stats = await saveRecords(records);
         rebuildItems(await loadRecords());
-        renderLibrary();
+        render();
 
         const failed = Object.keys(relayErrors);
         // Only advance the cursor when at least one relay answered in

--- a/src/portal/library.js
+++ b/src/portal/library.js
@@ -90,6 +90,9 @@ function buildItem(record, entityIndex) {
     let title = '';
     let sub = '';
     const haystack = [];
+    // Structured fields the entity/case views key on (Phase 12.5);
+    // null/absent where a kind doesn't carry them.
+    const extra = {};
 
     switch (event.kind) {
         case 30023: {
@@ -112,6 +115,8 @@ function buildItem(record, entityIndex) {
             if (c.isKey) bits.push('key claim');
             sub = bits.join(' · ');
             haystack.push(c.text, c.source, ...entityNames, c.title);
+            const dTag = (((event.tags || []).find((t) => t[0] === 'd')) || [])[1];
+            if (dTag && event.pubkey) extra.claimCoord = `30040:${event.pubkey}:${dTag}`;
             break;
         }
         case 30041: {
@@ -135,6 +140,9 @@ function buildItem(record, entityIndex) {
                 title = bits.join(' · ') || '(judgment)';
                 sub = a.rationale;
                 haystack.push(a.rationale, ...a.labels.map((l) => l.label), a.claimCoord);
+                extra.claimCoord = a.claimCoord;
+                extra.stance = a.stance;
+                extra.labelCount = a.labels.length;
             }
             break;
         }
@@ -145,6 +153,9 @@ function buildItem(record, entityIndex) {
                 title = r.relationship || '(link)';
                 sub = r.note || r.urls.join('  ');
                 haystack.push(r.relationship, r.note, ...r.urls);
+                extra.relationship = r.relationship;
+                extra.sourceCoord = r.source.coord || null;
+                extra.targetCoord = r.target.coord || null;
             }
             break;
         }
@@ -166,6 +177,7 @@ function buildItem(record, entityIndex) {
                 sub = [acct.displayName, acct.linkedEntityId ? `linked to ${acct.linkedEntityId}` : '']
                     .filter(Boolean).join(' · ');
                 haystack.push(acct.platform, acct.handle, acct.displayName, acct.stableId);
+                extra.linkedEntityId = acct.linkedEntityId || null;
             }
             break;
         }
@@ -244,7 +256,8 @@ function buildItem(record, entityIndex) {
         client,
         cases,
         created_at: event.created_at || 0,
-        searchText: haystack.filter(Boolean).join(' ').toLowerCase()
+        searchText: haystack.filter(Boolean).join(' ').toLowerCase(),
+        ...extra
     };
 }
 

--- a/tests/portal-graph.test.mjs
+++ b/tests/portal-graph.test.mjs
@@ -1,0 +1,216 @@
+// portal/graph.js tests — Phase 12.5 (docs/PORTAL_DESIGN.md).
+//
+// The ego graph is the headline "explore visually" surface, so its
+// selection rules are pinned: which claims spoke off the focus, how
+// assessments decorate (never node-ify), when a 30055 endpoint becomes
+// a ghost, sector caps with "+K more", and layout determinism.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const { buildEgoGraph, layoutEgoGraph } = await import('../src/portal/graph.js');
+const { buildItems } = await import('../src/portal/library.js');
+
+const USER_PK = 'a'.repeat(64);
+const FOCUS_PK = 'b'.repeat(64);   // person entity in the registry
+const OTHER_PK = 'c'.repeat(64);   // second person
+const CASE_PK = 'd'.repeat(64);    // case entity
+const ACCT_PK = 'e'.repeat(64);    // synthetic account pubkey
+
+const ENTITY_INDEX = {
+    [FOCUS_PK]: { entityId: 'entity_focus00000000', name: 'John Dehlin', type: 'person' },
+    [OTHER_PK]: { entityId: 'entity_other00000000', name: 'LDS Church', type: 'organization' },
+    [CASE_PK]:  { entityId: 'entity_case000000000', name: 'Excommunication', type: 'case' }
+};
+
+let nextId = 0;
+function rec(kind, tags, content = '', createdAt = 1000) {
+    return {
+        event: { id: `ev${nextId++}`, kind, pubkey: USER_PK, created_at: createdAt, tags, content },
+        relays: ['wss://r']
+    };
+}
+
+function claimRec(d, { about = [], source = [], createdAt = 1000, text = `claim ${d}` } = {}) {
+    const tags = [['d', d], ['r', 'https://example.com/v'], ['title', 'Src']];
+    for (const pk of about) tags.push(['p', pk, '', 'about']);
+    for (const pk of source) tags.push(['p', pk, '', 'source']);
+    return rec(30040, tags, text, createdAt);
+}
+
+function coord(d) { return `30040:${USER_PK}:${d}`; }
+
+function baseItems(records) {
+    nextId = 0;
+    return buildItems(records, { entityIndex: ENTITY_INDEX });
+}
+
+test('spokes: claims about vs sourced-by are distinct node types', () => {
+    const items = baseItems([
+        claimRec('claim_about1', { about: [FOCUS_PK], createdAt: 900 }),
+        claimRec('claim_about2', { about: [FOCUS_PK], createdAt: 800 }),
+        claimRec('claim_said1', { source: [FOCUS_PK], createdAt: 700 }),
+        claimRec('claim_unrelated', { about: [OTHER_PK], createdAt: 600 })
+    ]);
+    const g = buildEgoGraph(items, { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const types = g.nodes.map((n) => n.nodeType).sort();
+    assert.deepEqual(types.filter((t) => t === 'claim'), ['claim', 'claim']);
+    assert.deepEqual(types.filter((t) => t === 'sourced-claim'), ['sourced-claim']);
+    assert.equal(g.counts.claimsAbout, 2);
+    assert.equal(g.counts.claimsSourced, 1);
+    // The unrelated claim never appears.
+    assert.ok(!g.nodes.some((n) => n.id === `claim:${coord('claim_unrelated')}`));
+    // Every ring node has a spoke from the focus.
+    for (const node of g.nodes) {
+        assert.ok(g.edges.some((e) => e.from === 'focus' && e.to === node.id),
+            `missing spoke for ${node.id}`);
+    }
+});
+
+test('co-tagged entities and cases ring the focus', () => {
+    const items = baseItems([
+        claimRec('claim_1', { about: [FOCUS_PK, OTHER_PK, CASE_PK] }),
+        claimRec('claim_2', { about: [FOCUS_PK, OTHER_PK] })
+    ]);
+    const g = buildEgoGraph(items, { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const entityNode = g.nodes.find((n) => n.nodeType === 'entity');
+    assert.equal(entityNode.label, 'LDS Church');
+    assert.equal(entityNode.count, 2);
+    const caseNode = g.nodes.find((n) => n.nodeType === 'case');
+    assert.equal(caseNode.label, 'Excommunication');
+    // The co-tagged entity wires to the claims it shares with the focus.
+    const mentions = g.edges.filter((e) => e.kind === 'mention' && e.to === entityNode.id);
+    assert.equal(mentions.length, 2);
+});
+
+test('assessments decorate their claim node — latest wins, never a node', () => {
+    const records = [claimRec('claim_1', { about: [FOCUS_PK] })];
+    records.push(rec(30054, [
+        ['d', 'assess:1'], ['a', coord('claim_1')], ['r', 'https://example.com/v'],
+        ['stance', '1'], ['L', 'xray/assessment'], ['l', 'misleading', 'xray/assessment']
+    ], 'old judgment', 500));
+    records.push(rec(30054, [
+        ['d', 'assess:1b'], ['a', coord('claim_1')], ['r', 'https://example.com/v'],
+        ['stance', '-2'], ['L', 'xray/assessment'],
+        ['l', 'misleading', 'xray/assessment'], ['l', 'flip-flop', 'xray/assessment']
+    ], 'newer judgment', 900));
+    const g = buildEgoGraph(baseItems(records), { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const claimNode = g.nodes.find((n) => n.nodeType === 'claim');
+    assert.equal(claimNode.stance, -2);
+    assert.equal(claimNode.labelCount, 2);
+    assert.ok(!g.nodes.some((n) => n.nodeType === 'assessment'));
+});
+
+test('30055 contradiction: both endpoints visible → warn edge between them', () => {
+    const records = [
+        claimRec('claim_1', { about: [FOCUS_PK] }),
+        claimRec('claim_2', { about: [FOCUS_PK] }),
+        rec(30055, [
+            ['d', 'rel:1'],
+            ['a', coord('claim_1'), '', 'source'], ['a', coord('claim_2'), '', 'target'],
+            ['relationship', 'contradicts'], ['r', 'https://example.com/v']
+        ], '', 100)
+    ];
+    const g = buildEgoGraph(baseItems(records), { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const rel = g.edges.find((e) => e.kind === 'relationship');
+    assert.equal(rel.warn, true);
+    assert.equal(rel.from, `claim:${coord('claim_1')}`);
+    assert.equal(rel.to, `claim:${coord('claim_2')}`);
+    assert.ok(!g.nodes.some((n) => n.nodeType === 'ghost-claim'));
+});
+
+test('30055 with an out-of-ego endpoint grows a ghost node — the ⚠ is never hidden', () => {
+    const records = [
+        claimRec('claim_1', { about: [FOCUS_PK] }),
+        claimRec('claim_far', { about: [OTHER_PK] }),  // visible in corpus, not in ego
+        rec(30055, [
+            ['d', 'rel:1'],
+            ['a', coord('claim_1'), '', 'source'], ['a', coord('claim_far'), '', 'target'],
+            ['relationship', 'contradicts'], ['r', 'https://example.com/v']
+        ], '', 100)
+    ];
+    const g = buildEgoGraph(baseItems(records), { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const ghost = g.nodes.find((n) => n.nodeType === 'ghost-claim');
+    assert.ok(ghost, 'ghost endpoint expected');
+    assert.equal(ghost.coord, coord('claim_far'));
+    const rel = g.edges.find((e) => e.kind === 'relationship');
+    assert.equal(rel.warn, true);
+    assert.equal(rel.to, ghost.id);
+});
+
+test('sector cap: newest N kept, "+K more" node appears, expansion lifts it', () => {
+    const records = [];
+    for (let i = 0; i < 30; i++) {
+        records.push(claimRec(`claim_${String(i).padStart(2, '0')}`, { about: [FOCUS_PK], createdAt: 1000 + i }));
+    }
+    const items = baseItems(records);
+    const capped = buildEgoGraph(items, { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX, sectorCap: 24 });
+    assert.equal(capped.nodes.filter((n) => n.nodeType === 'claim').length, 24);
+    const more = capped.nodes.find((n) => n.nodeType === 'more' && n.forType === 'claim');
+    assert.equal(more.label, '+6 more');
+    // Newest first: claim_29 kept, claim_00 dropped.
+    assert.ok(capped.nodes.some((n) => n.id === `claim:${coord('claim_29')}`));
+    assert.ok(!capped.nodes.some((n) => n.id === `claim:${coord('claim_00')}`));
+
+    const expanded = buildEgoGraph(items, {
+        focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX, sectorCap: 24,
+        expandedTypes: new Set(['claim'])
+    });
+    assert.equal(expanded.nodes.filter((n) => n.nodeType === 'claim').length, 30);
+    assert.ok(!expanded.nodes.some((n) => n.nodeType === 'more'));
+});
+
+test('linked accounts spoke off the focus via linked-entity', () => {
+    const records = [
+        rec(32126, [
+            ['d', 'youtube:UC1'], ['p', ACCT_PK, '', 'account'],
+            ['account-platform', 'youtube'], ['account-id', 'UC1'],
+            ['account-username', 'mormonstories'],
+            ['linked-entity', 'entity_focus00000000']
+        ], '', 100),
+        rec(32126, [
+            ['d', 'youtube:UC2'], ['p', 'f'.repeat(64), '', 'account'],
+            ['account-platform', 'youtube'], ['account-id', 'UC2'],
+            ['linked-entity', 'entity_other00000000']
+        ], '', 90)
+    ];
+    const g = buildEgoGraph(baseItems(records), { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const accounts = g.nodes.filter((n) => n.nodeType === 'account');
+    assert.equal(accounts.length, 1);
+    assert.match(accounts[0].label, /mormonstories/);
+});
+
+test('focus falls back to the kind-0 profile name when not in the registry', () => {
+    const stranger = '9'.repeat(64);
+    const records = [rec(0, [], JSON.stringify({ name: 'Mystery Guest' }), 50)];
+    records[0].event.pubkey = stranger;
+    const g = buildEgoGraph(baseItems(records), { focusPubkey: stranger, entityIndex: ENTITY_INDEX });
+    assert.equal(g.focus.name, 'Mystery Guest');
+});
+
+test('layout is deterministic, centered, and gives every node a distinct position', () => {
+    const records = [
+        claimRec('claim_1', { about: [FOCUS_PK, OTHER_PK, CASE_PK] }),
+        claimRec('claim_2', { about: [FOCUS_PK] }),
+        claimRec('claim_3', { source: [FOCUS_PK] })
+    ];
+    const items = baseItems(records);
+    const g = buildEgoGraph(items, { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const a = layoutEgoGraph(g, { size: 720 });
+    const b = layoutEgoGraph(g, { size: 720 });
+    assert.deepEqual(a, b);
+    assert.deepEqual(a.focus, { x: 360, y: 360 });
+    const seen = new Set();
+    for (const node of g.nodes) {
+        const pos = a[node.id];
+        assert.ok(pos, `no position for ${node.id}`);
+        assert.ok(pos.x >= 0 && pos.x <= 720 && pos.y >= 0 && pos.y <= 720, `out of bounds: ${node.id}`);
+        const key = `${Math.round(pos.x)}:${Math.round(pos.y)}`;
+        assert.ok(!seen.has(key), `overlapping nodes at ${key}`);
+        seen.add(key);
+    }
+});


### PR DESCRIPTION
Fifth Phase 12 slice (design `docs/PORTAL_DESIGN.md` #48; prior slices #49–#52). The acceptance-walk centerpiece: focus an entity, walk its claims, the people/orgs around it, and a ⚠ contradiction; open a case and see its published artifacts.

- **Pure model** (`graph.js`): ego graph per the agreed Q2/Q3 answers — hand-rolled deterministic radial layout, type sectors, newest-first caps with expandable "+K more", assessments decorating claim nodes (never node-ifying), ⚠ `contradicts` edges with **ghost endpoints** when the counterpart claim is outside the ego set.
- **Entity view** (`entity-view.js`): SVG spokes, stance-tinted claims, drag-pan/wheel-zoom, locate pulse, refocus on entity click, case click-through, detail card with raw event.
- **Case dashboard** (`case-view.js`): rollup by type, density strip, member chips (→ spokes), claims with stance/⚠ badges — the publish-side complement of the Phase 11.5 local dashboard.
- Router in `index.js`; Library rows/badges link in; refreshes re-render the active view.

No graph dependency — vanilla SVG, Firefox 128 floor untouched.

Gates: build ✅ · 660/660 tests ✅ (9 new) · web-ext lint 0 errors ✅

Smoke: Library → click an entity's **✳ Spokes** → walk claims/co-tagged/cases → click a ⚠ edge's ghost endpoint → open a case badge → dashboard shows rollup + claims with badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)