### PR TITLE
feat(portal): inspector + reconciliation (Phase 12.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Portal inspector + reconciliation** (Phase 12.6). Clicking any
+  Library row opens an **inspector drawer**: the addressable
+  coordinate, event id, author, **which relays hold the event**, its
+  ledger status, the raw signed JSON (copyable), a jump to the source
+  URL, and for articles a read-only **Open in reader** that
+  reconstructs the capture from its signed event. Above the list, the
+  **reconciliation panel** diffs the local publish ledger against
+  relay truth — "ledger says N published; relays confirm M; K
+  missing; R remote-only" — matching by exact event id first, then by
+  replaceable address (so a republish from another device still
+  confirms), with the missing entries listed. Rows wear ✓ /
+  ◌ remote-only chips; comments/accounts/32125 (no publish ledger)
+  stay neutral by design. Strictly display-only: the portal never
+  writes `markPublished` or imports remote events into local models.
+
 - **Portal entity spokes graph + case dashboard** (Phase 12.5). The
   "explore visually" surface, per the agreed design: a hand-rolled
   SVG **ego graph** — focused entity centered, deterministic radial

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -907,9 +907,9 @@ Slices (one PR each):
 - ✅ **12.4** Timeline — density buckets + brush filtering. — #52
 - ✅ **12.5** Entity & case views — radial spokes graph + case
   dashboard. — #53
-- ⬜ **12.6** Inspector & reconciliation — raw events, per-relay
+- ✅ **12.6** Inspector & reconciliation — raw events, per-relay
   holdings, ledger diff (confirmed / missing / remote-only), privacy
-  footer.
+  footer. — #54
 - ⬜ **12.7** Hardening — adversarial review + fixes, SMOKE_TEST
   §Phase 12, docs pass.
 

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -533,6 +533,94 @@ button.xr-badge--case { cursor: pointer; background: transparent; }
   color: var(--xr-text);
 }
 
