### PR TITLE
fix(portal): Phase 12.7 hardening — adversarial-review fixes + smoke checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Fixed
 
+- **Hardening from the Phase 12.7 adversarial review** (three lenses,
+  every finding probe-verified; full record in `docs/JOURNAL.md`
+  2026-06-11). The two relay-sync bugs: an unreachable relay was
+  indistinguishable from an empty one (`queryRelays` resolves ok for a
+  failed connect), so an offline Refresh reported success and advanced
+  the portal's sync cursor over the outage — the connect failure is now
+  stamped on the per-relay stat and honored; and backfill paged with an
+  exclusive `until`, silently dropping same-second events at a relay's
+  response-cap boundary — paging is now inclusive with a
+  nothing-new-from-this-relay terminator. The sync cursor also
+  fingerprints the identity + relay sets (a new npub or relay triggers
+  a full backfill, not a one-hour window) and only advances on a clean
+  pass. "Open in reader" no longer writes the relay reconstruction into
+  the archive cache (read-only guarantee); reconciliation reads link
+  endpoints from the fields records actually carry and matches article
+  addresses by the raw-URL hash the wire uses; one millisecond-precision
+  timestamp can no longer freeze the timeline; sourced claims get
+  assessment tinting; case-dashboard rows open the inspector; the
+  Library gained the designed ledger-status facet, show-more pagination,
+  and the local-only count + legend; the portal is now linked from the
+  options and side-panel headers; and a failed IndexedDB open degrades
+  to live-only instead of bricking the page.
+
 - **Hardening from the Phase 11.7/11.8 review.** Case bundles now derive
   the key slot from the entity id and ignore any bundle-supplied
   `keyName` (a crafted bundle could otherwise bind a record to the

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,61 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — Phase 12.7: what the adversarial review caught (two relay-sync bugs + a read-only breach)
+
+**Tags:** bug, design, pattern
+
+A three-lens review (correctness / integration / design-fidelity, every
+finding probe-verified; 20 confirmed, 1 refuted) over the six portal
+slices. The load-bearing fixes, recorded because each encodes a
+contract a future reader could re-break:
+
+- **A dead relay is indistinguishable from an empty one** on the
+  `xray:relay:query` wire: `queryRelays` deliberately marks a failed
+  connect as EOSE so one bad relay can't block the pool (a Phase 5
+  choice), which means it answers `{ok:true, events:[]}` for an
+  unreachable relay. The portal's sync-cursor guard and "failed:"
+  status keyed off `ok` and so were dead code — an *offline* Refresh
+  advanced the cursor and silently ate the window. Fix: the connect
+  catch now also stamps `failed:true` + `error` on the per-relay stat
+  (additive; existing consumers unaffected) and the portal honors it.
+- **NIP-01 `until` is inclusive, and paging with `until = oldest − 1`
+  drops same-second siblings** whenever a relay's silent response cap
+  lands inside a same-second run — which is the *normal* shape of an
+  X-Ray corpus, since claims/comments bulk-publish in one pass. Fix:
+  page with `until = oldest` and terminate on "this page brought
+  nothing this relay hasn't already served" — per-relay, not global,
+  because relays page concurrently and one relay's coverage must not
+  truncate another's backfill. Residual (documented): a single
+  same-second run longer than the relay's own cap.
+- **The sync cursor now carries fingerprints of the author + relay
+  sets** and only advances on a clean pass (no failures, no
+  truncation): a newly pasted npub or newly added relay needs its full
+  history, not the last hour.
+- **"Open in reader" was a read-only breach**: the reader
+  unconditionally archive-caches on load, which would have overwritten
+  the local row's `publishedToRelay` marker with a relay
+  reconstruction. The stash record now carries `readOnly: true` and
+  the reader skips the cache save for it.
+- **Reconcile read link endpoints from fields that don't exist**
+  (`source`/`target` vs the real `source_claim_id`/`target_claim_id`)
+  — its test had seeded the same fiction and passed. The test now pins
+  the real field names, plus `publishedKind: 30055` (the
+  30043-retirement migration clears publish markers without it). Same
+  class of bug for articles: the archive's `urlHash` hashes the
+  *normalized* URL but the wire 30023 `d` hashes the *raw* URL, so the
+  address tier never fired; reconcile recomputes from `rec.url`.
+- Smaller, same pattern of "the design said so": one ms-precision
+  `created_at` could explode the timeline into ~3M buckets (sane-window
+  filter + bucket ceiling); sourced-claim nodes now get assessment
+  decoration like about-claims; case-dashboard rows are inspectable;
+  the Library gained its designed status facet, "show more" pagination,
+  the local-only count + no-ledger legend; the portal is linked from
+  the options/side-panel headers; a failed IndexedDB open un-memoizes
+  and the portal degrades to live-only instead of bricking.
+
+---
+
 ## 2026-06-10 — Phase 12 design: the "My Archive" portal (for review before code)
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,9 +58,10 @@ Phase 11 ████████████████████  complete 
                                 (docs/ASSESSMENTS_DESIGN.md). 11.1–11.6 +
                                 publishing (11.7) + collaboration (11.8)
                                 shipped; case smoke-runs pending
-Phase 12 ░░░░░░░░░░░░░░░░░░░░  in progress — "My Archive" personal data
-                                portal (docs/PORTAL_DESIGN.md, design
-                                agreed 2026-06-10); slices 12.1–12.7
+Phase 12 ████████████████████  complete — "My Archive" personal data
+                                portal (docs/PORTAL_DESIGN.md). 12.1–12.7
+                                shipped incl. adversarial-review fixes;
+                                §Phase 12 smoke-run pending
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -910,8 +911,9 @@ Slices (one PR each):
 - ✅ **12.6** Inspector & reconciliation — raw events, per-relay
   holdings, ledger diff (confirmed / missing / remote-only), privacy
   footer. — #54
-- ⬜ **12.7** Hardening — adversarial review + fixes, SMOKE_TEST
-  §Phase 12, docs pass.
+- ✅ **12.7** Hardening — three-lens adversarial review (20 confirmed
+  findings fixed, incl. two relay-sync bugs and a read-only breach;
+  JOURNAL 2026-06-11), SMOKE_TEST §Phase 12, docs pass.
 
 ---
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -426,6 +426,75 @@ sharing a case so a collaborator's claims aggregate with yours.
 
 ---
 