+/* ---------------- reconciliation panel (12.6) ---------------- */
+
+.xr-portal__recon {
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--xr-border);
+  font-size: 13px;
+}
+
+.xr-recon__line { color: var(--xr-text-dim); }
+.xr-recon__line--warn { color: var(--xr-warning); }
+
+.xr-portal__recon details { margin-top: 6px; }
+.xr-portal__recon summary { cursor: pointer; color: var(--xr-warning); font-size: 12px; }
+
+/* ---------------- inspector drawer (12.6) ---------------- */
+
+.xr-portal__inspector {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(440px, 90vw);
+  background: var(--xr-surface);
+  border-left: 1px solid var(--xr-border);
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.35);
+  padding: 14px 16px 24px;
+  overflow-y: auto;
+  z-index: 50;
+}
+
+.xr-inspector__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.xr-inspector__head .xr-chip__remove { margin-left: auto; font-size: 16px; }
+
+.xr-inspector__title { font-weight: 600; overflow-wrap: anywhere; }
+
+.xr-inspector__status {
+  display: inline-block;
+  margin: 8px 0;
+}
+
+.xr-inspector__fields { margin: 8px 0; font-size: 13px; }
+.xr-inspector__fields dt { color: var(--xr-text-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; margin-top: 8px; }
+.xr-inspector__fields dd { margin: 2px 0 0; overflow-wrap: anywhere; }
+
+.xr-inspector__mono { font-family: ui-monospace, Menlo, monospace; font-size: 12px; overflow-wrap: anywhere; }
+
+.xr-inspector__relays { margin: 10px 0; }
+
+.xr-inspector__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.xr-inspector__actions a { text-decoration: none; }
+
+.xr-inspector__raw pre {
+  margin: 8px 0 0;
+  padding: 10px;
+  background: var(--xr-bg);
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  overflow: auto;
+  max-height: 50vh;
+  font-size: 11px;
+  font-family: ui-monospace, Menlo, monospace;
+}
+
+.xr-row__title--link {
+  border: none;
+  background: none;
+  color: var(--xr-text);
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+
+.xr-row__title--link:hover { color: var(--xr-primary); }
+
 /* ---------------- footer ---------------- */
 
 .xr-portal__footer {

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -53,6 +53,10 @@
 
   <div class="xr-portal__status" id="xr-status" hidden></div>
 
+  <!-- Ledger vs relay truth (Phase 12.6): "ledger says N; relays
+       confirm M; K missing; R remote-only" + the missing list. -->
+  <section class="xr-portal__recon" id="xr-recon" hidden></section>
+
   <main class="xr-portal__main">
     <div class="xr-portal__empty" id="xr-empty" hidden></div>
     <ol class="xr-portal__list" id="xr-list"></ol>
@@ -60,6 +64,9 @@
          Populated by entity-view.js / case-view.js via the router. -->
     <section class="xr-portal__view" id="xr-view" hidden></section>
   </main>
+
+  <!-- Item inspector drawer (Phase 12.6). -->
+  <aside class="xr-portal__inspector" id="xr-inspector" hidden></aside>
 
   <footer class="xr-portal__footer">
     <span id="xr-footer-relays"></span>

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -24,6 +24,8 @@ import { buildBuckets, brushRange } from './timeline.js';
 import { el, svgEl, clear, truncate, shortKey } from './dom.js';
 import { renderEntityView } from './entity-view.js';
 import { renderCaseView } from './case-view.js';
+import { loadLocalLedger, reconcile } from './reconcile.js';
+import { renderInspector } from './inspector.js';
 
 const $ = (sel) => document.querySelector(sel);
 
@@ -39,6 +41,7 @@ const state = {
     groupByDomain: false,
     view: { name: 'library' },   // | {name:'entity', pubkey} | {name:'case', pubkey}
     expandedTypes: new Set(),    // graph sectors the user expanded
+    reconciliation: null,        // {summary, missing, statusByEventId} (12.6)
     relayErrors: {},
     truncated: false,
     loading: false
@@ -166,13 +169,34 @@ function casePubkeyFor(name) {
     return null;
 }
 
+function openInspector(item) {
+    const status = state.reconciliation
+        ? state.reconciliation.statusByEventId[item.id] || 'no-ledger'
+        : 'no-ledger';
+    renderInspector($('#xr-inspector'), item, { status });
+}
+
 function buildRow(item) {
     const row = el('li', 'xr-row');
     const head = el('div', 'xr-row__head');
     head.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
-    head.appendChild(el('span', 'xr-row__title', truncate(item.title, 160)));
+    const titleEl = el('button', 'xr-row__title xr-row__title--link', truncate(item.title, 160));
+    titleEl.type = 'button';
+    titleEl.title = 'Inspect — raw event, relays holding it, ledger status';
+    titleEl.addEventListener('click', () => openInspector(item));
+    head.appendChild(titleEl);
 
     const badges = el('span', 'xr-row__badges');
+    const status = state.reconciliation && state.reconciliation.statusByEventId[item.id];
+    if (status === 'confirmed') {
+        const b = el('span', 'xr-badge xr-badge--agree', '✓');
+        b.title = 'In the local publish ledger and on the relays';
+        badges.appendChild(b);
+    } else if (status === 'remote-only') {
+        const b = el('span', 'xr-badge xr-badge--case', '◌ remote-only');
+        b.title = 'On the relays but not in this device\'s publish ledger — published from another device, or before the ledger existed';
+        badges.appendChild(b);
+    }
     const relayBadge = el('span', 'xr-badge', `${item.relays.length} relay${item.relays.length === 1 ? '' : 's'}`);
     relayBadge.title = item.relays.join('\n');
     badges.appendChild(relayBadge);
@@ -210,18 +234,8 @@ function buildRow(item) {
     row.appendChild(head);
     if (item.sub) row.appendChild(el('div', 'xr-row__sub', truncate(item.sub, 240)));
 
-    const details = el('details');
-    details.appendChild(el('summary', null, 'Raw event'));
-    const pre = el('pre');
-    // Serialize lazily — hundreds of large 30023s stringified up front
-    // would make first paint pay for JSON nobody opened.
-    details.addEventListener('toggle', () => {
-        if (details.open && !pre.textContent) {
-            pre.textContent = JSON.stringify(item.event, null, 2);
-        }
-    });
-    details.appendChild(pre);
-    row.appendChild(details);
+    // Raw event, relay holdings, and ledger status live in the
+    // inspector drawer (12.6) — click the row title.
     return row;
 }
 
@@ -358,10 +372,67 @@ function renderTimeline() {
     host.appendChild(svg);
 }
 
+// ------------------------------------------------------------------
+// Reconciliation (12.6): ledger vs relay truth, display-only
+// ------------------------------------------------------------------
+
+async function updateReconciliation() {
+    try {
+        const ledger = await loadLocalLedger({ pubkeys: state.identities.map((i) => i.pubkey) });
+        state.reconciliation = reconcile(ledger, state.items);
+    } catch (err) {
+        Utils.error('Portal reconciliation failed:', err);
+        state.reconciliation = null;
+    }
+}
+
+function renderReconPanel() {
+    const host = $('#xr-recon');
+    clear(host);
+    const r = state.reconciliation;
+    if (!r || (r.summary.ledgerPublished === 0 && r.summary.remoteOnly === 0)) {
+        host.hidden = true;
+        return;
+    }
+    host.hidden = false;
+    const s = r.summary;
+    const line = el('div', 'xr-recon__line',
+        `Local ledger says ${s.ledgerPublished} published; the relays confirm ${s.confirmed}`
+        + (s.missing ? `; ${s.missing} missing` : '')
+        + (s.remoteOnly ? `; ${s.remoteOnly} on relays only (another device, or pre-ledger)` : '')
+        + '.');
+    line.classList.toggle('xr-recon__line--warn', s.missing > 0);
+    host.appendChild(line);
+
+    if (r.missing.length > 0) {
+        const details = el('details');
+        details.appendChild(el('summary', null, `Missing from the relays (${r.missing.length})`));
+        const ul = el('ol', 'xr-portal__list');
+        for (const entry of r.missing) {
+            const row = el('li', 'xr-row');
+            const head = el('div', 'xr-row__head');
+            head.appendChild(el('span', 'xr-row__kind', entry.source));
+            head.appendChild(el('span', 'xr-row__title', truncate(entry.label, 140)));
+            if (entry.publishedAt) {
+                head.appendChild(el('span', 'xr-row__date',
+                    'marked published ' + new Date(entry.publishedAt * 1000).toLocaleString()));
+            }
+            row.appendChild(head);
+            row.appendChild(el('div', 'xr-row__sub',
+                `event ${entry.publishedEventId ? entry.publishedEventId.slice(0, 16) + '…' : '?'} — `
+                + 'no configured relay returned it. It may have been rejected, expired, or published to relays not configured here.'));
+            ul.appendChild(row);
+        }
+        details.appendChild(ul);
+        host.appendChild(details);
+    }
+}
+
 function renderLibrary() {
     renderTabs();
     renderFacets();
     renderTimeline();
+    renderReconPanel();
     renderRows(applyFilters(state.items, state.filters));
 }
 
@@ -373,16 +444,23 @@ function libraryChromeVisible(visible) {
     $('#xr-tabs').hidden = !visible;
     $('#xr-facets').hidden = !visible;
     $('#xr-timeline').hidden = !visible || state.items.length === 0;
+    $('#xr-recon').hidden = !visible || !state.reconciliation;
     $('#xr-list').hidden = !visible;
     $('#xr-empty').hidden = true;
     $('#xr-view').hidden = visible;
 }
 
+function closeInspector() {
+    const host = $('#xr-inspector');
+    host.hidden = true;
+    clear(host);
+}
+
 const viewCallbacks = {
-    onBack: () => { state.view = { name: 'library' }; render(); },
-    onFocusEntity: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); render(); },
-    onOpenCase: (pubkey) => { state.view = { name: 'case', pubkey }; render(); },
-    onOpenGraph: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); render(); },
+    onBack: () => { state.view = { name: 'library' }; closeInspector(); render(); },
+    onFocusEntity: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); closeInspector(); render(); },
+    onOpenCase: (pubkey) => { state.view = { name: 'case', pubkey }; closeInspector(); render(); },
+    onOpenGraph: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); closeInspector(); render(); },
     onExpand: (type) => { state.expandedTypes.add(type); render(); }
 };
 
@@ -462,6 +540,8 @@ async function boot({ full = false } = {}) {
             rebuildItems(cached);
             render();
             setStatus(`${state.items.length} item(s) from cache — refreshing…`);
+            // Ledger diff against the cached view while the refresh runs.
+            updateReconciliation().then(() => renderReconPanel());
         }
 
         if (state.identities.length === 0 && state.entities.length === 0) {
@@ -500,6 +580,7 @@ async function boot({ full = false } = {}) {
 
         const stats = await saveRecords(records);
         rebuildItems(await loadRecords());
+        await updateReconciliation();
         render();
 
         const failed = Object.keys(relayErrors);

--- a/src/portal/inspector.js
+++ b/src/portal/inspector.js
@@ -1,0 +1,120 @@
+// Portal item inspector (Phase 12.6, docs/PORTAL_DESIGN.md).
+//
+// The provenance drawer: for any item — parsed summary, the
+// addressable coordinate, which relays actually hold it, its
+// reconciliation status against the local ledger, the raw signed
+// event (copyable), a jump to the source URL, and for articles a
+// read-only round-trip back into the reader via the existing
+// `xray:reader:open` message (the event reconstructs to an article
+// object; nothing is written anywhere).
+
+import { el, clear, truncate, shortKey } from './dom.js';
+import { kindLabel } from './library.js';
+import { replaceableKey } from '../shared/nostr-events.js';
+import { EventBuilder } from '../shared/event-builder.js';
+import { Utils } from '../shared/utils.js';
+
+const STATUS_TEXT = {
+    'confirmed':   ['✓ in ledger & on relays', 'xr-badge--agree'],
+    'remote-only': ['◌ remote-only — not in this device\'s ledger', 'xr-badge--case'],
+    'no-ledger':   ['— no local publish ledger for this kind', '']
+};
+
+/**
+ * @param {HTMLElement} host    the drawer container (#xr-inspector)
+ * @param {object} item         library item
+ * @param {object} opts
+ * @param {string} opts.status  reconciliation status for this event id
+ * @param {function} opts.onClose
+ */
+export function renderInspector(host, item, { status = 'no-ledger', onClose } = {}) {
+    clear(host);
+    host.hidden = false;
+
+    const head = el('div', 'xr-inspector__head');
+    head.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
+    head.appendChild(el('span', 'xr-inspector__title', truncate(item.title, 120)));
+    const close = el('button', 'xr-chip__remove', '✕');
+    close.type = 'button';
+    close.title = 'Close';
+    close.addEventListener('click', () => { host.hidden = true; clear(host); if (onClose) onClose(); });
+    head.appendChild(close);
+    host.appendChild(head);
+
+    const [statusText, statusClass] = STATUS_TEXT[status] || STATUS_TEXT['no-ledger'];
+    host.appendChild(el('div', `xr-badge xr-inspector__status ${statusClass}`, statusText));
+
+    const dl = el('dl', 'xr-inspector__fields');
+    const field = (label, value, mono) => {
+        if (!value) return;
+        dl.appendChild(el('dt', null, label));
+        const dd = el('dd', mono ? 'xr-inspector__mono' : null, value);
+        dl.appendChild(dd);
+    };
+    field('Published', item.created_at ? new Date(item.created_at * 1000).toLocaleString() : '');
+    const addr = replaceableKey(item.event);
+    field('Coordinate', addr, true);
+    field('Event id', item.event.id, true);
+    field('Author', shortKey(item.event.pubkey || ''), true);
+    if (item.cases.length) field('Cases', item.cases.join(', '));
+    host.appendChild(dl);
+
+    const relaySection = el('div', 'xr-inspector__relays');
+    relaySection.appendChild(el('h3', 'xr-case__heading', `Held by ${item.relays.length} relay(s)`));
+    for (const url of item.relays) relaySection.appendChild(el('div', 'xr-inspector__mono', url));
+    if (item.relays.length === 0) {
+        relaySection.appendChild(el('div', 'xr-view__empty', 'No relay returned this event in the last sync.'));
+    }
+    host.appendChild(relaySection);
+
+    const actions = el('div', 'xr-inspector__actions');
+    if (item.url) {
+        const a = el('a', 'xr-portal__btn xr-portal__btn--ghost', '↗ Source URL');
+        a.href = item.url;
+        a.target = '_blank';
+        a.rel = 'noreferrer noopener';
+        actions.appendChild(a);
+    }
+    const copy = el('button', 'xr-portal__btn xr-portal__btn--ghost', 'Copy raw event');
+    copy.type = 'button';
+    copy.addEventListener('click', async () => {
+        try {
+            await navigator.clipboard.writeText(JSON.stringify(item.event, null, 2));
+            copy.textContent = 'Copied ✓';
+            setTimeout(() => { copy.textContent = 'Copy raw event'; }, 1500);
+        } catch (err) {
+            Utils.error('Inspector: clipboard write failed', err);
+        }
+    });
+    actions.appendChild(copy);
+
+    if (item.kind === 30023) {
+        const open = el('button', 'xr-portal__btn', 'Open in reader');
+        open.type = 'button';
+        open.title = 'Reconstruct this capture from its signed event and open it read-only in the reader';
+        open.addEventListener('click', () => {
+            const article = EventBuilder.reconstructArticleFromEvent(item.event);
+            if (!article) {
+                open.textContent = 'Could not reconstruct';
+                return;
+            }
+            const id = crypto.randomUUID();
+            chrome.runtime.sendMessage({ type: 'xray:reader:open', id, article }, (resp) => {
+                if (!resp || !resp.ok) {
+                    Utils.error('Inspector: reader open failed', resp && resp.error);
+                    open.textContent = 'Reader open failed';
+                }
+            });
+        });
+        actions.appendChild(open);
+    }
+    host.appendChild(actions);
+
+    const details = el('details', 'xr-inspector__raw');
+    details.open = true;
+    details.appendChild(el('summary', null, 'Raw signed event'));
+    const pre = el('pre');
+    pre.textContent = JSON.stringify(item.event, null, 2);
+    details.appendChild(pre);
+    host.appendChild(details);
+}

--- a/src/portal/reconcile.js
+++ b/src/portal/reconcile.js
@@ -1,0 +1,211 @@
+// Portal reconciliation (Phase 12.6, docs/PORTAL_DESIGN.md).
+//
+// The local ledger records INTENT ("I published this"); the relays
+// record TRUTH. This module diffs them — strictly read-only, per the
+// signed-off design (Q5): the portal never writes markPublished and
+// never imports remote-only events into local models.
+//
+// Matching is two-tier per ledger entry:
+//   1. exact     — the recorded publishedEventId is on the relays
+//   2. by address — some version of the same replaceable address is
+//                   (a republish from any device replaces in place,
+//                   so the original event id legitimately disappears)
+// Neither ⇒ MISSING — the "ledger says 40, relays confirm 37" gap.
+//
+// The signing pubkey is not recorded on assessment/link/article
+// records (only claims grew publishedPubkey in 11.1), so their
+// candidate addresses fan out across the portal's resolved identity
+// set — exactly the set the corpus was queried with.
+//
+// Kinds with no publish ledger (comments 30041, accounts 32126,
+// 32125, 1985, 10002, 30078, dormant) are 'no-ledger': present on
+// relays by design, never an anomaly.
+
+import { ClaimModel } from '../shared/claim-model.js';
+import { AssessmentModel } from '../shared/assessment-model.js';
+import { EvidenceLinker } from '../shared/evidence-linker.js';
+import { EntityModel } from '../shared/entity-model.js';
+import { listArticles } from '../shared/archive-cache.js';
+import { Crypto } from '../shared/crypto.js';
+import { isSymmetricRelationship } from '../shared/assessment-taxonomy.js';
+import { replaceableKey } from '../shared/nostr-events.js';
+import { Utils } from '../shared/utils.js';
+
+const LEDGERED_KINDS = new Set([30023, 30040, 30054, 30055, 0]);
+
+async function sha16(s) {
+    return (await Crypto.sha256(String(s))).slice(0, 16);
+}
+
+const isCoord = (ref) => typeof ref === 'string' && ref.startsWith('30040:');
+
+/**
+ * Collect every local "I published this" record, with the candidate
+ * relay addresses it should be discoverable under.
+ *
+ * @param {{pubkeys?: string[]}} opts  the resolved identity set — used
+ *        where the signer's pubkey wasn't recorded locally
+ * @returns {Promise<Array<{source, localId, label, publishedAt, publishedEventId, addrs}>>}
+ */
+export async function loadLocalLedger({ pubkeys = [] } = {}) {
+    const entries = [];
+
+    try {
+        const claims = await ClaimModel.getAll();
+        for (const c of Object.values(claims || {})) {
+            if (!c || !c.publishedAt || !c.publishedEventId) continue;
+            const keys = Array.isArray(c.publishedPubkeys) && c.publishedPubkeys.length
+                ? c.publishedPubkeys
+                : (c.publishedPubkey ? [c.publishedPubkey] : []);
+            entries.push({
+                source: 'claim',
+                localId: c.id,
+                label: c.text || c.id,
+                publishedAt: c.publishedAt,
+                publishedEventId: c.publishedEventId,
+                addrs: keys.map((pk) => `30040:${pk}:${c.id}`)
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: claim ledger scan failed', err); }
+
+    try {
+        const assessments = await AssessmentModel.getAll();
+        for (const a of Object.values(assessments || {})) {
+            if (!a || !a.publishedAt || !a.publishedEventId) continue;
+            const coord = a.claim_ref && a.claim_ref.coord;
+            const addrs = [];
+            if (isCoord(coord)) {
+                const d = 'assess:' + (await sha16(coord));
+                for (const pk of pubkeys) addrs.push(`30054:${pk}:${d}`);
+            }
+            entries.push({
+                source: 'assessment',
+                localId: a.id,
+                label: (a.claim_ref && a.claim_ref.text) || a.rationale || a.id,
+                publishedAt: a.publishedAt,
+                publishedEventId: a.publishedEventId,
+                addrs
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: assessment ledger scan failed', err); }
+
+    try {
+        const links = await EvidenceLinker.getAll();
+        for (const l of Object.values(links || {})) {
+            if (!l || !l.publishedAt || !l.publishedEventId) continue;
+            const addrs = [];
+            // The wire d is recomputable only when both endpoints are
+            // coordinates (own claims backfill coords at publish, 11.7).
+            if (isCoord(l.source) && isCoord(l.target)) {
+                let a = l.source;
+                let b = l.target;
+                if (isSymmetricRelationship(l.relationship) && b < a) [a, b] = [b, a];
+                const d = 'rel:' + (await sha16(`${a}|${b}|${l.relationship}`));
+                for (const pk of pubkeys) addrs.push(`30055:${pk}:${d}`);
+            }
+            entries.push({
+                source: 'link',
+                localId: l.id,
+                label: `${l.relationship || 'link'} (${l.id})`,
+                publishedAt: l.publishedAt,
+                publishedEventId: l.publishedEventId,
+                addrs
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: link ledger scan failed', err); }
+
+    try {
+        const all = await EntityModel.getAll();
+        for (const e of Object.values(all || {})) {
+            if (!e || !e.publishedAt || !e.publishedEventId) continue;
+            const pk = e.keypair && e.keypair.pubkey;
+            entries.push({
+                source: 'entity',
+                localId: e.id,
+                label: e.name || e.id,
+                publishedAt: e.publishedAt,
+                publishedEventId: e.publishedEventId,
+                addrs: pk ? [`0:${pk}`] : []
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: entity ledger scan failed', err); }
+
+    try {
+        const articles = await listArticles();
+        for (const rec of (articles || [])) {
+            if (!rec || !rec.publishedToRelay || !rec.publishedEventId) continue;
+            entries.push({
+                source: 'article',
+                localId: rec.urlHash,
+                label: (rec.article && rec.article.title) || rec.url || rec.urlHash,
+                publishedAt: rec.cachedAt || null,
+                publishedEventId: rec.publishedEventId,
+                addrs: pubkeys.map((pk) => `30023:${pk}:${rec.urlHash}`)
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: article ledger scan failed', err); }
+
+    return entries;
+}
+
+/**
+ * Pure diff of ledger entries against the fetched corpus items.
+ *
+ * @param {Array} ledger  loadLocalLedger() output
+ * @param {Array} items   library items (each carries .event)
+ * @returns {{
+ *   summary: {ledgerPublished, confirmed, missing, remoteOnly},
+ *   missing: Array,                       // ledger entries no relay returned
+ *   statusByEventId: Object<string,string> // 'confirmed' | 'remote-only' | 'no-ledger'
+ * }}
+ */
+export function reconcile(ledger, items) {
+    const list = Array.isArray(items) ? items : [];
+    const entries = Array.isArray(ledger) ? ledger : [];
+
+    const itemIds = new Set(list.map((i) => i.id));
+    const itemAddrs = new Set();
+    for (const item of list) {
+        const addr = replaceableKey(item.event);
+        if (addr) itemAddrs.add(addr);
+    }
+
+    const missing = [];
+    let confirmed = 0;
+    const ledgerIds = new Set();
+    const ledgerAddrs = new Set();
+    for (const entry of entries) {
+        ledgerIds.add(entry.publishedEventId);
+        for (const addr of entry.addrs) ledgerAddrs.add(addr);
+        if (itemIds.has(entry.publishedEventId)) { confirmed++; entry.status = 'confirmed'; }
+        else if (entry.addrs.some((a) => itemAddrs.has(a))) { confirmed++; entry.status = 'confirmed-version'; }
+        else { entry.status = 'missing'; missing.push(entry); }
+    }
+
+    const statusByEventId = {};
+    let remoteOnly = 0;
+    for (const item of list) {
+        if (!LEDGERED_KINDS.has(item.kind)) {
+            statusByEventId[item.id] = 'no-ledger';
+            continue;
+        }
+        const addr = replaceableKey(item.event);
+        if (ledgerIds.has(item.id) || (addr && ledgerAddrs.has(addr))) {
+            statusByEventId[item.id] = 'confirmed';
+        } else {
+            statusByEventId[item.id] = 'remote-only';
+            remoteOnly++;
+        }
+    }
+
+    return {
+        summary: {
+            ledgerPublished: entries.length,
+            confirmed,
+            missing: missing.length,
+            remoteOnly
+        },
+        missing,
+        statusByEventId
+    };
+}

--- a/tests/portal-reconcile.test.mjs
+++ b/tests/portal-reconcile.test.mjs
@@ -1,0 +1,189 @@
+// portal/reconcile.js tests — Phase 12.6 (docs/PORTAL_DESIGN.md).
+//
+// Two layers under test: the pure ledger-vs-items diff (confirmed by
+// exact event id, confirmed by replaceable address when republished,
+// missing, remote-only, no-ledger) and the storage-touching
+// loadLocalLedger (real models against the chrome shim +
+// fake-indexeddb, pinning every addr-derivation rule — claim
+// coordinates from publishedPubkeys, the recomputable assess:/rel:
+// d-tags, entity kind-0 addresses, article urlHash addresses).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+await import('fake-indexeddb/auto');
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const { loadLocalLedger, reconcile } = await import('../src/portal/reconcile.js');
+const { Storage } = await import('../src/shared/storage.js');
+const { Crypto } = await import('../src/shared/crypto.js');
+const { saveArticle } = await import('../src/shared/archive-cache.js');
+
+const PK_A = 'a'.repeat(64);
+const PK_B = 'b'.repeat(64);
+const ENTITY_PK = 'f'.repeat(64);
+const EV = (n) => n.repeat(64);
+
+function item(id, kind, pubkey, { d, relays = ['wss://r'] } = {}) {
+    return {
+        id, kind,
+        event: { id, kind, pubkey, created_at: 1000, tags: d !== undefined ? [['d', d]] : [], content: '' },
+        relays
+    };
+}
+
+// ------------------------------------------------------------------
+// reconcile() — pure
+// ------------------------------------------------------------------
+
+test('reconcile: exact id, address-match, missing, remote-only, no-ledger', () => {
+    const ledger = [
+        { source: 'claim', localId: 'claim_1', label: 'one', publishedEventId: EV('1'),
+          addrs: [`30040:${PK_A}:claim_1`] },
+        { source: 'claim', localId: 'claim_2', label: 'two', publishedEventId: EV('2'),
+          addrs: [`30040:${PK_A}:claim_2`] },
+        { source: 'claim', localId: 'claim_3', label: 'three', publishedEventId: EV('3'),
+          addrs: [`30040:${PK_A}:claim_3`] }
+    ];
+    const items = [
+        item(EV('1'), 30040, PK_A, { d: 'claim_1' }),          // exact id match
+        item(EV('9'), 30040, PK_A, { d: 'claim_2' }),          // republished — addr match only
+        item(EV('8'), 30040, PK_A, { d: 'claim_x' }),          // remote-only (ledgered kind)
+        item(EV('7'), 30041, PK_A, { d: 'cmt:1' })             // no-ledger kind
+    ];
+    const r = reconcile(ledger, items);
+    assert.deepEqual(r.summary, { ledgerPublished: 3, confirmed: 2, missing: 1, remoteOnly: 1 });
+    assert.equal(r.missing[0].localId, 'claim_3');
+    assert.equal(ledger[0].status, 'confirmed');
+    assert.equal(ledger[1].status, 'confirmed-version');
+    assert.equal(r.statusByEventId[EV('1')], 'confirmed');
+    assert.equal(r.statusByEventId[EV('9')], 'confirmed');
+    assert.equal(r.statusByEventId[EV('8')], 'remote-only');
+    assert.equal(r.statusByEventId[EV('7')], 'no-ledger');
+});
+
+test('reconcile: empty inputs are calm', () => {
+    const r = reconcile([], []);
+    assert.deepEqual(r.summary, { ledgerPublished: 0, confirmed: 0, missing: 0, remoteOnly: 0 });
+    assert.deepEqual(r.missing, []);
+});
+
+// ------------------------------------------------------------------
+// loadLocalLedger() — against the real models
+// ------------------------------------------------------------------
+
+test('loadLocalLedger derives every addr rule from the local stores', async () => {
+    _stateStore.clear();
+    const coord = `30040:${PK_A}:claim_pub0000000001`;
+
+    await Storage.set('article_claims', {
+        claim_pub0000000001: {
+            id: 'claim_pub0000000001', text: 'Published claim', source_url: 'https://x.com/a',
+            publishedAt: 100, publishedEventId: EV('1'),
+            publishedPubkey: PK_A, publishedPubkeys: [PK_A, PK_B]
+        },
+        claim_unpub00000002: { id: 'claim_unpub00000002', text: 'Never published', source_url: 'https://x.com/b' }
+    });
+    await Storage.set('claim_assessments', {
+        assess_aaaaaaaaaaaaaaaa: {
+            id: 'assess_aaaaaaaaaaaaaaaa',
+            claim_ref: { coord, text: 'Published claim' },
+            stance: -1, labels: [], rationale: 'r',
+            publishedAt: 110, publishedEventId: EV('2')
+        }
+    });
+    await Storage.set('evidence_links', {
+        link_bbbbbbbbbbbbbbbb: {
+            id: 'link_bbbbbbbbbbbbbbbb',
+            source: `30040:${PK_B}:claim_zzz`,
+            target: coord,
+            relationship: 'contradicts',
+            // publishedKind matters: the 30043-retirement migration
+            // clears publish markers that lack it (normalizeLink).
+            publishedAt: 120, publishedEventId: EV('3'), publishedKind: 30055
+        }
+    });
+    await Storage.set('entities', {
+        entity_0123456789abcdef: {
+            id: 'entity_0123456789abcdef', name: 'Someone', type: 'person',
+            keyName: 'entity:entity_0123456789abcdef',
+            publishedAt: 130, publishedEventId: EV('4')
+        }
+    });
+    await Storage.set('local_keys', {
+        'entity:entity_0123456789abcdef': { name: 'entity:entity_0123456789abcdef', pubkey: ENTITY_PK, privateKey: '1'.repeat(64) }
+    });
+    const saved = await saveArticle({
+        article: { url: 'https://x.com/a', title: 'The Article' },
+        publishedToRelay: true,
+        publishedEventId: EV('5')
+    });
+
+    const { LocalKeyManager } = await import('../src/shared/local-key-manager.js');
+    await LocalKeyManager.init();
+
+    const ledger = await loadLocalLedger({ pubkeys: [PK_A] });
+    const bySource = (s) => ledger.filter((e) => e.source === s);
+
+    // Claim: one entry per published claim, addrs across the pubkey history.
+    assert.equal(bySource('claim').length, 1);
+    assert.deepEqual(bySource('claim')[0].addrs.sort(), [
+        `30040:${PK_A}:claim_pub0000000001`,
+        `30040:${PK_B}:claim_pub0000000001`
+    ]);
+
+    // Assessment: d = assess:<sha16(coord)> across resolved pubkeys.
+    const expectedAssessD = 'assess:' + (await Crypto.sha256(coord)).slice(0, 16);
+    assert.deepEqual(bySource('assessment')[0].addrs, [`30054:${PK_A}:${expectedAssessD}`]);
+
+    // Link: symmetric relationship sorts the coords before hashing.
+    const [cA, cB] = [`30040:${PK_B}:claim_zzz`, coord].sort();
+    const expectedRelD = 'rel:' + (await Crypto.sha256(`${cA}|${cB}|contradicts`)).slice(0, 16);
+    assert.deepEqual(bySource('link')[0].addrs, [`30055:${PK_A}:${expectedRelD}`]);
+
+    // Entity: replaceable kind-0 address under the entity's own key.
+    assert.deepEqual(bySource('entity')[0].addrs, [`0:${ENTITY_PK}`]);
+
+    // Article: d = the archive cache's urlHash.
+    assert.deepEqual(bySource('article')[0].addrs, [`30023:${PK_A}:${saved.urlHash}`]);
+    assert.equal(bySource('article')[0].publishedEventId, EV('5'));
+});
+
+test('loadLocalLedger: link with a local-id endpoint gets no addr (id-only match)', async () => {
+    _stateStore.clear();
+    await Storage.set('evidence_links', {
+        link_cccccccccccccccc: {
+            id: 'link_cccccccccccccccc',
+            source: 'claim_local000000001',          // endpoint still a local id
+            target: `30040:${PK_A}:claim_pub`,
+            relationship: 'supports',
+            publishedAt: 100, publishedEventId: EV('6'), publishedKind: 30055
+        }
+    });
+    const ledger = await loadLocalLedger({ pubkeys: [PK_A] });
+    const link = ledger.find((e) => e.source === 'link');
+    assert.deepEqual(link.addrs, []);
+    assert.equal(link.publishedEventId, EV('6'));
+});


### PR DESCRIPTION
Sixth Phase 12 slice (design `docs/PORTAL_DESIGN.md` #48; prior slices #49–#53). The ledger records intent; the relays record truth; this slice diffs them — strictly read-only (design Q5 ✅).

- **`reconcile.js`** — ledger collection with per-type address derivation (claim coords across `publishedPubkeys` history, recomputable `assess:`/`rel:` d-tags with symmetric-sort mirroring the builders, entity kind-0 addrs, article `urlHash`), plus the pure diff: confirmed (exact id) / confirmed-version (address match — a republish from another device still confirms) / **missing** / **remote-only** / no-ledger (comments/accounts/32125 — relay-only by design, never an anomaly).
- **`inspector.js`** — drawer on every row: coordinate, **relays holding the event**, ledger status, copyable raw JSON, source-URL jump, read-only **Open in reader** for articles via the existing `xray:reader:open`.
- **Panel + chips** — "ledger says N; relays confirm M; K missing; R remote-only" with the missing list; ✓ / ◌ chips on rows.
- Found-by-test nuance: published links must carry `publishedKind=30055`; the 30043-retirement migration (`normalizeLink`) clears markers without it — so legacy-30043-only links correctly read as unpublished.

Gates: build ✅ · 664/664 tests ✅ (4 new) · web-ext lint 0 errors ✅

Smoke: open portal → reconciliation line shows counts → click a row title → drawer shows relays + status + raw event → article rows offer "Open in reader".

🤖 Generated with [Claude Code](https://claude.com/claude-code)