+## Phase 12 — "My Archive" portal
+
+The read-back surface (docs/PORTAL_DESIGN.md). Best run on a profile
+that has already published a case or two: claims, comments,
+assessments, a cross-video `contradicts` link, entities, a couple of
+captured articles (the Phase 11/11b walkthrough leaves exactly this
+behind). The portal is **read-only** — nothing here publishes,
+deletes, or writes the local publish ledger.
+
+**Open + identity**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 12.1 | Toolbar right-click → **Open My Archive** (also: Options header → **My Archive**, side panel header → **Archive**) | ✅ full-tab portal opens from all three; relay list in the footer + the privacy note ("Relays can see that request") |
+| 12.2 | Header identity chips | ✅ your pubkey(s) render with provenance tags (`signer` / `sync-key` / `publish-history` / `manual`); entity-keys chip shows the count, hover lists names |
+| 12.3 | Paste a second npub → **Add identity** | ✅ chip appears tagged `manual` with a ✕; ✕ removes it |
+| 12.4 | (NIP-07 profile with no history) open the portal | ✅ honest empty state explains NIP-07 can't answer here and points to the npub field — no silent blank |
+
+**Corpus + Library**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 12.5 | First open | ✅ status walks resolve → query → "N item(s)"; list renders newest-first with kind chips |
+| 12.6 | Close and reopen the portal | ✅ items render **instantly from cache**, then "refreshing…" then "+N new" (or no change) |
+| 12.7 | Type tabs | ✅ counts per type; clicking filters; Articles / Claims / Comments / Assessments / Links / Entities / Cases / Accounts / Other |
+| 12.8 | **Search** a person's name | ✅ claims/comments/entities mentioning them filter live; tab counts follow |
+| 12.9 | Facets | ✅ platform / source domain / case / ledger-status selects filter; "Group by source" renders domain headers; an event published by another client wears a `via <client>` badge but is **not hidden**; >200 rows reveal incrementally via **Show more** |
+| 12.10 | Publish something new (reader) → portal **↻ Refresh** | ✅ status reports `+1 new`; the item appears |
+| 12.11 | **Full resync** | ✅ cache drops and rebuilds to the same state |
+
+**Timeline**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 12.12 | Density strip above the list | ✅ capture sessions show as spikes; gaps stay visible |
+| 12.13 | Drag across a spike | ✅ list filters to the brushed range; chip shows it; ✕ clears |
+
+**Graph + case (the acceptance walk)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 12.14 | An entity row → **✳ Spokes** | ✅ radial ego graph: claims ring the focus; co-tagged people/orgs; containing cases; linked accounts |
+| 12.15 | Claim nodes | ✅ assessed claims tint by stance (red/green/amber); hover shows label count |
+| 12.16 | The `contradicts` link | ✅ ⚠ dashed red edge between the two claims; if the counterpart claim belongs to another entity it renders as a **ghost node** — never hidden |
+| 12.17 | Click a co-tagged entity node | ✅ graph refocuses on it |
+| 12.18 | Locate box + pan/zoom | ✅ typing pulses the first match; drag pans; wheel zooms |
+| 12.19 | More than 24 claims → "+K more" node | ✅ clicking expands the sector |
+| 12.20 | A case badge or case row → **☰ Dashboard** | ✅ artifact rollup by type, density strip, member chips (click → spokes), claims with stance + ⚠ contradicted badges |
+
+**Inspector + reconciliation**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 12.21 | Click any row title | ✅ drawer: coordinate, event id, author, **relays holding it**, ledger status, raw signed JSON |
+| 12.22 | **Copy raw event** | ✅ clipboard gets the JSON ("Copied ✓") |
+| 12.23 | An article row → **Open in reader** | ✅ the capture reconstructs from its signed event and opens read-only in the reader |
+| 12.24 | Reconciliation line above the list | ✅ "Local ledger says N published; the relays confirm M…" — counts agree with reality |
+| 12.25 | Publish to a relay, then remove that relay from Settings → portal **Full resync** | ✅ the item moves to **missing**; the panel lists it with its event id |
+| 12.26 | Query a pubkey you've published with from another device | ✅ those items render fully with the **◌ remote-only** chip — informational, not an error |
+| 12.27 | After all of the above, check the side panel / reader / options | ✅ untouched — the portal wrote nothing (no markPublished changes, no new local claims/entities) |
+
+**Firefox**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 12.28 | Repeat 12.1, 12.5–12.7, 12.14, 12.21 on Firefox ≥128 | ✅ identical behavior (the portal is plain SVG/IDB/`chrome.*`-polyfilled APIs) |
+
+---
+
 ## Phase 6 — Entity sync
 
 Run on **Device A** (your normal profile) and **Device B** (a

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -283,7 +283,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         // NIP-07 signing back through a tab that has the content script
         // + MAIN-world bridge loaded.
         const sourceTabId = sender && sender.tab && sender.tab.id;
-        const record = { article, sourceTabId, createdAt: Date.now() };
+        // readOnly (Phase 12.7): set by the portal's "Open in reader" —
+        // the article is a relay reconstruction for VIEWING, and the
+        // reader must not let it touch the local archive cache.
+        const record = { article, sourceTabId, createdAt: Date.now(), readOnly: !!message.readOnly };
         const area = chrome.storage.session || chrome.storage.local;
         area.set({ ['xray:article:' + id]: record }, () => {
             const url = chrome.runtime.getURL('src/reader/index.html') + '?id=' + encodeURIComponent(id);

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -521,6 +521,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('qa-open-entities').addEventListener('click', () => {
         browserApi.runtime.sendMessage({ type: 'xray:openEntities' });
     });
+    document.getElementById('qa-open-portal').addEventListener('click', () => {
+        browserApi.runtime.sendMessage({ type: 'xray:openPortal' });
+    });
     document.getElementById('qa-capture-tips').addEventListener('click', () => {
         browserApi.runtime.sendMessage({ type: 'xray:openCaptureTips' });
     });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -12,6 +12,7 @@
       <div class="xr-opt__quick">
         <button class="xr-opt__btn" id="qa-toggle-capture" title="Capture the active tab and open it in the reader">Capture Page</button>
         <button class="xr-opt__btn" id="qa-open-entities" title="Open the entity browser sidepanel">Entity Browser</button>
+        <button class="xr-opt__btn" id="qa-open-portal" title="Open My Archive — everything you've published to NOSTR">My Archive</button>
         <button class="xr-opt__btn" id="qa-capture-tips" title="Capture guide on GitHub">Capture tips</button>
       </div>
     </div>

--- a/src/portal/case-view.js
+++ b/src/portal/case-view.js
@@ -37,7 +37,8 @@ function contradictedCoords(items) {
  * @param {Array}  params.items        ALL library items
  * @param {object} params.entityIndex  pubkey → {entityId, name, type}
  * @param {string} params.casePubkey
- * @param {object} params.callbacks    {onBack(), onFocusEntity(pubkey), onOpenGraph(pubkey)}
+ * @param {object} params.callbacks    {onBack(), onFocusEntity(pubkey),
+ *                                      onOpenGraph(pubkey), onOpenItem(item)}
  */
 export function renderCaseView(host, params) {
     const { items, entityIndex, casePubkey, callbacks } = params;
@@ -146,7 +147,11 @@ export function renderCaseView(host, params) {
         const row = el('li', 'xr-row');
         const headRow = el('div', 'xr-row__head');
         headRow.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
-        headRow.appendChild(el('span', 'xr-row__title', truncate(item.title, 160)));
+        const titleEl = el('button', 'xr-row__title xr-row__title--link', truncate(item.title, 160));
+        titleEl.type = 'button';
+        titleEl.title = 'Inspect — raw event, relays holding it, ledger status';
+        titleEl.addEventListener('click', () => callbacks.onOpenItem(item));
+        headRow.appendChild(titleEl);
         const badges = el('span', 'xr-row__badges');
         const assessment = item.claimCoord ? assessments.get(item.claimCoord) : null;
         if (assessment && assessment.stance !== null && assessment.stance !== undefined) {
@@ -184,7 +189,11 @@ export function renderCaseView(host, params) {
             const row = el('li', 'xr-row');
             const headRow = el('div', 'xr-row__head');
             headRow.appendChild(el('span', 'xr-row__kind', kindLabel(item.kind)));
-            headRow.appendChild(el('span', 'xr-row__title', truncate(item.title, 160)));
+            const titleEl = el('button', 'xr-row__title xr-row__title--link', truncate(item.title, 160));
+            titleEl.type = 'button';
+            titleEl.title = 'Inspect — raw event, relays holding it, ledger status';
+            titleEl.addEventListener('click', () => callbacks.onOpenItem(item));
+            headRow.appendChild(titleEl);
             if (item.created_at) {
                 headRow.appendChild(el('span', 'xr-row__date', new Date(item.created_at * 1000).toLocaleString()));
             }

--- a/src/portal/corpus.js
+++ b/src/portal/corpus.js
@@ -16,11 +16,13 @@
 // independent of the others.
 //
 // Backfill: relays cap responses silently (often below our `limit`),
-// so each relay pages backward with `until = oldest - 1` until it
-// returns an EMPTY page (not a short one — a short page may just be
-// the relay's own cap) or the page ceiling hits. Known v1 edge: a
-// relay holding more than a full page of events at one identical
-// timestamp can hide the overflow; accepted, per the design note.
+// so each relay pages backward with `until = oldest` — NIP-01 `until`
+// is INCLUSIVE, so the boundary second is re-asked-for and a cap that
+// landed mid-second can't silently drop its siblings (12.7 review
+// fix). Termination is "this page produced no event we hadn't already
+// seen", not "empty page", which also makes the tie-heavy case
+// converge. Residual edge: a single same-second run longer than the
+// relay's own cap can still hide its overflow; accepted.
 
 import { Utils } from '../shared/utils.js';
 
@@ -72,32 +74,49 @@ function relayQuery(filter, relays, timeoutMs = QUERY_TIMEOUT_MS) {
 
 /**
  * Page one relay backward through one base filter, feeding every event
- * into `collect(event, relayUrl)`.
+ * into `collect(event, relayUrl)`. Pagination terminates when a page
+ * contains nothing THIS RELAY hasn't already served — per-relay, not
+ * global, because relays page concurrently and one relay's coverage
+ * must never truncate another's backfill (or its provenance).
  */
 async function backfillRelay(relayUrl, baseFilter, collect, onProgress) {
     let until;
     let pages = 0;
+    const served = new Set(); // event ids this relay has returned
     for (;;) {
         const filter = { ...baseFilter, limit: PAGE_LIMIT };
         if (until !== undefined) filter.until = until;
         const resp = await relayQuery(filter, [relayUrl]);
         if (!resp.ok) return { ok: false, error: resp.error || 'query failed', pages };
+        // The background resolves ok:true even when the WebSocket never
+        // connected (queryRelays marks the relay EOSE to avoid blocking
+        // the pool) — the per-relay stat carries the truth (12.7).
+        const stat = resp.byRelay && resp.byRelay[relayUrl];
+        if (stat && stat.failed) {
+            return { ok: false, error: stat.error || 'relay unreachable', pages };
+        }
         const events = Array.isArray(resp.events) ? resp.events : [];
         pages++;
         if (events.length === 0) break;
         let oldest = Infinity;
+        let fresh = 0;
         for (const ev of events) {
             if (!ev || !ev.id) continue;
             if (typeof ev.created_at === 'number' && ev.created_at < oldest) oldest = ev.created_at;
+            if (!served.has(ev.id)) { served.add(ev.id); fresh++; }
             collect(ev, relayUrl);
         }
         if (typeof onProgress === 'function') onProgress();
+        // `until` is inclusive, so the boundary page always re-serves
+        // events we already hold — a page with nothing NEW means this
+        // relay is drained (or capped inside one second; see header).
+        if (fresh === 0) break;
         if (!Number.isFinite(oldest)) break;
         if (pages >= MAX_PAGES_PER_QUERY) {
             Utils.log('Portal corpus: page ceiling hit on', relayUrl, '— older events not fetched');
             return { ok: true, pages, truncated: true };
         }
-        until = oldest - 1;
+        until = oldest;
     }
     return { ok: true, pages, truncated: false };
 }

--- a/src/portal/entity-view.js
+++ b/src/portal/entity-view.js
@@ -141,7 +141,8 @@ export function renderEntityView(host, params) {
     nodeLayer.appendChild(focusG);
 
     for (const node of graph.nodes) {
-        const extra = node.nodeType === 'claim' ? stanceClass(node) : '';
+        const extra = (node.nodeType === 'claim' || node.nodeType === 'sourced-claim')
+            ? stanceClass(node) : '';
         const tip = node.labelCount
             ? `${node.label}\n${node.labelCount} label(s) on latest assessment`
             : node.label;

--- a/src/portal/graph.js
+++ b/src/portal/graph.js
@@ -135,7 +135,15 @@ export function buildEgoGraph(items, { focusPubkey, entityIndex = {}, expandedTy
     const keptSourced = capList('sourced-claim', claimsSourced);
     for (const item of keptSourced) {
         const id = `claim:${item.claimCoord || item.id}`;
-        if (!addNode({ id, nodeType: 'sourced-claim', label: item.title, item, stance: null, labelCount: 0 })) continue;
+        // Assessments decorate sourced claims exactly like about-claims
+        // (12.7 review fix — the same assessed claim must not render
+        // tinted on one entity's graph and bare on another's).
+        const assessment = item.claimCoord ? assessmentByCoord.get(item.claimCoord) : null;
+        if (!addNode({
+            id, nodeType: 'sourced-claim', label: item.title, item,
+            stance: assessment ? assessment.stance : null,
+            labelCount: assessment ? assessment.labelCount : 0
+        })) continue;
         if (item.claimCoord) claimNodeByCoord.set(item.claimCoord, id);
         edges.push({ from: 'focus', to: id, kind: 'spoke', role: 'source' });
     }

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -544,6 +544,19 @@ button.xr-badge--case { cursor: pointer; background: transparent; }
 .xr-recon__line { color: var(--xr-text-dim); }
 .xr-recon__line--warn { color: var(--xr-warning); }
 
+.xr-recon__legend {
+  margin-top: 2px;
+  color: var(--xr-text-dim);
+  font-size: 11px;
+  opacity: 0.8;
+}
+
+.xr-portal__more-row {
+  list-style: none;
+  text-align: center;
+  padding: 12px 0 4px;
+}
+
 .xr-portal__recon details { margin-top: 6px; }
 .xr-portal__recon summary { cursor: pointer; color: var(--xr-warning); font-size: 12px; }
 

--- a/src/portal/index.html
+++ b/src/portal/index.html
@@ -42,6 +42,12 @@
       <option value="ours">X-Ray only</option>
       <option value="other">Other clients</option>
     </select>
+    <select id="xr-facet-status" title="Filter by ledger status" hidden>
+      <option value="all">Any ledger status</option>
+      <option value="confirmed">✓ Confirmed</option>
+      <option value="remote-only">◌ Remote-only</option>
+      <option value="no-ledger">No ledger</option>
+    </select>
     <label class="xr-portal__group-toggle" title="Group the list by source domain">
       <input type="checkbox" id="xr-group-domain" /> Group by source
     </label>

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -13,18 +13,19 @@
 
 import { Storage } from '../shared/storage.js';
 import { Utils } from '../shared/utils.js';
+import { dedupeReplaceable } from '../shared/nostr-events.js';
 import { resolveIdentities, addManualIdentity, removeManualIdentity } from './identity.js';
 import { fetchCorpus, FALLBACK_RELAYS } from './corpus.js';
 import { saveRecords, loadRecords, getMeta, setMeta, clearAll } from './portal-cache.js';
 import {
     buildItems, applyFilters, typeCounts, facetValues, isOtherClient,
-    kindLabel, TYPE_DEFS, EMPTY_FILTERS
+    kindLabel, pageWindow, TYPE_DEFS, EMPTY_FILTERS
 } from './library.js';
 import { buildBuckets, brushRange } from './timeline.js';
 import { el, svgEl, clear, truncate, shortKey } from './dom.js';
 import { renderEntityView } from './entity-view.js';
 import { renderCaseView } from './case-view.js';
-import { loadLocalLedger, reconcile } from './reconcile.js';
+import { loadLocalLedger, reconcile, countLocalOnly } from './reconcile.js';
 import { renderInspector } from './inspector.js';
 
 const $ = (sel) => document.querySelector(sel);
@@ -42,10 +43,14 @@ const state = {
     view: { name: 'library' },   // | {name:'entity', pubkey} | {name:'case', pubkey}
     expandedTypes: new Set(),    // graph sectors the user expanded
     reconciliation: null,        // {summary, missing, statusByEventId} (12.6)
+    rowLimit: 200,               // incremental-reveal window (12.7)
+    cacheBroken: false,          // IndexedDB unavailable → live-only mode (12.7)
     relayErrors: {},
     truncated: false,
     loading: false
 };
+
+const ROW_PAGE_SIZE = 200;
 
 // ------------------------------------------------------------------
 // Header / identity / status
@@ -126,6 +131,7 @@ function renderTabs() {
         btn.classList.toggle('xr-tab--active', state.filters.type === def.key);
         btn.addEventListener('click', () => {
             state.filters.type = def.key;
+            state.rowLimit = ROW_PAGE_SIZE;
             renderLibrary();
         });
         host.appendChild(btn);
@@ -156,6 +162,9 @@ function renderFacets() {
     fillFacetSelect($('#xr-facet-domain'), facetValues(base, 'domain'), state.filters.domain, 'All sources');
     fillFacetSelect($('#xr-facet-case'), facetValues(base, 'cases'), state.filters.caseName, 'All cases');
     $('#xr-facet-client').value = state.filters.client;
+    // Status facet only means something once the ledger diff has run.
+    $('#xr-facet-status').hidden = !state.reconciliation;
+    $('#xr-facet-status').value = state.filters.status;
     // Sync any select whose remembered value vanished from the options.
     state.filters.platform = $('#xr-facet-platform').value;
     state.filters.domain = $('#xr-facet-domain').value;
@@ -239,14 +248,18 @@ function buildRow(item) {
     return row;
 }
 
-function renderRows(visible) {
+function renderRows(allVisible) {
     const list = $('#xr-list');
     const empty = $('#xr-empty');
     empty.hidden = true;
     list.hidden = false;
     clear(list);
 
-    if (visible.length === 0) {
+    // Incremental reveal (12.7): cap the DOM at rowLimit rows; counts,
+    // facets, and the timeline still see the full filtered set.
+    const { shown: visible, remaining } = pageWindow(allVisible, state.rowLimit);
+
+    if (allVisible.length === 0) {
         if (state.items.length === 0) {
             renderEmpty('Nothing found on the relays', [
                 'The configured relays returned no events for the resolved identities. '
@@ -273,6 +286,19 @@ function renderRows(visible) {
         }
     } else {
         for (const item of visible) list.appendChild(buildRow(item));
+    }
+
+    if (remaining > 0) {
+        const li = el('li', 'xr-portal__more-row');
+        const btn = el('button', 'xr-portal__btn xr-portal__btn--ghost',
+            `Show ${Math.min(ROW_PAGE_SIZE, remaining)} more (${remaining} remaining)`);
+        btn.type = 'button';
+        btn.addEventListener('click', () => {
+            state.rowLimit += ROW_PAGE_SIZE;
+            renderRows(applyFilters(state.items, state.filters));
+        });
+        li.appendChild(btn);
+        list.appendChild(li);
     }
 }
 
@@ -313,6 +339,7 @@ function renderTimeline() {
         chip.addEventListener('click', () => {
             state.filters.after = 0;
             state.filters.before = 0;
+            state.rowLimit = ROW_PAGE_SIZE;
             renderLibrary();
         });
         head.appendChild(chip);
@@ -365,6 +392,7 @@ function renderTimeline() {
         if (!range) return;
         state.filters.after = range.after;
         state.filters.before = range.before;
+        state.rowLimit = ROW_PAGE_SIZE;
         renderLibrary();
     });
     svg.addEventListener('mouseleave', () => { dragStart = null; });
@@ -380,6 +408,11 @@ async function updateReconciliation() {
     try {
         const ledger = await loadLocalLedger({ pubkeys: state.identities.map((i) => i.pubkey) });
         state.reconciliation = reconcile(ledger, state.items);
+        state.reconciliation.summary.localOnly = (await countLocalOnly()).total;
+        // Annotate items so the status facet can filter on plain fields.
+        for (const item of state.items) {
+            item.reconStatus = state.reconciliation.statusByEventId[item.id] || 'no-ledger';
+        }
     } catch (err) {
         Utils.error('Portal reconciliation failed:', err);
         state.reconciliation = null;
@@ -390,7 +423,8 @@ function renderReconPanel() {
     const host = $('#xr-recon');
     clear(host);
     const r = state.reconciliation;
-    if (!r || (r.summary.ledgerPublished === 0 && r.summary.remoteOnly === 0)) {
+    if (!r || (r.summary.ledgerPublished === 0 && r.summary.remoteOnly === 0
+        && !(r.summary.localOnly > 0))) {
         host.hidden = true;
         return;
     }
@@ -400,9 +434,13 @@ function renderReconPanel() {
         `Local ledger says ${s.ledgerPublished} published; the relays confirm ${s.confirmed}`
         + (s.missing ? `; ${s.missing} missing` : '')
         + (s.remoteOnly ? `; ${s.remoteOnly} on relays only (another device, or pre-ledger)` : '')
+        + (s.localOnly > 0 ? `; ${s.localOnly} local only (never published)` : '')
         + '.');
     line.classList.toggle('xr-recon__line--warn', s.missing > 0);
     host.appendChild(line);
+    host.appendChild(el('div', 'xr-recon__legend',
+        'Comments, linked accounts, and entity↔article links have no local publish ledger — '
+        + 'they appear from relays only and are never counted as missing.'));
 
     if (r.missing.length > 0) {
         const details = el('details');
@@ -461,7 +499,8 @@ const viewCallbacks = {
     onFocusEntity: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); closeInspector(); render(); },
     onOpenCase: (pubkey) => { state.view = { name: 'case', pubkey }; closeInspector(); render(); },
     onOpenGraph: (pubkey) => { state.view = { name: 'entity', pubkey }; state.expandedTypes = new Set(); closeInspector(); render(); },
-    onExpand: (type) => { state.expandedTypes.add(type); render(); }
+    onExpand: (type) => { state.expandedTypes.add(type); render(); },
+    onOpenItem: (item) => { openInspector(item); }
 };
 
 function render() {
@@ -511,6 +550,11 @@ function setBusy(busy) {
     state.loading = busy;
     $('#xr-refresh').disabled = busy;
     $('#xr-resync').disabled = busy;
+    // The identity form re-boots on submit; mid-refresh that submit
+    // would silently no-op (boot() early-returns while loading), so
+    // make the unavailability visible instead (12.7 review fix).
+    $('#xr-identity-input').disabled = busy;
+    $('#xr-identity-form button').disabled = busy;
 }
 
 /**
@@ -535,7 +579,16 @@ async function boot({ full = false } = {}) {
         renderFooter();
 
         // Cache first: anything we already hold renders immediately.
-        const cached = await loadRecords();
+        // A broken IndexedDB (quota, private mode) must not brick the
+        // portal — degrade to live-only mode (12.7 review fix).
+        let cached = [];
+        state.cacheBroken = false;
+        try {
+            cached = await loadRecords();
+        } catch (err) {
+            Utils.error('Portal cache unavailable — running live-only:', err);
+            state.cacheBroken = true;
+        }
         if (cached.length > 0) {
             rebuildItems(cached);
             render();
@@ -560,11 +613,22 @@ async function boot({ full = false } = {}) {
             return;
         }
 
-        // Incremental unless asked for a full pass or never synced.
-        const sync = full ? null : await getMeta('sync');
-        const since = sync && Number.isFinite(sync.lastSyncAt)
-            ? sync.lastSyncAt - SYNC_OVERLAP_SECONDS
-            : undefined;
+        // Incremental only when the cursor is trustworthy: it must
+        // exist AND have been written for the SAME identity and relay
+        // sets — a new pubkey or relay needs its full history, not the
+        // last hour (12.7 review fix). Cache-broken mode always runs full.
+        const authorsKey = [
+            ...state.identities.map((i) => i.pubkey),
+            ...state.entities.map((e) => e.pubkey)
+        ].sort().join(',');
+        const relaysKey = [...state.relays].sort().join(',');
+        let sync = null;
+        if (!full && !state.cacheBroken) {
+            try { sync = await getMeta('sync'); } catch (_) { /* live-only */ }
+        }
+        const cursorValid = sync && Number.isFinite(sync.lastSyncAt)
+            && sync.authorsKey === authorsKey && sync.relaysKey === relaysKey;
+        const since = cursorValid ? sync.lastSyncAt - SYNC_OVERLAP_SECONDS : undefined;
         const fetchStartedAt = Math.floor(Date.now() / 1000);
 
         setStatus(`Querying ${state.relays.length} relay(s)${since ? ' for new events' : ''}…`);
@@ -578,16 +642,38 @@ async function boot({ full = false } = {}) {
         state.relayErrors = relayErrors;
         state.truncated = truncated;
 
-        const stats = await saveRecords(records);
-        rebuildItems(await loadRecords());
+        let stats = { added: records.length, updated: 0, superseded: 0, skippedStale: 0 };
+        if (state.cacheBroken) {
+            // Live-only mode: the cache normally dedupes at write time,
+            // so collapse replaceable versions here instead.
+            const live = dedupeReplaceable(records.map((r) => r.event));
+            const liveIds = new Set(live.map((e) => e.id));
+            rebuildItems(records.filter((r) => liveIds.has(r.event.id)));
+        } else {
+            try {
+                stats = await saveRecords(records);
+                rebuildItems(await loadRecords());
+            } catch (err) {
+                Utils.error('Portal cache write failed — rendering live results:', err);
+                state.cacheBroken = true;
+                const live = dedupeReplaceable(records.map((r) => r.event));
+                const liveIds = new Set(live.map((e) => e.id));
+                rebuildItems(records.filter((r) => liveIds.has(r.event.id)));
+            }
+        }
         await updateReconciliation();
         render();
 
         const failed = Object.keys(relayErrors);
-        // Only advance the cursor when at least one relay answered in
-        // full — an all-failed refresh must not eat the window.
-        if (failed.length < state.relays.length) {
-            await setMeta('sync', { lastSyncAt: fetchStartedAt });
+        // Advance the cursor only on a CLEAN pass: every relay answered
+        // and no relay hit the page ceiling. Failure and truncation are
+        // per-relay while the cursor is global — advancing it over a
+        // partial fetch would hide the unfetched window from every
+        // future incremental refresh (12.7 review fix).
+        if (!state.cacheBroken && failed.length === 0 && !truncated) {
+            try {
+                await setMeta('sync', { lastSyncAt: fetchStartedAt, authorsKey, relaysKey });
+            } catch (_) { /* live-only */ }
         }
 
         const parts = [`${state.items.length} item(s)`];
@@ -635,19 +721,24 @@ function wireChrome() {
         clearTimeout(searchTimer);
         searchTimer = setTimeout(() => {
             state.filters.query = e.target.value;
+            state.rowLimit = ROW_PAGE_SIZE;
             renderLibrary();
         }, 150);
     });
 
+    // 'client' and 'status' are enum facets whose empty value means
+    // 'all'; the value facets fall back to '' (no filter).
     const facetWiring = [
-        ['#xr-facet-platform', 'platform'],
-        ['#xr-facet-domain', 'domain'],
-        ['#xr-facet-case', 'caseName'],
-        ['#xr-facet-client', 'client']
+        ['#xr-facet-platform', 'platform', ''],
+        ['#xr-facet-domain', 'domain', ''],
+        ['#xr-facet-case', 'caseName', ''],
+        ['#xr-facet-client', 'client', 'all'],
+        ['#xr-facet-status', 'status', 'all']
     ];
-    for (const [sel, field] of facetWiring) {
+    for (const [sel, field, fallback] of facetWiring) {
         $(sel).addEventListener('change', (e) => {
-            state.filters[field] = e.target.value || (field === 'client' ? 'all' : '');
+            state.filters[field] = e.target.value || fallback;
+            state.rowLimit = ROW_PAGE_SIZE;
             renderLibrary();
         });
     }

--- a/src/portal/inspector.js
+++ b/src/portal/inspector.js
@@ -99,7 +99,9 @@ export function renderInspector(host, item, { status = 'no-ledger', onClose } = 
                 return;
             }
             const id = crypto.randomUUID();
-            chrome.runtime.sendMessage({ type: 'xray:reader:open', id, article }, (resp) => {
+            // readOnly: the reader must not write this relay
+            // reconstruction into the local archive cache (Q5).
+            chrome.runtime.sendMessage({ type: 'xray:reader:open', id, article, readOnly: true }, (resp) => {
                 if (!resp || !resp.ok) {
                     Utils.error('Inspector: reader open failed', resp && resp.error);
                     open.textContent = 'Reader open failed';

--- a/src/portal/library.js
+++ b/src/portal/library.js
@@ -286,6 +286,7 @@ export const EMPTY_FILTERS = Object.freeze({
     domain: '',
     caseName: '',
     client: 'all',   // 'all' | 'ours' | 'other'
+    status: 'all',   // 'all' | 'confirmed' | 'remote-only' | 'no-ledger' (12.6 reconciliation)
     query: '',
     after: 0,        // epoch seconds, inclusive — 0 = unset (timeline brush)
     before: 0        // epoch seconds, exclusive — 0 = unset
@@ -307,6 +308,10 @@ export function applyFilters(items, filters) {
         if (f.before && item.created_at >= f.before) return false;
         if (f.client === 'ours' && isOtherClient(item)) return false;
         if (f.client === 'other' && !isOtherClient(item)) return false;
+        // reconStatus is annotated onto items after reconcile() runs;
+        // unannotated items read as 'no-ledger' so the facet stays
+        // honest before the (async) ledger diff lands.
+        if (f.status !== 'all' && (item.reconStatus || 'no-ledger') !== f.status) return false;
         for (const token of tokens) {
             if (!item.searchText.includes(token)) return false;
         }
@@ -323,6 +328,17 @@ export function typeCounts(items) {
         if (counts[item.typeKey] !== undefined) counts[item.typeKey]++;
     }
     return counts;
+}
+
+/**
+ * The Library's incremental-reveal window (12.7): the list renders
+ * `limit` rows and a "show more" affordance for the rest, so a
+ * many-thousand-event corpus can't jank first paint.
+ */
+export function pageWindow(items, limit) {
+    const list = Array.isArray(items) ? items : [];
+    const n = Number.isFinite(limit) && limit > 0 ? limit : list.length;
+    return { shown: list.slice(0, n), remaining: Math.max(0, list.length - n) };
 }
 
 /**

--- a/src/portal/portal-cache.js
+++ b/src/portal/portal-cache.js
@@ -48,6 +48,8 @@ let _dbPromise = null;
 export function openPortalDb() {
     if (_dbPromise) return _dbPromise;
     _dbPromise = new Promise((resolve, reject) => {
+        // (Rejections un-memoize below so one failed open — quota,
+        // private-mode restrictions — doesn't brick every later call.)
         let open;
         try { open = idb().open(DB_NAME, DB_VERSION); }
         catch (err) { reject(err); return; }
@@ -70,6 +72,7 @@ export function openPortalDb() {
         open.onsuccess = () => resolve(open.result);
         open.onerror   = () => reject(open.error);
     });
+    _dbPromise.catch(() => { _dbPromise = null; });
     return _dbPromise;
 }
 

--- a/src/portal/reconcile.js
+++ b/src/portal/reconcile.js
@@ -94,11 +94,13 @@ export async function loadLocalLedger({ pubkeys = [] } = {}) {
         for (const l of Object.values(links || {})) {
             if (!l || !l.publishedAt || !l.publishedEventId) continue;
             const addrs = [];
-            // The wire d is recomputable only when both endpoints are
+            // Records store endpoints as source_claim_id/target_claim_id
+            // (canonical refs — local id for ours, coordinate for
+            // foreign). The wire d is recomputable only when both are
             // coordinates (own claims backfill coords at publish, 11.7).
-            if (isCoord(l.source) && isCoord(l.target)) {
-                let a = l.source;
-                let b = l.target;
+            if (isCoord(l.source_claim_id) && isCoord(l.target_claim_id)) {
+                let a = l.source_claim_id;
+                let b = l.target_claim_id;
                 if (isSymmetricRelationship(l.relationship) && b < a) [a, b] = [b, a];
                 const d = 'rel:' + (await sha16(`${a}|${b}|${l.relationship}`));
                 for (const pk of pubkeys) addrs.push(`30055:${pk}:${d}`);
@@ -134,18 +136,55 @@ export async function loadLocalLedger({ pubkeys = [] } = {}) {
         const articles = await listArticles();
         for (const rec of (articles || [])) {
             if (!rec || !rec.publishedToRelay || !rec.publishedEventId) continue;
+            // The archive's urlHash hashes the NORMALIZED url, but the
+            // published kind-30023 d-tag hashes the RAW capture url
+            // (event-builder) — recompute from rec.url or the address
+            // tier never fires (12.7 review fix).
+            const wireD = rec.url ? (await Crypto.sha256(rec.url)).slice(0, 16) : null;
             entries.push({
                 source: 'article',
                 localId: rec.urlHash,
                 label: (rec.article && rec.article.title) || rec.url || rec.urlHash,
                 publishedAt: rec.cachedAt || null,
                 publishedEventId: rec.publishedEventId,
-                addrs: pubkeys.map((pk) => `30023:${pk}:${rec.urlHash}`)
+                addrs: wireD ? pubkeys.map((pk) => `30023:${pk}:${wireD}`) : []
             });
         }
     } catch (err) { Utils.error('Reconcile: article ledger scan failed', err); }
 
     return entries;
+}
+
+/**
+ * Count local records that were never published — the design's
+ * "local only / never published (shown only as counts)" bucket.
+ * Display-only, like everything else here.
+ *
+ * @returns {Promise<{claim: number, assessment: number, link: number,
+ *                    entity: number, article: number, total: number}>}
+ */
+export async function countLocalOnly() {
+    const counts = { claim: 0, assessment: 0, link: 0, entity: 0, article: 0, total: 0 };
+    const unpublished = (r) => r && (!r.publishedAt || !r.publishedEventId);
+    try {
+        for (const c of Object.values(await ClaimModel.getAll() || {})) if (unpublished(c)) counts.claim++;
+    } catch (_) { /* counted as zero */ }
+    try {
+        for (const a of Object.values(await AssessmentModel.getAll() || {})) if (unpublished(a)) counts.assessment++;
+    } catch (_) { /* counted as zero */ }
+    try {
+        for (const l of Object.values(await EvidenceLinker.getAll() || {})) if (unpublished(l)) counts.link++;
+    } catch (_) { /* counted as zero */ }
+    try {
+        for (const e of Object.values(await EntityModel.getAll() || {})) if (unpublished(e)) counts.entity++;
+    } catch (_) { /* counted as zero */ }
+    try {
+        for (const r of (await listArticles() || [])) {
+            if (r && (!r.publishedToRelay || !r.publishedEventId)) counts.article++;
+        }
+    } catch (_) { /* counted as zero */ }
+    counts.total = counts.claim + counts.assessment + counts.link + counts.entity + counts.article;
+    return counts;
 }
 
 /**

--- a/src/portal/timeline.js
+++ b/src/portal/timeline.js
@@ -43,10 +43,18 @@ export function bucketStart(ts, bucket) {
  * @param {{bucket?: 'day'|'week'}} [opts]  omit to auto-choose
  * @returns {{bucket: string, buckets: Array<{start: number, end: number, count: number}>}}
  */
+// Plausible-seconds window: NOSTR predates 2015 nowhere we care about,
+// and anything past ~2286 (1e10) is a millisecond-precision timestamp
+// from a broken writer. One such event would otherwise stretch the
+// series by ~50k years of buckets and freeze the tab (12.7 review fix).
+const MIN_SANE_TS = 1262304000;     // 2010-01-01
+const MAX_SANE_TS = 10000000000;    // ~2286; 13-digit ms values exceed this
+const MAX_BUCKETS = 5000;           // hard safety ceiling for the dense series
+
 export function buildBuckets(items, { bucket } = {}) {
     const stamps = (Array.isArray(items) ? items : [])
         .map((i) => i && i.created_at)
-        .filter((t) => Number.isFinite(t) && t > 0);
+        .filter((t) => Number.isFinite(t) && t >= MIN_SANE_TS && t < MAX_SANE_TS);
     if (stamps.length === 0) return { bucket: bucket || 'day', buckets: [] };
 
     const min = Math.min(...stamps);
@@ -62,7 +70,7 @@ export function buildBuckets(items, { bucket } = {}) {
     }
 
     const buckets = [];
-    for (let start = first; start <= max; start += size) {
+    for (let start = first; start <= max && buckets.length < MAX_BUCKETS; start += size) {
         buckets.push({ start, end: start + size, count: counts.get(start) || 0 });
     }
     return { bucket: chosen, buckets };

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -138,8 +138,11 @@ async function loadArticle() {
     // Cache the freshly-loaded article locally so revisits can detect
     // prior captures. publishedToRelay stays false until the publish
     // flow explicitly flips it. Fire-and-forget — reader load should
-    // not block on the IDB round trip.
-    if (state.article && state.article.url) {
+    // not block on the IDB round trip. SKIPPED for read-only opens
+    // (the portal's relay reconstructions, Phase 12.7): overwriting
+    // the archive row here would reset its publishedToRelay marker and
+    // break the portal's read-only guarantee.
+    if (state.article && state.article.url && !(stored && stored.readOnly)) {
         ArchiveCache.saveArticle({ article: state.article, source: 'capture' })
             .catch((err) => console.warn('[X-Ray Reader] archive cache save failed:', err));
     }

--- a/src/shared/nostr-client.js
+++ b/src/shared/nostr-client.js
@@ -257,9 +257,18 @@ export const NostrClient = {
           })
           .catch((err) => {
             Utils.log('queryRelays: connect failed', url, err && err.message);
-            // Mark as EOSE so we don't wait on it.
+            // Mark as EOSE so we don't wait on it — but record the
+            // failure too (Phase 12.7): a dead relay is otherwise
+            // indistinguishable from an empty one ({received:0,
+            // eose:true}), and callers like the portal's sync cursor
+            // must not treat "unreachable" as "answered with nothing".
+            // Additive fields; existing byRelay consumers are unaffected.
             const stat = byRelay.get(url);
-            if (stat) stat.eose = true;
+            if (stat) {
+              stat.eose = true;
+              stat.failed = true;
+              stat.error = (err && err.message) || 'connect failed';
+            }
             if ([...byRelay.values()].every((s) => s.eose)) finish();
           });
       }

--- a/src/sidepanel/index.html
+++ b/src/sidepanel/index.html
@@ -9,6 +9,7 @@
 <body class="xr-side">
   <header class="xr-side__chrome">
     <h1 class="xr-side__title">🩻 Entities</h1>
+    <button class="xr-side__btn" id="xr-open-portal" title="Open My Archive — everything you've published to NOSTR">Archive</button>
     <button class="xr-side__btn xr-side__btn--primary" id="xr-new-entity" title="Create a new entity">＋ New</button>
   </header>
 

--- a/src/sidepanel/index.js
+++ b/src/sidepanel/index.js
@@ -1453,6 +1453,9 @@ async function init() {
 
     // Header buttons.
     $('#xr-new-entity').addEventListener('click', openCreateModal);
+    $('#xr-open-portal').addEventListener('click', () => {
+        chrome.runtime.sendMessage({ type: 'xray:openPortal' });
+    });
 
     // Detail view buttons.
     $('#xr-back').addEventListener('click', () => {

--- a/tests/portal-corpus.test.mjs
+++ b/tests/portal-corpus.test.mjs
@@ -81,18 +81,64 @@ test('per-relay provenance: shared events accumulate both relays', async () => {
     assert.deepEqual(byId.get('e3'), [RELAY_B]);
 });
 
-test('pagination stops on an EMPTY page, not a short one, and pages with until = oldest - 1', async () => {
+test('pagination pages with INCLUSIVE until = oldest and stops when a page brings nothing new', async () => {
     const pagesServed = [];
     reset((_relay, filter) => {
         pagesServed.push(filter.until);
         if (filter.until === undefined) return [ev('p1', 100), ev('p2', 90)];   // short page (relay cap)
-        if (filter.until === 89) return [ev('p3', 50)];                          // older events still there
-        if (filter.until === 49) return [];                                      // genuinely dry
+        if (filter.until === 90) return [ev('p2', 90), ev('p3', 50)];            // boundary second re-served
+        if (filter.until === 50) return [ev('p3', 50)];                          // nothing new → stop
         throw new Error(`unexpected until ${filter.until}`);
     });
     const { records } = await fetchCorpus({ pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A] });
-    assert.deepEqual(pagesServed, [undefined, 89, 49]);
+    assert.deepEqual(pagesServed, [undefined, 90, 50]);
     assert.equal(records.length, 3);
+});
+
+test('a relay cap landing inside a same-second run no longer drops the siblings', async () => {
+    // Relay holds [n@200, a@100, b@100, c@100] and caps responses at 3.
+    // The old `until = oldest - 1` skipped past second 100 after page 1
+    // and lost b and c forever; inclusive until recovers them.
+    const ALL = [ev('n', 200), ev('a', 100), ev('b', 100), ev('c', 100)];
+    reset((_relay, filter) => ALL
+        .filter((e) => filter.until === undefined || e.created_at <= filter.until)
+        .slice(0, 3));
+    const { records } = await fetchCorpus({ pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A] });
+    assert.deepEqual(records.map((r) => r.event.id).sort(), ['a', 'b', 'c', 'n']);
+});
+
+test('a dead relay (connect failed → ok:true but byRelay.failed) lands in relayErrors', async () => {
+    // The background resolves ok:true for unreachable relays — the
+    // queryRelays connect-catch marks the per-relay stat instead.
+    reset(null);
+    globalThis.chrome.runtime.sendMessage = (message, cb) => {
+        sentMessages.push(message);
+        const relay = message.relays[0];
+        if (relay === RELAY_A) {
+            cb({ ok: true, events: [], byRelay: { [relay]: { received: 0, eose: true, failed: true, error: 'connect failed' } } });
+        } else {
+            const events = message.filter.until === undefined ? [ev('ok1', 10)] : [ev('ok1', 10)];
+            cb({ ok: true, events: message.filter.until === undefined ? events : [], byRelay: { [relay]: { received: events.length, eose: true } } });
+        }
+    };
+    const { records, relayErrors } = await fetchCorpus({
+        pubkeys: [PK], entityPubkeys: [], relays: [RELAY_A, RELAY_B]
+    });
+    assert.deepEqual(Object.keys(relayErrors), [RELAY_A]);
+    assert.match(relayErrors[RELAY_A], /connect failed/);
+    assert.equal(records.length, 1);
+    // Restore the scripted handler transport for later tests.
+    globalThis.chrome.runtime.sendMessage = (message, cb) => {
+        sentMessages.push(message);
+        const relay = message.relays && message.relays[0];
+        try {
+            const result = scriptedHandler(relay, message.filter);
+            if (result && result.error) { cb({ ok: false, error: result.error }); return; }
+            cb({ ok: true, events: result, byRelay: { [relay]: { received: result.length, eose: true } } });
+        } catch (err) {
+            cb({ ok: false, error: err.message });
+        }
+    };
 });
 
 test('Q1 filter carries authors + the full kind list + a limit', async () => {

--- a/tests/portal-graph.test.mjs
+++ b/tests/portal-graph.test.mjs
@@ -214,3 +214,16 @@ test('layout is deterministic, centered, and gives every node a distinct positio
         seen.add(key);
     }
 });
+
+test('sourced claims get the same assessment decoration as about-claims (12.7 fix)', async () => {
+    const records = [claimRec('claim_said', { source: [FOCUS_PK] })];
+    records.push(rec(30054, [
+        ['d', 'assess:s'], ['a', coord('claim_said')], ['r', 'https://example.com/v'],
+        ['stance', '-2'], ['L', 'xray/assessment'],
+        ['l', 'misleading', 'xray/assessment'], ['l', 'flip-flop', 'xray/assessment']
+    ], 'judged', 900));
+    const g = buildEgoGraph(baseItems(records), { focusPubkey: FOCUS_PK, entityIndex: ENTITY_INDEX });
+    const node = g.nodes.find((n) => n.nodeType === 'sourced-claim');
+    assert.equal(node.stance, -2);
+    assert.equal(node.labelCount, 2);
+});

--- a/tests/portal-library.test.mjs
+++ b/tests/portal-library.test.mjs
@@ -166,7 +166,7 @@ test('isOtherClient: badge only when a client tag exists and is not ours', () =>
 
 test('EMPTY_FILTERS and TYPE_DEFS are pinned', () => {
     assert.deepEqual(EMPTY_FILTERS,
-        { type: 'all', platform: '', domain: '', caseName: '', client: 'all', query: '', after: 0, before: 0 });
+        { type: 'all', platform: '', domain: '', caseName: '', client: 'all', status: 'all', query: '', after: 0, before: 0 });
     assert.deepEqual(TYPE_DEFS.map((d) => d.key),
         ['article', 'claim', 'comment', 'assessment', 'link', 'entity', 'case', 'account', 'other']);
     assert.equal(kindLabel(30040), 'Claim');
@@ -183,4 +183,27 @@ test('malformed events degrade to other-typed generic items, never vanish', () =
     assert.equal(items.length, 3);
     for (const item of items) assert.ok(item.title.length > 0);
     assert.deepEqual(items.map((i) => i.typeKey).sort(), ['entity', 'other', 'other']);
+});
+
+// ------------------------------------------------------------------
+// Phase 12.7 review fixes
+// ------------------------------------------------------------------
+
+test('status facet filters on reconStatus; unannotated items read as no-ledger', async () => {
+    const { pageWindow } = await import('../src/portal/library.js');
+    const items = buildItems(corpus(), { entityIndex: {} }).map((i, n) => ({
+        ...i,
+        reconStatus: n === 0 ? 'confirmed' : (n === 1 ? 'remote-only' : undefined)
+    }));
+    assert.equal(applyFilters(items, { status: 'confirmed' }).length, 1);
+    assert.equal(applyFilters(items, { status: 'remote-only' }).length, 1);
+    assert.equal(applyFilters(items, { status: 'no-ledger' }).length, items.length - 2);
+    assert.equal(applyFilters(items, { status: 'all' }).length, items.length);
+
+    // pageWindow: the Library's incremental-reveal cap.
+    const win = pageWindow(items, 3);
+    assert.equal(win.shown.length, 3);
+    assert.equal(win.remaining, items.length - 3);
+    assert.deepEqual(pageWindow(items, 0).shown.length, items.length); // 0 = no cap
+    assert.deepEqual(pageWindow([], 5), { shown: [], remaining: 0 });
 });

--- a/tests/portal-reconcile.test.mjs
+++ b/tests/portal-reconcile.test.mjs
@@ -36,7 +36,7 @@ globalThis.chrome = {
     }
 };
 
-const { loadLocalLedger, reconcile } = await import('../src/portal/reconcile.js');
+const { loadLocalLedger, reconcile, countLocalOnly } = await import('../src/portal/reconcile.js');
 const { Storage } = await import('../src/shared/storage.js');
 const { Crypto } = await import('../src/shared/crypto.js');
 const { saveArticle } = await import('../src/shared/archive-cache.js');
@@ -117,8 +117,11 @@ test('loadLocalLedger derives every addr rule from the local stores', async () =
     await Storage.set('evidence_links', {
         link_bbbbbbbbbbbbbbbb: {
             id: 'link_bbbbbbbbbbbbbbbb',
-            source: `30040:${PK_B}:claim_zzz`,
-            target: coord,
+            // Real records store canonical refs under *_claim_id —
+            // pinned here after the 12.7 review caught reconcile
+            // reading nonexistent source/target fields.
+            source_claim_id: `30040:${PK_B}:claim_zzz`,
+            target_claim_id: coord,
             relationship: 'contradicts',
             // publishedKind matters: the 30043-retirement migration
             // clears publish markers that lack it (normalizeLink).
@@ -135,8 +138,11 @@ test('loadLocalLedger derives every addr rule from the local stores', async () =
     await Storage.set('local_keys', {
         'entity:entity_0123456789abcdef': { name: 'entity:entity_0123456789abcdef', pubkey: ENTITY_PK, privateKey: '1'.repeat(64) }
     });
+    // A URL the archive's normalization rewrites — pins that the
+    // article address uses the RAW-url hash (the wire d), not urlHash.
+    const RAW_URL = 'https://X.com/a?utm_source=test';
     const saved = await saveArticle({
-        article: { url: 'https://x.com/a', title: 'The Article' },
+        article: { url: RAW_URL, title: 'The Article' },
         publishedToRelay: true,
         publishedEventId: EV('5')
     });
@@ -166,9 +172,30 @@ test('loadLocalLedger derives every addr rule from the local stores', async () =
     // Entity: replaceable kind-0 address under the entity's own key.
     assert.deepEqual(bySource('entity')[0].addrs, [`0:${ENTITY_PK}`]);
 
-    // Article: d = the archive cache's urlHash.
-    assert.deepEqual(bySource('article')[0].addrs, [`30023:${PK_A}:${saved.urlHash}`]);
+    // Article: d = sha256 of the RAW capture url (what the published
+    // 30023 actually carries) — NOT the archive's normalized urlHash.
+    const expectedArticleD = (await Crypto.sha256(saved.url || RAW_URL)).slice(0, 16);
+    assert.deepEqual(bySource('article')[0].addrs, [`30023:${PK_A}:${expectedArticleD}`]);
     assert.equal(bySource('article')[0].publishedEventId, EV('5'));
+});
+
+test('countLocalOnly tallies never-published records across the models', async () => {
+    _stateStore.clear();
+    await Storage.set('article_claims', {
+        claim_pub0000000001: {
+            id: 'claim_pub0000000001', text: 'published', source_url: 'https://x.com/a',
+            publishedAt: 100, publishedEventId: EV('1'), publishedPubkey: PK_A
+        },
+        claim_unpub00000002: { id: 'claim_unpub00000002', text: 'draft 1', source_url: 'https://x.com/b' },
+        claim_unpub00000003: { id: 'claim_unpub00000003', text: 'draft 2', source_url: 'https://x.com/c' }
+    });
+    await Storage.set('claim_assessments', {
+        assess_aaaaaaaaaaaaaaaa: { id: 'assess_aaaaaaaaaaaaaaaa', claim_ref: { text: 't' }, stance: 1, labels: [], rationale: '' }
+    });
+    const counts = await countLocalOnly();
+    assert.equal(counts.claim, 2);
+    assert.equal(counts.assessment, 1);
+    assert.equal(counts.total >= 3, true);
 });
 
 test('loadLocalLedger: link with a local-id endpoint gets no addr (id-only match)', async () => {
@@ -176,8 +203,8 @@ test('loadLocalLedger: link with a local-id endpoint gets no addr (id-only match
     await Storage.set('evidence_links', {
         link_cccccccccccccccc: {
             id: 'link_cccccccccccccccc',
-            source: 'claim_local000000001',          // endpoint still a local id
-            target: `30040:${PK_A}:claim_pub`,
+            source_claim_id: 'claim_local000000001', // endpoint still a local id
+            target_claim_id: `30040:${PK_A}:claim_pub`,
             relationship: 'supports',
             publishedAt: 100, publishedEventId: EV('6'), publishedKind: 30055
         }

--- a/tests/portal-timeline.test.mjs
+++ b/tests/portal-timeline.test.mjs
@@ -67,10 +67,22 @@ test('buildBuckets: empty/garbage input yields an empty series', () => {
     assert.deepEqual(buildBuckets([{ created_at: 0 }, {}, null]).buckets, []);
 });
 
-test('brushRange normalizes reversed drags and clamps to the series', () => {
+test('buildBuckets: a millisecond-precision created_at cannot explode the series', () => {
+    const d0 = Date.UTC(2026, 5, 1) / 1000;
     const { buckets } = buildBuckets([
-        { created_at: 1000 * DAY + 10 },
-        { created_at: 1002 * DAY + 10 }
+        { created_at: d0 },
+        { created_at: d0 * 1000 }   // 13-digit ms timestamp from a broken writer
+    ]);
+    // The insane stamp is ignored entirely — one bucket, not ~3 million.
+    assert.equal(buckets.length, 1);
+    assert.equal(buckets[0].count, 1);
+});
+
+test('brushRange normalizes reversed drags and clamps to the series', () => {
+    const d0 = Date.UTC(2026, 5, 1) / 1000;
+    const { buckets } = buildBuckets([
+        { created_at: d0 + 10 },
+        { created_at: d0 + 2 * DAY + 10 }
     ], { bucket: 'day' });
     assert.equal(buckets.length, 3);
     const forward = brushRange(buckets, 0, 1);


### PR DESCRIPTION
Final Phase 12 slice (design `docs/PORTAL_DESIGN.md` #48; slices #49–#54). Per the working agreement, a **multi-agent adversarial review** ran over the finished slices — three lenses (correctness / integration / design-fidelity), 24 agents, every finding adversarially probe-verified against the real code: **20 confirmed, 1 refuted**. All 20 are fixed here; the full record is the JOURNAL 2026-06-11 entry.

## The load-bearing fixes

- **Dead relay ≠ empty relay** — `queryRelays` resolves `ok:true, events:[]` for a failed connect (deliberate Phase 5 pool behavior), so the portal's relay-failure UI and sync-cursor guard were dead code and an *offline* Refresh silently advanced the cursor. The connect-catch now stamps `failed`/`error` on the per-relay stat (additive) and the portal honors it.
- **Inclusive-`until` pagination** — `until = oldest − 1` dropped same-second events at a relay's response-cap boundary (the *normal* corpus shape: bulk publishes share a second). Now `until = oldest` with a per-relay "nothing new" terminator, so concurrent relays can't truncate each other's backfill either.
- **Cursor fingerprints** — the sync cursor records the author + relay sets and advances only on a clean pass; a newly added npub or relay gets a full backfill, not a one-hour window.
- **Read-only breach closed** — "Open in reader" stash carries `readOnly: true`; the reader skips its unconditional archive-cache save (which would have reset `publishedToRelay`).
- **Reconcile contract fixes** — link endpoints read from `source_claim_id`/`target_claim_id` (the test had seeded the same fiction it then passed); article addresses match by the raw-URL hash the wire `d` actually uses.
- Plus: ms-timestamp timeline guard, sourced-claim assessment tinting, inspectable case-dashboard rows, the designed ledger-status facet, show-more pagination, local-only counts + legend, portal links in the options/side-panel headers, and IDB-failure live-only degradation.

## Also here

`docs/SMOKE_TEST.md` gains the grouped **§Phase 12** checklist (12.1–12.28, the acceptance walk); CHANGELOG/ROADMAP/JOURNAL updated; ROADMAP marks Phase 12 complete pending the smoke-run.

Gates: build ✅ · 670/670 tests ✅ · web-ext lint 0 errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)