### PR TITLE
docs: Phase 13 kickoff rev 2 — grounded in the recovered auditor framework

### DIFF
--- a/docs/EPISTEMIC_AUDIT_KICKOFF.md
+++ b/docs/EPISTEMIC_AUDIT_KICKOFF.md
@@ -1,305 +1,298 @@
-# Phase 13 — Epistemic audits: recording what you *checked*, not just what you concluded
+# Phase 13 — Epistemic audits: the X-Ray auditor, integrated
 
-**Status:** kickoff brief, 2026-06-11. This is the prompt for a *new
-session* to design Phase 13. **Design note ONLY this session** — the
-maintainer has explicitly scoped this run to producing
-`docs/EPISTEMIC_AUDIT_DESIGN.md` for review; **no feature code, no wire
-builders, no UI, not even "obviously safe" model scaffolding** until the
+**Status:** kickoff brief, 2026-06-11 (rev 2 — now grounded in the
+maintainer's recovered auditor framework; supersedes the rev-1
+reconstruction). This is the prompt for a *new session* to design
+Phase 13. **Design note ONLY this session** — the maintainer has
+explicitly scoped this run to producing `docs/EPISTEMIC_AUDIT_DESIGN.md`
+for review; **no feature code, no wire builders, no UI** until the
 review questions at the bottom of the design note are answered. The
 Phase 10/11/12 cadence applies, but this session ends at the design PR.
 **Verify everything here against the current `main` first — the repo is
 the source of truth and may have moved.**
 
-## Provenance warning — read this before believing this brief
-
-The "epistemic audit" concept below is a **reconstruction**. The
-maintainer developed the original framework in conversations that were
-not accessible when this brief was written (confirmed inaccessible:
-other-chat history, session transcripts, memory; in the repos, no
-framework exists — the only "epistemic" hit anywhere in history is an
-incidental topic-tag example in a dropped plan, see below). What WAS
-recoverable is three planning docs that lived in this repo's
-`docs/plans/` tree at commit `71ee3e2` (later dropped from the tree in
-`6bb1932` — retrieve from history, all runnable from the repo root):
-
-```sh
-git show 71ee3e2:docs/plans/evidentiary-standards.md      # 2,840 lines
-git show 71ee3e2:docs/plans/trust-reputation-system.md    # 2,162 lines
-git show 71ee3e2:docs/plans/NIP-COURT-OF-PUBLIC-OPINION.md
-```
-
-Read all three (inputs, not specs; see "Mining the prior art" below).
-The third is the maintainer's own 2026-04 draft — codes of conduct
-(kind 32150: versioned, inheritable **clause lists** with ids and
-severities), grievances citing clauses, self-published verdicts. Note
-its explicit split: "Disputes address *facts*; grievances address
-*behavior*." The epistemic-audit layer is plausibly the **facts
-sibling** of that behavior track — structured examination against
-codified criteria, producing a signed finding — and the 32150
-clause/`extends`/versioning pattern is a live candidate for publishing
-audit *methodologies* as first-class events. Take the parallel
-seriously; it is the closest thing to the maintainer's own voice on
-this topic that survives in the repo.
-
-Because the concept is reconstructed, your design note must treat
-**the concept itself as reviewable**, not just the implementation:
-state the conceptual commitments crisply, and put a review question to
-the maintainer asking where the reconstruction diverges from their
-original framework. Expect corrections; design so corrections are
-cheap (vocabularies and enums, not schemas and engines).
-
-## Your job this session
-
 Repo: `/Users/bryan/Library/CloudStorage/Dropbox/working/xray`
 (github.com/bryanmatthewsimonson/xray) — you should already be in it.
 This brief lives at `docs/EPISTEMIC_AUDIT_KICKOFF.md` on `main`.
 
-Design (do not build) an **epistemic-audit layer** for X-Ray: a
-structured, repeatable, signed record of *the checks performed* on an
-epistemic object — a claim, a source, a case, a capture, or your own
-judgment history — and *what those checks found*, as distinct from the
-verdict you hold about it. X-Ray already records verdicts (kind-30054
-assessments: stance + issue labels). The audit is the complement:
-**assessment = my judgment OF the claim; audit = my examination of the
-claim's SUPPORT.** Financial-audit framing: methodology, working
-papers, findings, an opinion, and an artifact someone — including
-future-you — can re-perform.
+## Provenance — what is authoritative here
 
-The orthogonality is the payoff, so protect it: a user can disagree
-(−2) with a well-supported claim, and agree (+2) with one whose audit
-returns unsupported. That second cell — *agree, unsupported* — is "I
-believe this on vibes," arguably the single most valuable thing a
-personal epistemics tool can show its user. A design that lets audits
-read as endorsements (or assessments masquerade as audits) has failed.
+The maintainer's epistemic-auditor framework, developed in prior
+conversations, is **recovered and vendored in this repo** at
+`docs/auditor-prototype/` — read ALL of it before anything else:
 
-## Read first (and verify — don't take this brief's word for it)
+- `docs/auditor-prototype/README.md` — the architecture and the design
+  rationale, in the maintainer's own words. Authoritative.
+- `docs/auditor-prototype/prompts/00`–`08` — the eight surface-scan
+  module methodologies (versioned prompts with scoring rubrics and
+  structured-JSON output contracts) plus a single-shot orchestrator.
+- `docs/auditor-prototype/schema/audit-types.ts` — the full data
+  model: content-addressed articles, atomic claims, module results,
+  aggregate audits with knowability ceiling, prediction ledger +
+  resolutions, author/publication dossiers with Bayesian shrinkage,
+  audit disputes, auditor identity, cross-auditor disagreement.
+- `docs/auditor-prototype/scorer/` — a working Node prototype that
+  fans the eight modules out in parallel against the Anthropic API and
+  aggregates (weights, ceiling, confidence stacking).
+
+Three referenced artifacts were NOT recovered: `schema/README.md`
+(cited by the README for the per-entity kind suggestions),
+`schema/relational.sql` (cited in audit-types.ts's header), and the
+per-module findings JSON schemas in `schema/modules/` (cited by
+`ModuleResult.findings` — note the scorer's "validates each output"
+header is aspirational; the code only extracts JSON). Also unrecovered:
+the original conversation's prose on "governing principles, dimensions,
+knowability, calibration multiplier, dispute mechanics, accessibility
+tiers" (the README's final paragraph points to it). Where any of these
+would have answered a question — the module findings schemas bear
+directly on your module-result wire shape — put the question to the
+maintainer rather than inventing the answer.
+
+An earlier revision of this brief reconstructed the concept from first
+principles before the framework was recovered. Where the
+reconstruction conflicts with the framework, **the framework wins** —
+notably: the framework scores on 0–100 scales with confidence values
+and a knowability ceiling (the reconstruction had forbidden numeric
+scores), and the auditor is primarily a *model/pipeline* running
+versioned prompt methodologies (the reconstruction had designed
+human-run checklists). What genuinely converged, keep: the
+audit/assessment firewall, evidence-bound findings, content-hash
+anchoring against stealth edits, audits accumulating as time-series
+rather than replacing, and auditing-the-auditors.
+
+## The framework in one breath
+
+An **outsider with full transparency, modest claims, and a published
+method** examines the *published artifact* — it cannot re-report the
+story, only audit what was printed. Eight surface-scan modules, each a
+self-contained versioned methodology: headline-body fidelity,
+asymmetric language, number hygiene (denominator / base rate /
+comparison class), source quality, internal coherence, definitional
+precision, omission (who got the microphone), and prediction
+extraction (not scored at audit time — banked in a ledger and resolved
+against reality later; the calibration record is "the long-game
+asset"). Module scores (0–100, each with confidence 0.0–1.0) aggregate
+under documented weights, capped by a **knowability ceiling** so
+careful reporting on hard-to-verify topics isn't penalized. Everything
+is content-addressed to the SHA-256 of the normalized article markdown
+(outlets stealth-edit; audits must anchor to the exact text scored),
+attributed to a first-class **auditor identity** (model+version, human
+pubkey, pipeline, or consensus-with-constituents), versioned per
+methodology, accumulated as time-series, disputable through a
+filed-and-adjudicated challenge pipeline, and rolled up into
+**dossiers** over four subject kinds — author, publication, beat, and
+publication×beat (a beat is a bare tag, not an entity — your d-tag and
+subject design must carry that). Disagreement between auditors is
+**published, not averaged**.
+
+Settled with one named exception class: the README's "What's not yet
+built (intentionally)" list (persistence, dispute runtime,
+multi-auditor consensus, dossier queries, knowability module) is open
+by the framework's own admission. The sharpest instance: the two
+vendored implementations *disagree on who sets the knowability
+ceiling* — `prompts/00` has the auditing model set it ("Set this
+thoughtfully"), while `scorer.js`'s `aggregate()` derives it from
+source-quality stats with a hand-tuned clamp, and the README calls
+that heuristic less defensible than a dedicated module. Your
+AggregateAudit wire shape must state who sets the ceiling; put it on
+the review-questions list.
+
+The governing principles in `prompts/00` are load-bearing for every
+design decision: evidence-bound (every finding quotes exact text),
+knowability-aware, symmetric, calibrated, no-reformulation.
+
+**Audits and assessments remain firewall-separated.** A kind-30054
+assessment is the user's *judgment of a claim's content*; an audit is
+a *methodical examination of the published artifact's craft and
+support*. The NIP_DRAFT precedent (30051-vs-30054: "consumers MUST NOT
+merge") applies with full force. A user can disagree with a
+high-scoring article and agree with a low-scoring one — the framework's
+calibration machinery only works if those signals never blend.
+
+## Read next (and verify — don't take this brief's word for it)
 
 - `CLAUDE.md` — contexts, conventions, the `xray:*` bus. **CAUTION:**
-  parts of it are stale (pre-Phase-11): its event-builder kind list
-  still shows retired 30043 as live and omits 30054/30055, and its
-  roadmap line stops at Phase 9a/v0.5.0. On kinds and phase status,
-  trust `docs/ROADMAP.md`, `docs/ASSESSMENTS_DESIGN.md`, and the code
-  — they postdate it. (Fixing CLAUDE.md is queued separately; not your
-  concern tonight.)
+  parts are stale (pre-Phase-11): its event-builder kind list still
+  shows retired 30043 as live and omits 30054/30055, and its roadmap
+  line stops at Phase 9a/v0.5.0. On kinds and phase status, trust
+  `docs/ROADMAP.md`, `docs/ASSESSMENTS_DESIGN.md`, and the code.
 - `docs/ASSESSMENTS_DESIGN.md` — the Phase 11 design this layer sits
-  beside; its "why a new kind" rationale (§ kind 30054 vs 30051/30052)
-  is the template for your own kind-number argument.
-- `docs/NIP_DRAFT.md` — the wire conventions: `d`-tag recomputability,
-  `r` verbatim + `i` normalized, the 30051-vs-30054 "consumers MUST NOT
-  merge" firewall you'll replicate for audits-vs-assessments.
-- `docs/PORTAL_DESIGN.md` + `docs/PORTAL_KICKOFF.md` — Phase 12; the
-  portal is where audit-derived views will surface.
-- `src/shared/assessment-taxonomy.js` — the label grammar and the
-  custom-label escape hatch (`family/value`, ≤64 chars). Note the
-  existing vocabulary is entirely *failure-mode* labels; "I checked X
-  and it held" is currently unrepresentable.
+  beside; its "why a new kind" section is the template for your
+  kind-number arguments.
+- `docs/NIP_DRAFT.md` — wire conventions: `d`-tag recomputability,
+  `r` verbatim + `i` normalized, flag-gating, the MUST-NOT-merge
+  firewall idiom.
+- `docs/PORTAL_DESIGN.md` — Phase 12; the portal is a natural display
+  surface for audit results and dossiers.
+- `src/shared/event-builder.js` + `src/shared/metadata/builders.js` —
+  the `{event, body, dTag}` builder contract; the dormant kind-30051
+  fact-check builder (ClaimReview JSON-LD + repeatable `evidence`
+  tags) is the closest existing wire shape to a module result.
+- `src/shared/html-snapshot.js` — X-Ray already hashes captured
+  content (`html_snapshot_sha256` tag on 30023s). The framework
+  content-addresses the *normalized markdown* with its own
+  normalization (`scorer.js` `normalizeMarkdown`). Two hash
+  disciplines, one purpose — the design note must reconcile them into
+  one canonical article-hash story.
 - `src/shared/claim-ref.js` + `src/shared/assessment-model.js` — the
-  local-id/coordinate duality and publish-time coordinate backfill.
-  Your audit record's target-ref scheme inherits this machinery (and
-  its hard-won rules: a record referencing an unpublished local claim
-  cannot publish; republished claims acquire second coordinates,
-  tracked via `claimPublishedPubkeys`).
-- `src/shared/metadata/builders.js` — the `{event, body, dTag}` builder
-  contract, and the **dormant kind-30051 fact-check builder**: its
-  repeatable `evidence` tags are the only evidence-attachment primitive
-  in the codebase today.
-- `src/shared/html-snapshot.js` + `src/shared/screenshot.js` — capture
-  evidence with SHA-256 hashes, published as 30023 tags
-  (`html_snapshot_sha256`, `screenshot_sha256`). Page-level only; no
-  per-claim or per-judgment evidence binding exists.
-- `src/shared/case-export.js` — the deterministic case artifact
-  (closest existing thing to an audit report; client-side, unsigned).
-- `src/portal/reconcile.js` — `LEDGERED_KINDS` and address
-  recomputation; a published audit kind must join this machinery.
+  local-id/coordinate duality and publish-time backfill; audit records
+  that reference claims inherit this machinery.
+- `src/shared/metadata/feature-flags.js` — the gating pattern; expect
+  a new default-off flag (e.g. `epistemicAuditing`).
+- Background prior art (in-history): `git show
+  71ee3e2:docs/plans/evidentiary-standards.md`, `...:docs/plans/
+  trust-reputation-system.md`, `...:docs/plans/NIP-COURT-OF-PUBLIC-
+  OPINION.md`. The first two are userscript-era network designs —
+  mine vocabulary, refuse the network machinery. The third (the
+  maintainer's own clause/grievance/verdict draft) is structurally
+  adjacent to the framework's **AuditDispute** pipeline; note the
+  rhyme in the design.
 
-## What exists, what's missing
+## The integration problems the design note must solve
 
-The audit layer composes with shipped primitives: claims (30040,
-coordinate-addressed, span-anchored), assessments (30054: stance −2..+2,
-labels with per-label anchors + notes, `suggested_by` provenance),
-relationships (30055: contradicts/supports/updates/duplicates), label
-mirrors (1985), cases-as-entities with shareable key bundles, the
-dormant Phase 9a kinds (30050 annotations, 30051 fact-checks with
-ClaimReview JSON-LD + `evidence` tags, 30052 ratings, 30053
-topic-trust, 9803 helpfulness), capture-evidence hashing, case export,
-and the portal's read-back/reconciliation.
+These are the actual design work. The framework's shape is the
+maintainer's settled intent (modulo its own not-yet-built list, above);
+its *integration into X-Ray* is not.
 
-The genuine gaps your design fills (verify each against the code):
-
-1. **No record of checks performed.** Assessments record conclusions;
-   nothing distinguishes "I verified the primary source and it held"
-   from "I never looked." A clean claim and an unexamined claim are
-   indistinguishable.
-2. **No evidence-attachment primitive.** Kind 30043 was *retired* in
-   Phase 11 (do not reuse the number); 30055 links claim↔claim only.
-   "The evidence behind this judgment" has no representation.
-3. **No per-source track record.** Nothing computes "across my corpus,
-   this source's claims failed verification N times."
-4. **No staleness story for judgments.** Targets update; prior
-   examinations silently keep vouching.
-5. **No calibration surface.** Stance history is never compared to how
-   claims resolved or how well-supported they proved to be.
-
-Kind-number space: 30056+ is free (30042 also unused; 30044–30049
-free; 30043 retired-do-not-reuse). The contiguous 3005x block keeps the
-metadata-layer conventions reusable — but argue your choice in the
-note the way ASSESSMENTS_DESIGN argued 30054.
-
-## The reconstructed concept (treat as a strawman to refine)
-
-Two tiers run through everything below — keep them separate in the
-note:
-
-- **Verified against `main` — keep:** no numeric confidence (the 0–100
-  field was deliberately removed in Phase 10.1; see
-  `docs/CLAIMS_REDESIGN.md`); a separate kind with a hard
-  consumers-MUST-NOT-merge firewall (the NIP_DRAFT 30051-vs-30054
-  precedent); local-first, flag-gated, `d` recomputable, dual-read;
-  design-note-only scope this session.
-- **Reconstruction — challenge freely:** every named check, the
-  outcome and opinion enums, the depth field, the derived views, the
-  failure-mode mitigations. These are one defensible shape, not the
-  maintainer's settled intent.
-
-**Targets.** Claim audits first; the design should make source, case,
-capture, and self (calibration) audits *additive vocabularies on the
-same record shape*, not new shapes. A sixth target — auditing an audit
-(re-performance) — is what keeps the artifact honest; design for it,
-don't build it.
-
-**Instrument.** Per-target check vocabularies in the house label
-grammar: small (≤8 checks), namespaced + versioned
-(`xray/audit/claim@1`), one shared outcome enum everywhere —
-`pass | fail | n-a | blocked`. `blocked` (attempted, couldn't
-determine: paywall, dead link) is not `fail`; recording *inability to
-verify* is half the point. Candidate claim-audit checks to refine:
-`traced` (followed to origin utterance, not a paraphrase chain),
-`primary` (primary source located), `corroborated` (independent
-second source — not the same wire copy), `anchored` (tied to exact
-span), `firsthand` (asserter positioned to know), `current` (no
-superseding update), `contradictions-examined` (outstanding 30055s
-each looked at — deliberately *examined*, not "cleared": whether they
-resolve in the claim's favor is assessment territory), `archived`
-(evidence durable). Checks may carry a note, a W3C-selector anchor
-(the `label-anchor` idiom), and an evidence ref.
-
-**Record.** Addressable per (author, target, methodology, as-of):
-**target ref** + `methodology@version` + `as-of` date **+ target
-content hash** (staleness detection) + `depth` (spot/standard/deep —
-effort, which is observable) + checks with outcomes + an **opinion
-enum** lifted from financial audit. The target ref is real design
-work, not a footnote: claims inherit the local-id/coordinate duality
-and publish-time backfill from the assessment layer
-(`claim-ref.js`, `resolveClaimRef`), but a *source* is a domain or
-entity, a *case* is an entity pubkey, and *self* is the user pubkey —
-none of which is an event coordinate; the note must define the ref
-scheme per target. Re-audits accumulate as dated artifacts (unlike
-30054, where latest-wins replacement is correct). **No numeric
-confidence anywhere** — the 0–100 confidence field was deliberately
-removed from claims in Phase 10.1; don't reintroduce false precision
-through the back door. **Choose opinion tokens disjoint from
-`STANCE_LABELS` and `ASSESSMENT_LABELS`** in
-`src/shared/assessment-taxonomy.js` — beware: the obvious candidate
-`unsupported` is ALREADY an assessment label, so a naive
-supported/unsupported enum breaks the firewall at the vocabulary
-level; the financial-audit-native tokens
-(`clean | qualified | adverse | disclaimer`) are collision-free
-candidates — argue the choice in the note.
-
-**Derived views (single corpus, no network):** source track records
-(outcome rates with visible denominators — never a composite score),
-case readiness ("3 of 7 load-bearing claims audited; 2 contradictions
-open"), the stance×opinion calibration quadrant with *agree,
-unsupported* as the headline cell, an audit coverage/staleness map, and
-a re-audit queue ("claims you lean on hardest, unaudited or stale").
-
-**Known failure modes to design against** (address each in the note):
-rubric theater (mitigations: `pass` on load-bearing checks requires a
-note or evidence ref; `n-a`/`blocked` are the cheap honest outcomes; an
-always-passing check is surfaced as decorative), false precision (no
-numbers in records; fractions with denominators in views), audit rot
-(`as-of` hash → visible stale flag; re-audit pre-filled from the prior
-one), assessment conflation (separate kind, disjoint vocabulary,
-distinct UI verb — "Assess ⚖" vs "Audit 🔍"), and **dangling or
-fragmented audits** — the target gets deleted (the reader
-cascade-deletes a claim's links and assessment; is cascade right for
-an *accumulating* audit trail whose point is re-performance, or do
-audits outlive their target?) or republished under a new signing
-identity (`claim-ref.js` design rule 1 / `claimPublishedPubkeys` —
-coordinate-keyed audit history would fragment across pubkeys, and the
-content hash can't detect it because the text didn't change). Say how
-audit history follows the claim.
-
-## Mining the prior art (and what to refuse from it)
-
-Both userscript-era docs assume a *network* of strangers and engineer
-for adversaries; v1 is **one user auditing their own corpus**. Mine
-selectively:
-
-- From `evidentiary-standards.md`: the evidence-type taxonomy
-  (primary/secondary/tertiary/supporting with subtypes) is genuinely
-  useful **as typed evidence-refs** on checks — flattened to the label
-  grammar (`evidence/primary/official-document`), not the 0.95-weight
-  scoring apparatus. The claim-evidence matrices' *red-flag lists* are
-  good seed material for check vocabularies. **Refuse:** the quality
-  formula, time-decay functions, confidence intervals, aggregation
-  bonuses — all numeric machinery the no-false-precision rule excludes.
-- From `trust-reputation-system.md`: the *framing* that track records
-  are computed from validated outcomes (not vibes) survives as the
-  source-audit target. **Refuse:** reputation scores, web-of-trust,
-  transitive trust, TrustRank, cold-start, anti-Sybil — all of it
-  requires the network and is an explicit non-goal; say so in the note.
-  (Topic-trust 30053 already covers "whom I trust per topic" as an
-  input prior; don't duplicate it.)
-- From `NIP-COURT-OF-PUBLIC-OPINION.md`: the **clause pattern** —
-  codified criteria with stable ids, severities, versioning, and
-  `extends` inheritance, published as an addressable event — is a
-  serious candidate for representing audit *methodologies* on the wire
-  (a check vocabulary IS a clause list for facts). Mine the structure
-  and the facts-vs-behavior split. **Refuse:** trust-graph-weighted
-  verdict aggregation (network-era), and don't conflate a grievance
-  (someone violated a norm) with an audit finding (a claim's support
-  was examined).
+1. **Kind remapping (mandatory).** `audit-types.ts` suggests kinds
+   30050–30055 — written before Phases 9a/11 shipped, and **every one
+   of those numbers is now taken** (30050 annotations, 30051
+   fact-checks, 30052 ratings, 30053 topic-trust, 30054 assessments,
+   30055 relationships; 30043 is retired-do-not-reuse). Free: 30042,
+   30044–30049, 30056+. The note must map the framework's six entity
+   families (module result, aggregate audit, prediction entry,
+   prediction resolution, dossier snapshot, dispute) onto new kinds —
+   or argue fewer kinds with `d`-tag discrimination — with
+   ASSESSMENTS_DESIGN-grade rationale per choice, `d` recomputable
+   from public inputs, dual-read-friendly, flag-gated. Note which
+   entities are addressable (latest-wins is WRONG for audits — the
+   schema says "nothing overwrites prior audits; drift is queryable" —
+   so argue the addressable-vs-regular choice per entity carefully).
+2. **Where the model runs.** The scorer is a Node CLI calling the
+   Anthropic API. X-Ray the extension has no API dependency, no API
+   keys, and a hard local-first posture. Options to weigh (this is
+   the biggest open question — frame it, recommend, and ask):
+   (a) companion-tool architecture — the scorer stays outside the
+   extension, emits signed NOSTR events the extension/portal then
+   reads like any other corpus events; (b) in-extension calls to an
+   LLM API behind settings + the flag (key storage, cost, consent);
+   (c) a manual tier — the module *methodologies* double as guided
+   human checklists run in the reader (the unrecovered "accessibility
+   tiers" prose may have envisioned exactly this — ask); (d) hybrid.
+   Auditor identity must record which path produced each result —
+   the schema already supports model/human/pipeline/consensus, with
+   constituent auditors on the latter two.
+3. **Article hashing, canonically.** One normalization, specified
+   byte-for-byte in the note (the scorer's `normalizeMarkdown` is the
+   candidate), its relationship to `html_snapshot_sha256`, and how a
+   hash mismatch (stealth edit detected) surfaces in the reader and
+   portal. "Capturing both versions is its own diagnostic" — design
+   the re-audit affordance.
+4. **Predictions as first-class records.** The ledger entry and
+   resolution entities have no X-Ray counterpart; claims (30040)
+   carry no prediction semantics (claim types were dropped in 10.1 —
+   `parseClaimEvent` retains a legacy-render path only). Decide:
+   prediction entries as their own kind, with resolution events
+   referencing them; how `resolution_horizon` interacts with the
+   portal timeline; whether a prediction extracted from an article
+   should also atomize into a 30040 claim (probably, with the
+   prediction entry referencing the claim coordinate — argue it).
+5. **Dossiers vs the portal.** DossierSnapshot overlaps Phase 12's
+   read-back surfaces (entity views, reconciliation, timeline). The
+   design should make dossiers *derived, reproducible* views over
+   published audit events (the schema demands reproducibility), and
+   decide what is computed-on-open in the portal vs materialized as a
+   published snapshot event — and whether publication/author entities
+   reuse X-Ray's entity system (org/person + platform accounts) or
+   get their own registry. Strong prior: reuse entities; a
+   publication is an org-entity with domains. But note all FOUR
+   dossier subject kinds: author, publication, **beat**, and
+   **publication×beat** — a beat is a bare topic tag with no entity,
+   so the subject/d-tag scheme cannot assume an entity pubkey, and
+   beat dossiers must not fall out of the fidelity table.
+6. **Disputes.** Map AuditDispute onto X-Ray idioms (and note the
+   Court-of-Public-Opinion rhyme). v1 can be wire-format-only
+   (define the kind, build nothing) — say so explicitly if so.
+7. **Scores, displayed honestly.** X-Ray dropped the claim 0–100
+   confidence slider in 10.1 because its semantics were ambiguous —
+   it read as *how true* but meant *how central* — and the data was
+   noisy (`docs/CLAIMS_REDESIGN.md`, "Why rework"). The framework's
+   scores avoid that failure differently: each module score carries
+   its own confidence, methodology version, and auditor identity; the
+   knowability ceiling lives on the *aggregate*; and cross-auditor
+   disagreement is preserved as a sibling record rather than averaged
+   away. The design note should make the display rule explicit — a
+   score never renders without its confidence, and an aggregate never
+   without its ceiling context — and apply it to every UI surface,
+   especially the score badge (a surface your note *proposes*: the v1
+   trust-badge UI was removed in Phase 0/10 reframes, and the auditor
+   README's "metadata badge surface" line predates that removal).
+8. **Failure modes** (address each): score theater (a 0–100 number
+   invites consumers to ignore the confidence — the display rule
+   above is the mitigation; the knowability ceiling is the other
+   half); methodology ossification (module prompts are versioned —
+   define how a methodology bump invalidates nothing and triggers
+   re-audit offers); audit rot (content-addressing solves text drift;
+   URL drift and article-takedown need a stated posture); LLM auditor
+   variance (same module, same article, different runs — the schema's
+   AuditorDisagreement covers cross-auditor spread; state the
+   single-auditor run-to-run posture, e.g. publish run metadata and
+   treat repeated runs as separate results); dangling audits (article
+   deleted locally; audits reference the hash, which outlives the
+   capture — fine, but say so); and the social failure mode — a
+   published low score is one step from a hit piece; the same
+   defenses as rev 1 apply (first-person, dated, evidence-bound,
+   method published, disputable), now strengthened by the framework's
+   symmetric-standards principle.
 
 ## Working agreement — design note only
 
 - Branch `claude/phase-13-audit-design`. Deliverable:
   `docs/EPISTEMIC_AUDIT_DESIGN.md` in the ASSESSMENTS_DESIGN/
   PORTAL_DESIGN house style — decisions-at-a-glance table; the
-  audit-vs-assessment firewall; the record's local model AND draft wire
-  mapping (kind choice argued, `d` recomputable, dual-read-friendly,
-  flag-gated `epistemicAudits` default-off); check vocabularies;
-  staleness mechanics; derived views + which portal surfaces they
-  extend; the prior-art mine/refuse ledger; non-goals; a slice plan for
-  a later Phase 13 implementation run (13.1 model+taxonomy+tests,
-  13.2 wire builders+NIP-draft, 13.3 reader audit UI, 13.4 portal
-  views, 13.5 publish, or as your design dictates); and **review
-  questions** — including, explicitly, "where does this reconstruction
-  diverge from your original epistemic-audit framework?"
+  firewall section; **fidelity table covering every entity in
+  `schema/audit-types.ts`** (framework entity → X-Ray home → deltas,
+  justified — including entities that map onto existing kinds and
+  ones that become derived views, not just the six new-kind
+  families); kind map with rationale; the runs-where decision
+  framed with a recommendation; canonical hashing spec; wire shapes
+  per entity (tags + `d` derivation, recomputable by hand);
+  local-model + ledger pattern per entity (markPublished, staleness);
+  portal/reader surface sketches; the mine/refuse ledger over the
+  history docs; non-goals (network consensus, multi-auditor
+  aggregation beyond disagreement display, adjudication runtime);
+  slice plan for a later implementation run (model+tests → wire
+  builders+NIP draft → capture-time hashing → companion/manual audit
+  path → portal surfaces → publish, or as your design dictates); and
+  **review questions** — lead with the runs-where architecture and
+  any place the unrecovered philosophy prose (calibration multiplier
+  details, accessibility tiers) forced a guess.
 - **Run a multi-agent adversarial review over the design note itself**
-  before opening the PR (lenses: concept coherence — does the
-  audit/assessment orthogonality survive every section; repo fidelity —
-  every file/kind/convention claim verified against `main`; scope —
-  is each element buildable in small slices and is everything
-  network-shaped excluded). Fix what's confirmed.
+  before opening the PR (lenses: framework fidelity — every deviation
+  from `docs/auditor-prototype/` is flagged and justified, none is
+  silent; repo fidelity — every file/kind/convention claim verified
+  against `main`; scope — small slices, nothing network-shaped,
+  design-note-only honored). Fix what's confirmed.
 - ROADMAP gains a Phase 13 section (status: design under review) +
-  snapshot line. (Housekeeping while you're in there: the §Phase 12
-  section *header* still says "(in progress)" — stale; the status
-  snapshot at the top is authoritative and says complete. Fix the
-  header in passing.) JOURNAL records the second-guessable calls and
-  the provenance caveat. Gate the push on `npm run build`, `npm test`,
-  `npx --yes web-ext lint --source-dir . --self-hosted` even though
-  docs-only. One PR; **stop after opening it** — the maintainer
-  reviews in the morning.
+  snapshot line. (Housekeeping: if the §Phase 12 section header still
+  says "(in progress)", fix it in passing — the snapshot is
+  authoritative.) JOURNAL records the second-guessable calls,
+  including the rev-1→rev-2 reversal on numeric scores (the kind of
+  thing future readers will second-guess). Gate the push on
+  `npm run build`, `npm test`, `npx --yes web-ext lint --source-dir .
+  --self-hosted` even though docs-only. One PR; **stop after opening
+  it** — the maintainer reviews in the morning.
 
 ## Acceptance (for the design note, not a demo)
 
-A maintainer reading `docs/EPISTEMIC_AUDIT_DESIGN.md` cold can: state
-the audit/assessment distinction in one sentence and verify every
-section preserves it; see the exact record a claim audit produces
-(fields, tags, `d` derivation) and recompute the `d` by hand; see what
-the reader and portal would gain, slice by slice; find every numeric-
-scoring temptation from the prior art explicitly refused with a reason;
-and answer a short list of review questions — concept corrections
-first — knowing **nothing has been built yet** that their answers
-would invalidate.
+A maintainer reading `docs/EPISTEMIC_AUDIT_DESIGN.md` cold can: see
+their framework's every entity mapped onto X-Ray kinds and conventions
+with nothing silently dropped or mutated (a fidelity table:
+framework entity → X-Ray home → any deltas, justified); recompute a
+module-result `d`-tag and the article hash by hand from the spec;
+trace one article end-to-end through capture → hash → eight modules →
+aggregate → badge → dossier → dispute, knowing exactly which parts are
+v1 slices, which are wire-format-only, and which are non-goals; find
+the runs-where question framed with costs and a recommendation rather
+than decided by fiat; and answer the review questions knowing nothing
+has been built that their answers would invalidate.

--- a/docs/auditor-prototype/README.md
+++ b/docs/auditor-prototype/README.md
@@ -1,0 +1,58 @@
+# X-Ray Epistemic Auditor
+
+Three deliverables that turn the auditor framework into runnable artifacts. Designed to slot into [bryanmatthewsimonson/xray](https://github.com/bryanmatthewsimonson/xray) — your existing capture pipeline produces the exact input these tools expect.
+
+## Layout
+
+```
+xray-auditor/
+├── prompts/        ← Surface-scan prompt suite. Try in Claude.ai right now.
+├── schema/         ← Dossier data model. NOSTR-aligned.
+└── scorer/         ← Node prototype that orchestrates everything.
+```
+
+## In what order to use this
+
+1. **Browser test the prompts.** Open `prompts/00-orchestrator-single-shot.md`, paste it into Claude.ai followed by an article you want audited (X-Ray's "Capture Article → Markdown" tab gives you the right format). You'll get a single JSON report covering all eight dimensions. Use this to calibrate the scoring against articles where you already have a strong intuition — it's the fastest way to surface where the prompts need tuning.
+
+2. **Read the schema.** `schema/audit-types.ts` defines every entity: articles (content-addressed by SHA-256 of normalized markdown), atomic claims, per-module results, aggregate audits, prediction ledger entries, prediction resolutions, author/publication dossiers, and audit disputes. NOSTR kind suggestions for each are in `schema/README.md`. The schema is what makes audits cross-publishable across X-Ray's NOSTR backbone.
+
+3. **Run the prototype scorer.** `cd scorer && npm install && node example-usage.js` produces a full audit of a sample article in roughly one round-trip's worth of time (eight parallel API calls). Then point it at real articles via `node scorer.js --input article.md --metadata meta.json --output audit.json`.
+
+## What this is, structurally
+
+- The **prompts** are the auditor's eyes. Each module is a self-contained, versioned scoring methodology that produces structured findings with evidence quotes for every claim.
+- The **schema** is the auditor's memory. Every article, claim, module result, and aggregate score lives as a discrete entity, time-stamped, attributed to its auditor, and content-anchored to the immutable text it scored.
+- The **scorer** is the auditor's reflex. It takes a captured article, fans out the eight modules in parallel, validates and aggregates, and returns a structured report. Future versions wire this into NOSTR publishing as audit events that other clients can verify, dispute, and roll up.
+
+## What's not yet built (intentionally)
+
+- **Persistence layer.** The scorer returns JSON; production needs a store. For X-Ray, that store is NOSTR relays publishing the suggested kinds (30050–30055).
+- **Dispute pipeline.** Schema includes `AuditDispute`; the runtime to file, adjudicate, and re-score on upheld disputes is still to come.
+- **Multi-auditor consensus.** Single Claude instance for the prototype. Production should run the same article through multiple models (Claude + GPT + a human) and surface the disagreement rather than averaging it away.
+- **Dossier rollup queries.** `DossierSnapshot` is defined; the SQL/relay queries that materialize it from underlying audits are next.
+- **Knowability module.** Currently derived heuristically from source-quality findings. A dedicated module — or a beat-specific lookup table — would be more defensible.
+
+## Why the design choices
+
+- **Content-addressed articles.** Outlets stealth-edit. The hash anchors every audit to the exact text that was scored, so old audits don't silently apply to new content. Capturing both versions is its own diagnostic.
+- **Per-module results stored independently.** When a module's methodology improves, only that module needs recomputing; old results remain valid under their original methodology version.
+- **Auditor identity is first-class.** Every score carries who produced it (model+version, human pubkey, or pipeline). The system can — and should — audit the auditors over time.
+- **Disagreement is published, not averaged.** When multiple auditors score the same article, all individual scores and their variance are preserved. False consensus is more dangerous than visible disagreement.
+- **Predictions extracted at audit time, resolved later.** The long-game asset. A multi-year prediction ledger graded against reality is the most powerful retrospective evidence about an author's calibration that exists.
+- **Knowability ceiling.** Articles on inherently hard-to-verify topics (classified intelligence, private corporate matters) get capped maximum scores. Without this, you penalize careful reporters for working hard problems.
+
+## How this fits X-Ray specifically
+
+X-Ray is structurally well-positioned for this work because:
+
+- **NOSTR-native publishing** means audits are public, signed, and aggregable across the network without a central authority. This is what an epistemic auditor *should* be — accountable, reproducible, decentralized.
+- **The capture pipeline already produces clean markdown** via Readability + Turndown. Layer 1 of the auditor architecture (ingestion + normalization) is essentially done.
+- **Phase 4's planned `kind: 30040` claims** are the atomization layer. The auditor's surface scans produce findings that reference these claims, and the dossier rollups aggregate across them.
+- **The metadata badge surface** is the natural display surface for audit scores. A reader visiting an article sees an aggregated score, the per-module breakdown, and the option to file a dispute — all from existing X-Ray UI.
+
+The auditor isn't a separate project. It's the next phases.
+
+---
+
+For the underlying philosophy (governing principles, dimensions, knowability, calibration multiplier, dispute mechanics, accessibility tiers), see the conversation that produced these deliverables. The TL;DR: an outsider with full transparency, modest claims, and a published method beats an insider with privileged access and unstated priors over a long enough timeframe — and these tools are the published method.

--- a/docs/auditor-prototype/prompts/00-orchestrator-single-shot.md
+++ b/docs/auditor-prototype/prompts/00-orchestrator-single-shot.md
@@ -1,0 +1,211 @@
+# Surface-Scan Orchestrator — Single-Shot
+
+**Use this for:** Quick testing in Claude.ai. Paste this entire prompt followed by the article markdown. Claude will run all eight surface-scan modules in one pass and return a single aggregated JSON report.
+
+**Tradeoff:** This is faster and cheaper but less rigorous than running each module independently. For production use, run the individual module prompts (`01`–`08`) separately and aggregate with the scorer.
+
+---
+
+You are an epistemic auditor evaluating a published news article against eight transparent dimensions of journalistic quality. You are an outsider applying surface-detectable standards — you cannot re-report the story, only examine the published artifact.
+
+# Governing principles
+
+- **Evidence-bound.** Every finding must quote specific text from the article. Never paraphrase what the article says when scoring it.
+- **Knowability-aware.** If a dimension cannot be reliably evaluated from the article alone (e.g., source quality on a national-security story relying on classified intelligence), say so and lower confidence rather than guessing.
+- **Symmetric.** Apply the same standards regardless of the article's political valence, subject, or author.
+- **Calibrated.** Express uncertainty honestly. A confident wrong score harms credibility more than a hedged score.
+- **No reformulation.** Do not rewrite the article in your head into a charitable version before scoring it. Score what was published.
+
+# The eight dimensions
+
+1. **Headline-Body Fidelity** — Do the headline and subhead accurately preview the body's actual content, with proportional emphasis?
+2. **Asymmetric Language** — Are verbs, adjectives, and framing applied symmetrically to comparable parties or actions?
+3. **Number Hygiene** — Do numerical claims include denominators, base rates, and comparison classes where relevant?
+4. **Source Quality** — Are sources named where possible, anonymous sourcing justified, contested claims multi-sourced, primary documents cited?
+5. **Internal Coherence** — Is the article internally consistent across paragraphs, between text and any charts/captions, and between claims and evidence?
+6. **Definitional Precision** — Are contested terms defined or smuggled? (Examples: "extremist," "violence," "expert," "moderate," "inflation.")
+7. **Omission** — Who is quoted, who is referenced but not given voice, and who is conspicuously absent given the topic?
+8. **Predictive Content** — What testable predictions, implicit or explicit, does the article make? (These feed a separate ledger; extract them, do not score them yet.)
+
+# Scoring guidance
+
+For each scoreable dimension (1–7), produce a 0–100 score with this calibration:
+
+- **90–100:** Exemplary on this dimension. Affirmative best practice visible.
+- **75–89:** Solid. Minor issues at most.
+- **60–74:** Acceptable but with noticeable concerns.
+- **40–59:** Significant problems on this dimension.
+- **20–39:** Severe problems; the article materially fails this dimension.
+- **0–19:** Catastrophic; this dimension is essentially abandoned.
+
+Each dimension also gets a **confidence** value 0.0–1.0 reflecting how sure you are of your score given what's evaluable from the article alone. Lower confidence on dimensions where surface evaluation is structurally limited.
+
+The **knowability ceiling** is the maximum total score this article could plausibly achieve given the inherent difficulty of its subject. A careful piece on classified intelligence might cap at 80; a careful piece on a public dataset might cap at 98. Set this thoughtfully; it prevents penalizing reporters for working hard topics.
+
+# Output format
+
+Return **only** a single valid JSON object. No preamble, no markdown fences, no closing commentary.
+
+```json
+{
+  "article_metadata": {
+    "headline": "<exact headline>",
+    "subhead": "<exact subhead or null>",
+    "byline": "<author name(s) or null>",
+    "publication": "<publication name or null>",
+    "publication_date": "<ISO date or null>",
+    "url": "<source URL or null>",
+    "word_count_estimate": <integer>
+  },
+  "dimensions": {
+    "headline_body_fidelity": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "findings": [
+        {
+          "issue": "<short description>",
+          "severity": "low" | "medium" | "high",
+          "evidence_quote": "<exact quote>",
+          "notes": "<1-2 sentence explanation>"
+        }
+      ],
+      "strengths": ["<affirmative observation with evidence>"]
+    },
+    "asymmetric_language": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "parties_identified": ["<party A>", "<party B>", "..."],
+      "findings": [
+        {
+          "dimension": "verbs" | "adjectives" | "framing" | "epithets",
+          "party_a": "<name>",
+          "party_a_term": "<word/phrase used>",
+          "party_b": "<name>",
+          "party_b_term": "<word/phrase used>",
+          "severity": "low" | "medium" | "high",
+          "evidence_quote": "<exact quote>"
+        }
+      ]
+    },
+    "number_hygiene": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "numerical_claims": [
+        {
+          "claim": "<the claim as it appears>",
+          "value": "<the number>",
+          "has_denominator": true | false,
+          "has_base_rate": true | false,
+          "has_comparison_class": true | false,
+          "evidence_quote": "<exact quote>",
+          "notes": "<what's missing or done well>"
+        }
+      ]
+    },
+    "source_quality": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "sources": [
+        {
+          "label": "<short identifier>",
+          "type": "named_primary" | "named_secondary" | "anonymous_justified" | "anonymous_bare" | "document_cited" | "study_cited" | "expert_says_vague",
+          "claims_supported": ["<claim 1>", "<claim 2>"],
+          "evidence_quote": "<exact quote>"
+        }
+      ],
+      "single_sourced_contested_claims": [
+        {
+          "claim": "<the claim>",
+          "source": "<the lone source>",
+          "evidence_quote": "<exact quote>"
+        }
+      ],
+      "anonymous_sourcing_justified": true | false | "n/a"
+    },
+    "internal_coherence": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "contradictions": [
+        {
+          "type": "factual" | "tonal" | "numerical" | "causal",
+          "claim_a": "<first claim>",
+          "claim_b": "<contradicting claim>",
+          "evidence_quote_a": "<exact quote>",
+          "evidence_quote_b": "<exact quote>",
+          "severity": "low" | "medium" | "high"
+        }
+      ]
+    },
+    "definitional_precision": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "contested_terms": [
+        {
+          "term": "<the term>",
+          "defined_in_text": true | false,
+          "definition_quote": "<exact quote or null>",
+          "smuggled_assumption": "<what assumption is buried in undefined use, or null>",
+          "severity": "low" | "medium" | "high"
+        }
+      ]
+    },
+    "omission": {
+      "score": 0-100,
+      "confidence": 0.0-1.0,
+      "voices_quoted": [
+        {
+          "name_or_role": "<who>",
+          "perspective": "<short summary>"
+        }
+      ],
+      "voices_referenced_but_not_quoted": ["<role/name>"],
+      "voices_expected_but_absent": [
+        {
+          "role": "<who would normally be heard from on this topic>",
+          "why_expected": "<reason>",
+          "severity": "low" | "medium" | "high"
+        }
+      ]
+    }
+  },
+  "predictions_extracted": [
+    {
+      "prediction": "<the testable claim>",
+      "type": "explicit" | "implicit",
+      "hedge_level": "confident" | "hedged" | "speculative",
+      "resolution_horizon": "<e.g., '6 months', '2026 election', 'unspecified'>",
+      "resolution_criteria": "<what would resolve this true or false>",
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "knowability_ceiling": 0-100,
+  "knowability_notes": "<why this ceiling; what limits surface-scan evaluation of this piece>",
+  "aggregate_score": 0-100,
+  "aggregate_score_notes": "<how the dimensions combined; which dominated the result>",
+  "overall_confidence": 0.0-1.0,
+  "top_strengths": ["<strength 1>", "<strength 2>"],
+  "top_concerns": ["<concern 1>", "<concern 2>"],
+  "auditor_caveats": ["<what an outsider scan cannot determine here>"]
+}
+```
+
+# Aggregation rule for `aggregate_score`
+
+Compute a weighted average of the seven scored dimensions:
+
+- Headline-Body Fidelity: weight 0.15
+- Asymmetric Language: weight 0.15
+- Number Hygiene: weight 0.10
+- Source Quality: weight 0.20
+- Internal Coherence: weight 0.10
+- Definitional Precision: weight 0.10
+- Omission: weight 0.20
+
+Then cap the result at the `knowability_ceiling`. If the cap binds, note this in `aggregate_score_notes`.
+
+---
+
+# ARTICLE TO AUDIT
+
+Paste the article markdown below this line:
+

--- a/docs/auditor-prototype/prompts/01-headline-body-fidelity.md
+++ b/docs/auditor-prototype/prompts/01-headline-body-fidelity.md
@@ -1,0 +1,82 @@
+# Module 01 — Headline-Body Fidelity
+
+**Purpose:** Determine whether the article's headline (and subhead, if present) accurately previews the body's actual content with proportional emphasis. This is the single most-cheated dimension in modern journalism and is detectable in seconds from the published artifact alone.
+
+**Input:** Article markdown including headline, subhead (if any), byline, and body.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Headline-Body Fidelity check on a news article.
+
+# Methodology
+
+1. **Read the headline (and subhead) ALONE.** Do not look at the body yet. List every claim or implication a reasonable reader would take from the headline. Categorize each as factual, causal, evaluative, or predictive. Mark whether the implied strength is definite, likely, or hedged.
+
+2. **Now read the body.** For each headline implication, locate the supporting (or contradicting) text and quote it exactly. If support is absent, say so.
+
+3. **Score each implication's support status:** `supported`, `partially_supported`, `unsupported`, or `contradicted`.
+
+4. **Identify structural issues:**
+   - Buried qualifications (key hedge appears in paragraph 8+)
+   - Inverted emphasis (the actual lead fact is buried)
+   - Clickbait framing (headline poses a question or makes a claim the body cannot deliver)
+   - Implicit-actor switching (headline ascribes action to one party, body reveals another)
+   - Tense or modality drift (headline asserts what body says was alleged, expected, or possible)
+
+5. **Compute an overall fidelity score 0–100:**
+   - **90–100:** Every implication is fully supported with proportional emphasis.
+   - **75–89:** Minor mismatches; small hedge gaps or proportional emphasis quibbles.
+   - **60–74:** Noticeable gaps; the headline overstates or compresses meaningfully.
+   - **40–59:** Significant mismatches; a careful reader of the body would not write this headline.
+   - **20–39:** Severe; the headline materially misleads.
+   - **0–19:** The headline contradicts or has no relationship to the body's actual claims.
+
+6. **Confidence (0.0–1.0):** Lower confidence if the body is truncated, paywalled, or relies on visual/multimedia content you cannot evaluate.
+
+# Output
+
+Return only this JSON, no preamble, no markdown fences:
+
+```json
+{
+  "module": "headline_body_fidelity",
+  "version": "1.0",
+  "headline": "<exact headline>",
+  "subhead": "<exact subhead or null>",
+  "headline_implications": [
+    {
+      "id": 0,
+      "implication": "<what a reader takes from the headline>",
+      "type": "factual" | "causal" | "evaluative" | "predictive",
+      "implied_strength": "definite" | "likely" | "hedged"
+    }
+  ],
+  "body_findings": [
+    {
+      "implication_id": 0,
+      "support_status": "supported" | "partially_supported" | "unsupported" | "contradicted",
+      "evidence_quote": "<exact quote from body, or null>",
+      "notes": "<1-2 sentence assessment>"
+    }
+  ],
+  "structural_issues": [
+    {
+      "type": "buried_qualification" | "inverted_emphasis" | "clickbait_framing" | "actor_switching" | "modality_drift" | "other",
+      "description": "<what was found>",
+      "evidence_quote": "<exact quote>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this surface scan cannot determine>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/02-asymmetric-language.md
+++ b/docs/auditor-prototype/prompts/02-asymmetric-language.md
@@ -1,0 +1,93 @@
+# Module 02 — Asymmetric Language Detection
+
+**Purpose:** Detect framing asymmetry — different verbs, adjectives, or rhetorical treatment applied to comparable parties or actions. This is almost always invisible to the writer and detectable to a reader scanning for it.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing an Asymmetric Language check on a news article.
+
+# Methodology
+
+1. **Identify the parties.** List every named party, faction, country, institution, or movement that appears in adversarial, contrasting, or comparable roles within the article. (If there is no contrast structure, the article scores 100 by default.)
+
+2. **For each party, extract the language applied to them:**
+   - Verbs (especially of action, speech, and motivation)
+   - Adjectives and adjectival phrases
+   - Epithets, labels, or category terms (e.g., "extremist," "moderate," "experts," "officials")
+   - Sourcing verbs ("said," "claimed," "explained," "alleged," "admitted")
+
+3. **Compare the language across parties for asymmetry on these dimensions:**
+   - **Action verbs:** Does one party "lash out" while the other "responds"? Does one "attack" while the other "defends"? Does one "claim" while the other "explains"?
+   - **Motivation attribution:** Are motives assigned to one party but not the other? Is one party's behavior explained while the other's is treated as self-evidently bad?
+   - **Epithets and labels:** Is one side labeled with a contested term (e.g., "extremist," "radical") while the other gets a neutral term (e.g., "activist," "advocate")?
+   - **Sourcing verbs:** Does one party "say" while the other "claims" or "alleges"?
+   - **Visibility of agency:** Is one party's action described in active voice ("X attacked Y") while another's is described in passive voice ("Z were killed")?
+   - **Quantitative framing:** Are similar numbers framed differently for different parties (e.g., "only" vs "as many as")?
+
+4. **Score 0–100:**
+   - **90–100:** Symmetric or essentially symmetric treatment. Any small asymmetries are explainable by the actual asymmetry of the events.
+   - **75–89:** Minor asymmetries; possibly unintentional word choice.
+   - **60–74:** Noticeable patterns; multiple asymmetric word choices in the same direction.
+   - **40–59:** Systematic asymmetric framing visible across multiple dimensions.
+   - **20–39:** Severe; the article reads as advocacy through word choice.
+   - **0–19:** Pure rhetorical framing; the language alone tells the reader who to side with.
+
+5. **Confidence (0.0–1.0):** Lower confidence on articles where there is genuinely asymmetric reality being reported (e.g., reporting on a confirmed atrocity by one party). Asymmetric language can be appropriate when the underlying facts are asymmetric.
+
+# Important caveat
+
+Asymmetry in language is not always wrong. If party A has been convicted of a crime and party B has not, different verbs may be appropriate. The standard is *unjustified* asymmetry — language choices that pre-stage a conclusion the article has not earned through evidence. Note when asymmetry tracks established fact versus when it simply tilts the framing.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "asymmetric_language",
+  "version": "1.0",
+  "has_contrast_structure": true | false,
+  "parties_identified": [
+    {
+      "name": "<party name>",
+      "role": "<their role in the contrast>"
+    }
+  ],
+  "language_applied": [
+    {
+      "party": "<party name>",
+      "verbs": ["<verb 1>", "<verb 2>"],
+      "adjectives": ["<adj 1>"],
+      "epithets_or_labels": ["<label 1>"],
+      "sourcing_verbs": ["<verb>"]
+    }
+  ],
+  "asymmetry_findings": [
+    {
+      "dimension": "action_verbs" | "motivation_attribution" | "epithets" | "sourcing_verbs" | "voice_agency" | "quantitative_framing",
+      "party_a": "<name>",
+      "party_a_term": "<word/phrase>",
+      "party_b": "<name>",
+      "party_b_term": "<word/phrase>",
+      "evidence_quote_a": "<exact quote>",
+      "evidence_quote_b": "<exact quote>",
+      "justified_by_underlying_facts": true | false,
+      "justification_notes": "<if justified, why>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/03-number-hygiene.md
+++ b/docs/auditor-prototype/prompts/03-number-hygiene.md
@@ -1,0 +1,92 @@
+# Module 03 — Number Hygiene
+
+**Purpose:** Audit every numerical claim in the article against three tests: does it have a denominator (where ratio matters), a base rate (for comparison to background), and a comparison class (versus what)? Most numbers in news fail at least one.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Number Hygiene check on a news article.
+
+# Methodology
+
+1. **Extract every numerical claim** in the article body. This includes:
+   - Counts and totals ("400 people attended")
+   - Percentages and ratios ("up 40%")
+   - Dollar/currency amounts
+   - Dates and timeframes used as evidence
+   - Comparisons ("twice as many," "the largest in a decade")
+   - Probabilities and forecasts
+   - Survey/poll results
+   - Rankings and rates
+
+2. **For each numerical claim, apply three tests:**
+
+   - **Denominator test:** When the claim is a count or change, is the relevant total or population provided? "400 arrests" without "out of how many encounters" or "compared to how many last year" fails this test. "400 of 1,200 protests resulted in arrests" passes.
+
+   - **Base rate test:** Is the historical or contextual baseline provided? "Crime up 40%" without prior years' levels, the long-run trend, or the absolute number fails. "Crime up 40% from a 30-year low" passes (and is a different story).
+
+   - **Comparison class test:** Is the comparison set defined and appropriate? "The largest in a decade" — largest *what*, in *which* category, by *which* measure? "$2 billion in damages — comparable to the 2018 fires which caused $X billion" passes; "$2 billion — a staggering sum" fails.
+
+3. **Note additional issues where present:**
+   - Cherry-picked timeframe (start/end dates chosen to maximize the apparent change)
+   - Survivorship bias (sample excludes relevant cases)
+   - Causation implied without evidence ("after X policy, Y rose")
+   - Precision mismatch (precise numbers reported with vague sourcing)
+   - Conflation of stocks and flows
+   - Aggregation hiding distribution (averages without ranges; totals without per-capita)
+
+4. **Score 0–100:**
+   - **90–100:** Numbers consistently contextualized with appropriate denominators, base rates, and comparisons.
+   - **75–89:** Most numbers contextualized; minor gaps.
+   - **60–74:** Mixed; some numbers well-handled, others bare.
+   - **40–59:** Most numerical claims fail at least one test.
+   - **20–39:** Numbers used rhetorically, with little context.
+   - **0–19:** Numbers function purely as emotional triggers; no numerate reader could derive meaning from them.
+
+5. **Confidence (0.0–1.0):** Lower if the article relies heavily on charts or tables you cannot evaluate.
+
+# Important note
+
+Not every number needs all three tests. A weather report saying "high of 78°F" needs no denominator. Apply the tests only where they are *relevant* to the claim's interpretive weight. The judgment call is whether a numerate reader could be misled by what's missing.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "number_hygiene",
+  "version": "1.0",
+  "numerical_claims": [
+    {
+      "id": 0,
+      "claim": "<the claim as it appears in context>",
+      "value": "<the number>",
+      "context": "<short summary of what the number is purporting to demonstrate>",
+      "denominator_test": "passed" | "failed" | "not_applicable",
+      "base_rate_test": "passed" | "failed" | "not_applicable",
+      "comparison_class_test": "passed" | "failed" | "not_applicable",
+      "additional_issues": ["cherry_picked_timeframe", "implied_causation", "precision_mismatch", "..."],
+      "evidence_quote": "<exact quote>",
+      "notes": "<what's done well or missing>"
+    }
+  ],
+  "summary": {
+    "total_claims": <integer>,
+    "claims_failing_at_least_one_test": <integer>,
+    "most_common_failure": "denominator" | "base_rate" | "comparison_class" | "none"
+  },
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/04-source-quality.md
+++ b/docs/auditor-prototype/prompts/04-source-quality.md
@@ -1,0 +1,118 @@
+# Module 04 — Source Quality Audit
+
+**Purpose:** Count and classify every source the article uses; identify contested claims that rest on inadequate sourcing; check whether anonymous sourcing is justified and whether primary documents (when cited) are linked or quoted.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Source Quality audit on a news article.
+
+# Methodology
+
+1. **Identify every source the article relies on.** A "source" is anyone or anything providing factual claims, including:
+   - Named individuals quoted or paraphrased
+   - Anonymous individuals (with or without justification)
+   - Documents (court filings, government reports, leaked memos)
+   - Studies and data (peer-reviewed, working papers, datasets)
+   - Other media outlets (cited or republished)
+   - Vague attributions ("experts say," "officials told reporters," "according to people familiar with the matter")
+
+2. **Classify each source** into one of these categories:
+   - `named_primary` — Named, directly involved, on the record (e.g., a quoted official with relevant authority)
+   - `named_secondary` — Named, but commenting on events they were not directly part of (e.g., academics, analysts)
+   - `anonymous_justified` — Anonymous with stated justification ("granted anonymity to discuss internal deliberations") AND with the source's relationship to the matter described
+   - `anonymous_bare` — Anonymous with no justification or only a vague description
+   - `document_cited` — Specific document referenced; ideally linked or quoted
+   - `study_cited` — Specific study referenced; ideally with author, journal, date
+   - `expert_says_vague` — Group attributions without specific individuals ("experts say," "many believe")
+
+3. **Map sources to the claims they support.** For each major factual claim in the article, identify which sources back it.
+
+4. **Identify single-sourced contested claims.** A "contested claim" is any claim that:
+   - Other parties named in the article would likely dispute
+   - Concerns motivation, intent, or private knowledge
+   - Concerns events the source was not directly party to
+   - Is presented as fact but is reasonably subject to dispute
+
+   Single-sourcing such claims (especially via anonymous or vague sources) is a serious sourcing failure.
+
+5. **Evaluate anonymous sourcing justification.** When sources are anonymous, the article should say *why* anonymity was granted (e.g., "because they were not authorized to speak publicly") and describe the source's relationship to the matter ("a senior official at X department"). Bare anonymity ("a source said") fails this standard.
+
+6. **Evaluate primary source linking.** When the article cites documents, studies, or data, are they linked, quoted, or specifically identified such that a reader could retrieve them? Or are they characterized only by the article's framing?
+
+7. **Score 0–100:**
+   - **90–100:** Sources are predominantly named and primary; anonymous sourcing is sparse, justified, and described; documents are linked or quoted; contested claims are multi-sourced.
+   - **75–89:** Mostly named sourcing; anonymous sources justified; some documents linked.
+   - **60–74:** Mixed; reliance on `expert_says_vague` or unjustified anonymous sourcing in non-contested areas.
+   - **40–59:** Multiple contested claims rest on anonymous or vague sourcing without justification.
+   - **20–39:** Article essentially built on anonymous sourcing or single-sourced contested claims.
+   - **0–19:** No identifiable sourcing for major claims, or sources presented in ways that prevent reader verification.
+
+8. **Confidence (0.0–1.0):** Lower confidence on stories where anonymous sourcing may be genuinely necessary (national security, internal corporate matters, personal safety) and where the underlying sourcing quality is unverifiable from the article alone.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "source_quality",
+  "version": "1.0",
+  "sources": [
+    {
+      "id": 0,
+      "label": "<short identifier, e.g., 'unnamed senior official' or 'Sarah Chen, professor at MIT'>",
+      "type": "named_primary" | "named_secondary" | "anonymous_justified" | "anonymous_bare" | "document_cited" | "study_cited" | "expert_says_vague",
+      "anonymity_justification": "<exact quote, or null if not anonymous>",
+      "relationship_to_matter": "<as described in article>",
+      "evidence_quote": "<exact quote where source is introduced>"
+    }
+  ],
+  "claim_to_source_map": [
+    {
+      "claim": "<the factual claim>",
+      "source_ids": [0, 2],
+      "is_contested": true | false,
+      "contested_reason": "<why this claim is disputable, or null>",
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "single_sourced_contested_claims": [
+    {
+      "claim": "<the claim>",
+      "source_id": 0,
+      "source_type": "anonymous_bare" | "named_secondary" | "...",
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "primary_documents": [
+    {
+      "document": "<what document>",
+      "linked_or_quoted": true | false,
+      "specific_enough_to_retrieve": true | false,
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "summary": {
+    "total_sources": <integer>,
+    "named_count": <integer>,
+    "anonymous_count": <integer>,
+    "anonymous_justified_count": <integer>,
+    "expert_says_vague_count": <integer>,
+    "documents_cited": <integer>,
+    "documents_specifically_identified": <integer>
+  },
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine, e.g., 'cannot verify the actual quality of anonymous sources from the article alone'>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/05-internal-coherence.md
+++ b/docs/auditor-prototype/prompts/05-internal-coherence.md
@@ -1,0 +1,82 @@
+# Module 05 — Internal Coherence
+
+**Purpose:** Detect contradictions and inconsistencies within the article itself — between paragraphs, between text and any embedded data references, between framing and evidence. Internal incoherence is the cheapest signal of editorial sloppiness or motivated framing.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing an Internal Coherence check on a news article.
+
+# Methodology
+
+1. **Read the full article carefully**, building a mental model of every factual, causal, and evaluative claim.
+
+2. **Look for contradictions of these types:**
+
+   - **Factual contradiction:** Two statements that cannot both be true. ("The protest had 5,000 attendees." Later: "The crowd of several hundred...")
+   - **Numerical contradiction:** Numbers that don't reconcile. (Sum of subgroup totals doesn't match the stated total; percentages add to more than 100; chart caption disagrees with text.)
+   - **Causal contradiction:** Cause-and-effect chains that conflict. ("X happened because of Y." Later: "Z, which began before Y, caused X.")
+   - **Tonal/evaluative contradiction:** Different emotional or evaluative framings of the same event in different parts of the article.
+   - **Modality contradiction:** Claim asserted as fact in one place and as allegation, possibility, or denial in another.
+   - **Quote-paraphrase contradiction:** A direct quote that doesn't support the article's paraphrase or characterization of it.
+   - **Caption-text contradiction:** Image or chart captions that contradict the body text.
+   - **Lead-body contradiction:** The lede frames the story one way; the body's content supports a different (often more nuanced or contrary) framing.
+
+3. **Look for logical inconsistencies even without direct contradiction:**
+   - Conclusions that don't follow from the evidence presented
+   - Claims that prove too much or too little
+   - Premises that, if true, would undermine the article's framing
+
+4. **Distinguish genuine contradiction from intentional dialectic.** A piece that fairly presents two opposing views and notes the conflict is not internally incoherent — that's the article doing its job. A piece that asserts both views as its own factual frame is.
+
+5. **Score 0–100:**
+   - **90–100:** Internally coherent throughout; any tensions are explicitly flagged and contextualized.
+   - **75–89:** Minor inconsistencies; possibly editing artifacts.
+   - **60–74:** Noticeable contradictions or logical gaps that a careful reader would catch.
+   - **40–59:** Multiple significant inconsistencies; framing not supported by article's own content.
+   - **20–39:** Severe; the article's own evidence contradicts its conclusions.
+   - **0–19:** The article actively confuses or misleads through internal contradiction.
+
+6. **Confidence (0.0–1.0):** Lower confidence on long articles, articles relying heavily on charts/images you cannot evaluate, or articles in highly technical domains where apparent contradiction may reflect specialized usage.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "internal_coherence",
+  "version": "1.0",
+  "contradictions": [
+    {
+      "type": "factual" | "numerical" | "causal" | "tonal" | "modality" | "quote_paraphrase" | "caption_text" | "lead_body",
+      "claim_a": "<first claim>",
+      "claim_b": "<contradicting claim>",
+      "evidence_quote_a": "<exact quote>",
+      "evidence_quote_b": "<exact quote>",
+      "is_dialectic_intent": true | false,
+      "severity": "low" | "medium" | "high",
+      "notes": "<short explanation>"
+    }
+  ],
+  "logical_gaps": [
+    {
+      "description": "<the gap>",
+      "evidence_quote": "<exact quote>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/06-definitional-precision.md
+++ b/docs/auditor-prototype/prompts/06-definitional-precision.md
@@ -1,0 +1,97 @@
+# Module 06 — Definitional Precision
+
+**Purpose:** Identify contested terms used in the article and check whether they are defined or smuggled. Undefined contested terms quietly prefigure conclusions; defining them forces the writer to make explicit what would otherwise be assumed.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Definitional Precision check on a news article.
+
+# Methodology
+
+1. **Identify contested terms** the article uses to characterize events, parties, or concepts. A term is "contested" when reasonable people disagree about what it means or when it applies. Examples:
+
+   - **Political/social:** "extremist," "moderate," "radical," "mainstream," "fringe," "patriot," "insurgent," "terrorist," "freedom fighter," "activist," "advocate"
+   - **Action-characterizing:** "violence," "peaceful protest," "riot," "uprising," "crackdown," "intervention," "invasion"
+   - **Epistemic authority:** "expert," "scientist," "researcher," "official," "spokesperson"
+   - **Quantitative-sounding but vague:** "many," "most," "few," "some," "widespread," "rare," "growing," "declining"
+   - **Economic:** "inflation," "recession," "growth," "stimulus," "austerity," "free market," "regulation"
+   - **Identity:** "left," "right," "progressive," "conservative," "liberal" (these mean different things in different contexts)
+   - **Technical:** Any specialized term used without definition in a piece for general readers
+
+2. **For each contested term, check:**
+   - Is the term defined in the article (explicitly or via clear context)?
+   - If defined, is the definition appropriate and disclosed (rather than buried)?
+   - If not defined, what assumption is being smuggled? (e.g., calling a group "extremist" without definition assumes the reader shares the writer's threshold for that label.)
+   - Is the term used consistently? Or does its meaning shift across the article?
+
+3. **Look for "weasel quantifiers"** — words like "many," "some," "growing," "increasingly" — that imply quantitative claims without quantitative evidence. These should be backed by numbers or scoped explicitly.
+
+4. **Look for category laundering** — using a contested category as if it were a settled one. ("Misinformation," "hate speech," "election denier," "national security threat" are often used this way.)
+
+5. **Score 0–100:**
+   - **90–100:** Contested terms are defined, scoped, or sourced. Weasel quantifiers are backed.
+   - **75–89:** Most contested terms handled; minor smuggling.
+   - **60–74:** Several contested terms used without definition; some load-bearing for the article's frame.
+   - **40–59:** Contested terms central to the article's claims are not defined.
+   - **20–39:** Article's frame depends on contested terms used as if settled.
+   - **0–19:** The article is built on smuggled definitions; without them, its conclusions evaporate.
+
+6. **Confidence (0.0–1.0):** High by default for this dimension — definitions are surface-detectable. Lower if the article is highly technical and you may be misjudging which terms are contested in that field.
+
+# Important caveat
+
+Not every word is contested. A piece on baseball using "shortstop" without definition is fine. Apply this lens only to terms whose meaning is *load-bearing* for the article's claims and where reasonable readers would diverge on application.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "definitional_precision",
+  "version": "1.0",
+  "contested_terms": [
+    {
+      "term": "<the term>",
+      "occurrences": <integer>,
+      "first_use_quote": "<exact quote of first use>",
+      "defined_in_text": true | false,
+      "definition_quote": "<exact quote, or null>",
+      "definition_quality": "explicit" | "contextual" | "absent",
+      "smuggled_assumption": "<what is assumed when the term is used undefined, or null>",
+      "load_bearing": true | false,
+      "used_consistently": true | false,
+      "severity_if_undefined": "low" | "medium" | "high"
+    }
+  ],
+  "weasel_quantifiers": [
+    {
+      "term": "<e.g., 'many', 'growing', 'most'>",
+      "evidence_quote": "<exact quote>",
+      "backed_by_evidence": true | false,
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "category_laundering": [
+    {
+      "category": "<the contested category>",
+      "evidence_quote": "<exact quote>",
+      "treatment": "<how the article treats it as if settled>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/07-omission.md
+++ b/docs/auditor-prototype/prompts/07-omission.md
@@ -1,0 +1,114 @@
+# Module 07 — Omission Test
+
+**Purpose:** Identify who is quoted, who is referenced but not given voice, and who is conspicuously absent given the article's topic. The pattern of who gets the microphone is often more revealing than what they say.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing an Omission Test on a news article.
+
+# Methodology
+
+1. **Catalog the voices that appear in the article:**
+   - **Directly quoted:** Anyone whose words appear in quotation marks (with attribution).
+   - **Paraphrased:** Anyone whose position is summarized by the article ("X said that...").
+   - **Referenced but silent:** Parties named or alluded to but not given voice (e.g., "company representatives did not respond" or simply absent).
+   - **Implicit:** Stakeholders whose existence is implied by the topic but who are not named.
+
+2. **Identify the topic's natural stakeholder set.** For any given news topic, there are roles that a balanced piece would normally include. Examples:
+
+   - A story about a labor dispute should include workers, management, union representation (if any), and ideally an outside observer.
+   - A story about a regulation should include the regulator, the regulated industry, the proponents (often advocacy groups or affected populations), and critics.
+   - A story about a court ruling should include both sides' counsel, the court's reasoning, and ideally legal commentators not party to the case.
+   - A story about a study should include the study's authors, methodology context, and outside experts capable of evaluating the work.
+   - A story about a foreign policy decision should include the originating government, affected parties, and (where reachable) those most affected by the policy.
+   - A story about a community impact should include members of that community, not only officials describing the community.
+
+3. **Compare the catalog to the natural stakeholder set.** Identify roles that should plausibly be heard from but are absent. For each absence, note whether the article addresses why (e.g., "X declined to comment," "Y could not be reached," "the agency has not responded to requests for comment") or whether the absence is unexplained.
+
+4. **Look for asymmetric quotation density.** Even when both sides are technically represented, count column-inches or quote-density given to each. Heavy imbalance can be a form of omission.
+
+5. **Check for "speaks-for" omission.** When the article allows one party to characterize another party's position rather than quoting that party directly, this is a common omission pattern. ("Critics worry that X..." with no critic actually quoted.)
+
+6. **Check for community-versus-officials omission.** Stories about communities (e.g., a neighborhood, a profession, an affected population) that quote only officials, experts, or institutional spokespersons fail this dimension.
+
+7. **Score 0–100:**
+   - **90–100:** Stakeholder set well-represented; quotation density roughly balanced; absences (if any) explicitly addressed.
+   - **75–89:** Most stakeholders heard from; minor imbalance.
+   - **60–74:** One or two important voices missing; or one perspective dominates the quote density.
+   - **40–59:** Significant absences; the story tells one side substantively.
+   - **20–39:** Severe; the story is essentially one-sided through omission.
+   - **0–19:** Article presents a topic while excluding the parties most relevant to it.
+
+8. **Confidence (0.0–1.0):** Lower confidence when you cannot identify the natural stakeholder set with high confidence (e.g., highly technical or jurisdiction-specific stories). Higher when the topic has well-understood stakeholder geometry.
+
+# Important caveat
+
+Not every story needs every voice. A breaking-news report 30 minutes after an event cannot include all stakeholders; an investigative piece months in development should. Calibrate expectations to the article's apparent reporting timeline and scope. Use the article's own framing of itself as a guide.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "omission",
+  "version": "1.0",
+  "topic_summary": "<one sentence on what the article is about>",
+  "voices_directly_quoted": [
+    {
+      "name_or_role": "<who>",
+      "perspective_summary": "<short summary>",
+      "quote_density": "high" | "medium" | "low",
+      "evidence_quote": "<exact quote of one of their statements>"
+    }
+  ],
+  "voices_paraphrased_only": [
+    {
+      "name_or_role": "<who>",
+      "perspective_summary": "<short summary>",
+      "evidence_quote": "<exact quote of paraphrase>"
+    }
+  ],
+  "voices_referenced_but_silent": [
+    {
+      "name_or_role": "<who>",
+      "absence_addressed": true | false,
+      "absence_explanation": "<exact quote, or null>"
+    }
+  ],
+  "natural_stakeholder_set": [
+    "<role 1>",
+    "<role 2>"
+  ],
+  "voices_expected_but_absent": [
+    {
+      "role": "<who would normally be heard from>",
+      "why_expected": "<reason this voice is normally part of this kind of story>",
+      "absence_addressed": true | false,
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "speaks_for_instances": [
+    {
+      "speaking_party": "<who>",
+      "spoken_for_party": "<whose position is being characterized>",
+      "evidence_quote": "<exact quote>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "quotation_balance_notes": "<observations about quote density across perspectives>",
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence; e.g., 'unfamiliar with full stakeholder set in this jurisdiction'>",
+  "auditor_caveats": ["<things this scan cannot determine, e.g., 'cannot verify whether absent voices were actually contacted'>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/prompts/08-prediction-extraction.md
+++ b/docs/auditor-prototype/prompts/08-prediction-extraction.md
@@ -1,0 +1,84 @@
+# Module 08 — Prediction Extraction
+
+**Purpose:** Extract every testable prediction the article makes (explicit or implicit) for the long-term prediction ledger. Predictions are *not scored at extraction* — they are scored later when reality resolves them. This module produces the input to the ledger; over time, the ledger produces the most powerful retrospective evidence about an author or publication's calibration.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor extracting predictions from a news article for a long-term prediction ledger.
+
+# Methodology
+
+1. **Identify every claim in the article that makes a prediction about the future.** Predictions can be:
+
+   - **Explicit:** "X will happen by Y date." "Experts predict Z." "Analysts expect..."
+   - **Implicit:** Claims that, while not framed as predictions, presuppose future outcomes. (e.g., "The new policy will reduce emissions by 20%" — this asserts a future outcome.)
+   - **Conditional:** "If X, then Y will follow." (Log both the condition and the predicted consequence.)
+   - **Negative:** "Z is unlikely to happen." "There is no evidence Y will occur."
+   - **Counterfactual-with-future:** "Without X, Y would have happened" combined with "now Y will not happen."
+
+2. **For each prediction, capture:**
+
+   - **The prediction itself** in clear, testable language.
+   - **Type:** explicit, implicit, conditional, negative, counterfactual.
+   - **Hedge level:** confident, hedged ("could," "might," "may," "is expected to"), or speculative ("some worry that," "it's possible").
+   - **Source within the article:** Is the prediction made by the article's own voice, or attributed to a named source, or attributed vaguely ("experts say")?
+   - **Resolution horizon:** When could this be resolved? An ISO date if computable; otherwise a description ("within the next 12 months," "by the next election," "unspecified").
+   - **Resolution criteria:** What observable event or measurement would resolve this true or false? Be concrete.
+   - **Tractability:** Is this prediction *in principle* resolvable from public information? (Some predictions about classified or private matters may never resolve publicly.)
+
+3. **Do not score the predictions.** Resolution and scoring happen later. Your job is to make the prediction ledger entry as clear and verifiable-later as possible.
+
+4. **Skip non-predictions.** Speculation framed as analysis ("X means we should think about Y") is not a prediction. Past-tense claims are not predictions. Statements about ongoing trends without a future-pointing component are not predictions.
+
+# Guidance on hedge levels
+
+- **Confident:** No hedge language. ("X will happen.")
+- **Hedged:** Modal verbs or qualifiers. ("X could happen," "X is likely to happen," "X is expected to happen.")
+- **Speculative:** Multiple layers of distance. ("Some worry that X might happen.")
+
+The hedge level matters because the calibration multiplier in the eventual scoring rewards hedged-and-wrong less harshly than confident-and-wrong, and rewards confident-and-right more than hedged-and-right.
+
+# Output
+
+Return only this JSON:
+
+```json
+{
+  "module": "prediction_extraction",
+  "version": "1.0",
+  "predictions": [
+    {
+      "id": 0,
+      "prediction": "<clear, testable statement of the prediction>",
+      "type": "explicit" | "implicit" | "conditional" | "negative" | "counterfactual",
+      "hedge_level": "confident" | "hedged" | "speculative",
+      "attributed_to": "article_voice" | "named_source" | "vague_attribution",
+      "attributed_source_name": "<name if attributed, or null>",
+      "condition": "<for conditional predictions, the antecedent; null otherwise>",
+      "resolution_horizon": "<ISO date if computable, else descriptive string>",
+      "resolution_criteria": "<concrete, observable criteria>",
+      "tractability": "publicly_resolvable" | "requires_private_info" | "ambiguous",
+      "evidence_quote": "<exact quote from article>"
+    }
+  ],
+  "summary": {
+    "total_predictions": <integer>,
+    "explicit_count": <integer>,
+    "implicit_count": <integer>,
+    "confident_count": <integer>,
+    "hedged_count": <integer>,
+    "speculative_count": <integer>,
+    "publicly_resolvable_count": <integer>
+  },
+  "auditor_caveats": ["<e.g., 'some implicit predictions may have been missed'>"]
+}
+```
+
+---
+
+# ARTICLE
+

--- a/docs/auditor-prototype/schema/audit-types.ts
+++ b/docs/auditor-prototype/schema/audit-types.ts
@@ -1,0 +1,432 @@
+// =============================================================================
+// X-Ray Epistemic Auditor — Data Schema
+// =============================================================================
+//
+// Designed with NOSTR alignment for X-Ray, but storage-agnostic. Every entity
+// can be expressed as either:
+//   (a) a NOSTR replaceable/addressable event (kind suggestions noted), or
+//   (b) a row in a relational store (Postgres sketch in schema/relational.sql).
+//
+// Design principles:
+//   - Articles are content-addressed (SHA-256 of normalized markdown). All
+//     downstream entities reference the article HASH, not the URL. URLs change;
+//     content does not. This makes audits replay-safe across stealth edits.
+//   - Per-module results stored independently so methodology updates only
+//     require recomputing the affected modules, not the whole article.
+//   - Every score carries a confidence value AND a versioned methodology
+//     reference. Stored audits stay valid under their original methodology
+//     even after methodology updates.
+//   - Auditor identity is first-class. Model+version, human pubkey, or a
+//     hybrid pipeline are all captured the same way.
+//   - All time-series. The latest audit is just the newest one; nothing
+//     overwrites prior audits. Drift is queryable.
+//   - Predictions are extracted at audit time but resolved later. Resolution
+//     events reference the prediction ID and feed the calibration multiplier.
+//
+// Suggested NOSTR kinds (claim before publishing as a NIP):
+//   30023  — Article (existing X-Ray kind for long-form)
+//   30040  — Atomic claim extracted from article (planned X-Ray Phase 4)
+//   30050  — Surface-scan module result (this proposal)
+//   30051  — Aggregate article audit (this proposal)
+//   30052  — Prediction ledger entry (this proposal)
+//   30053  — Prediction resolution (this proposal)
+//   30054  — Author/publication dossier snapshot (this proposal)
+//   30055  — Audit dispute / challenge (this proposal)
+//
+// =============================================================================
+
+
+// ---------- Common primitives ----------
+
+export type ISO8601 = string;            // "2026-05-06T14:23:00Z"
+export type SHA256Hex = string;          // 64 hex chars
+export type NostrPubkey = string;        // 64 hex chars (npub-decoded)
+export type NostrEventId = string;       // 64 hex chars
+export type Score = number;              // 0–100
+export type Confidence = number;         // 0.0–1.0
+export type Severity = "low" | "medium" | "high";
+export type SemVer = string;             // "1.2.0"
+
+
+// ---------- Auditor identity ----------
+
+export type AuditorKind = "model" | "human" | "pipeline" | "consensus";
+
+export interface AuditorIdentity {
+  kind: AuditorKind;
+  // For models: provider + model + version (e.g., "anthropic/claude-opus-4-7")
+  // For humans: NOSTR pubkey
+  // For pipelines: a name + manifest hash referencing the orchestration config
+  // For consensus: a name + the constituent auditor IDs
+  id: string;
+  display_name?: string;
+  // For pipelines/consensus: the constituent auditors that produced the result
+  constituents?: AuditorIdentity[];
+}
+
+
+// ---------- Article (content-addressed) ----------
+
+export interface Article {
+  // Primary key: SHA-256 of the normalized markdown body
+  // Normalization: trim trailing whitespace, collapse multi-blank lines, LF
+  // line endings, strip extension-injected DOM (X-Ray's content-extractor
+  // already produces clean output suitable for hashing).
+  hash: SHA256Hex;
+
+  // The source URL at capture time. May change later; not authoritative.
+  source_url: string;
+
+  // Captured headline, subhead, byline, publication, date.
+  // These are EXTRACTED and stored separately because they participate in
+  // multiple module checks (especially headline_body_fidelity).
+  headline: string;
+  subhead: string | null;
+  byline_raw: string | null;     // verbatim byline text
+  author_ids: string[];          // resolved author entity IDs (may be empty)
+  publication_id: string | null; // resolved publication entity ID
+  publication_date: ISO8601 | null;
+  language: string;              // BCP-47 ("en", "en-US", "es")
+  word_count: number;
+
+  // The full normalized markdown. Stored once; everything else references hash.
+  body_markdown: string;
+
+  // Capture metadata.
+  captured_at: ISO8601;
+  captured_by: AuditorIdentity;  // who/what fetched and normalized
+  capture_method: "xray_extension" | "api_fetch" | "manual_paste";
+
+  // Optional: archive link for permanent reference (Wayback, archive.today,
+  // or X-Ray's own archive system once Phase 6 lands).
+  archive_url?: string;
+}
+
+
+// ---------- Atomic claim ----------
+// Maps to X-Ray's planned kind 30040.
+
+export type ClaimType =
+  | "factual"      // assertion about state of the world
+  | "causal"       // X caused Y
+  | "evaluative"   // X is good/bad/significant
+  | "predictive"   // X will happen
+  | "definitional" // X means Y
+  | "attributive"; // X said/did Y
+
+export interface AtomicClaim {
+  id: string;                    // UUID or NOSTR event id
+  article_hash: SHA256Hex;       // anchor to immutable article
+  claim_text: string;            // restated in clear, testable form
+  type: ClaimType;
+  // Verbatim quote from the article that establishes this claim
+  evidence_quote: string;
+  // Character span in the source markdown for precise anchoring
+  source_span: { start: number; end: number };
+  // The article's stated source for this claim (may be "article_voice")
+  article_attributed_source: string;
+  is_contested: boolean;
+  contested_reason: string | null;
+  extracted_by: AuditorIdentity;
+  extracted_at: ISO8601;
+}
+
+
+// ---------- Surface-scan module result ----------
+// Maps to suggested kind 30050. One per (article, module, auditor, run).
+
+export type ModuleName =
+  | "headline_body_fidelity"
+  | "asymmetric_language"
+  | "number_hygiene"
+  | "source_quality"
+  | "internal_coherence"
+  | "definitional_precision"
+  | "omission"
+  | "prediction_extraction";
+
+export interface ModuleResult {
+  id: string;
+  article_hash: SHA256Hex;
+  module: ModuleName;
+  module_version: SemVer;        // matches the prompt's declared version
+  auditor: AuditorIdentity;
+  run_at: ISO8601;
+
+  // Score and confidence (omitted for prediction_extraction which doesn't score)
+  score: Score | null;
+  confidence: Confidence | null;
+
+  // The raw structured findings — schema varies by module.
+  // Validated against the per-module JSON schemas in /schema/modules/.
+  findings: Record<string, unknown>;
+
+  // Evidence quotes referenced by findings, deduplicated and indexed for
+  // claim-level cross-referencing across modules.
+  evidence_quotes: Array<{
+    quote: string;
+    source_span?: { start: number; end: number };
+  }>;
+
+  // Notes about what limited the auditor's confidence
+  auditor_caveats: string[];
+}
+
+
+// ---------- Aggregate article audit ----------
+// Maps to suggested kind 30051. Combines module results into article score.
+
+export interface AggregateAudit {
+  id: string;
+  article_hash: SHA256Hex;
+  auditor: AuditorIdentity;       // typically a "pipeline" auditor
+  run_at: ISO8601;
+
+  // Per-module result references and the weights used in this aggregation.
+  module_contributions: Array<{
+    module: ModuleName;
+    module_result_id: string;
+    score: Score | null;
+    confidence: Confidence;
+    weight: number;                // 0.0–1.0; sums to 1.0 across scoreable modules
+  }>;
+
+  // The knowability ceiling: max score achievable given inherent topic difficulty.
+  // 100 = fully publicly verifiable. 60 = relies heavily on classified or
+  // private sources that cannot be checked from the article alone.
+  knowability_ceiling: Score;
+  knowability_notes: string;
+
+  // Raw weighted aggregate before ceiling.
+  raw_weighted_score: Score;
+
+  // Final score after applying ceiling. If ceiling binds, raw > final.
+  final_score: Score;
+  ceiling_binding: boolean;
+
+  // Aggregate confidence. Lower than min(module_confidences) by convention,
+  // because pipeline-level uncertainty stacks.
+  overall_confidence: Confidence;
+
+  // Highlights for human consumption.
+  top_strengths: string[];
+  top_concerns: string[];
+
+  // Dispute pointer: if a later challenge has been adjudicated against this
+  // audit, the dispute event ID lives here. Score does not silently change;
+  // the dispute is its own event and the audit may be superseded by a
+  // newer aggregate audit.
+  superseded_by?: string;          // ID of newer audit
+  disputes: string[];              // IDs of dispute events referencing this audit
+}
+
+
+// ---------- Prediction ledger entry ----------
+// Maps to suggested kind 30052. Extracted at audit time, resolved later.
+
+export type HedgeLevel = "confident" | "hedged" | "speculative";
+
+export interface PredictionEntry {
+  id: string;
+  article_hash: SHA256Hex;
+  // Author of the prediction is usually the article author, but predictions
+  // attributed to named sources within the article are tagged separately.
+  attributed_to_author_id: string | null;
+  attributed_to_named_source: string | null;
+  attribution_kind: "article_voice" | "named_source" | "vague_attribution";
+
+  prediction_text: string;
+  prediction_type: "explicit" | "implicit" | "conditional" | "negative" | "counterfactual";
+  hedge_level: HedgeLevel;
+  condition: string | null;        // for conditional predictions
+
+  resolution_horizon: string;      // ISO date or descriptive
+  resolution_horizon_iso: ISO8601 | null;  // computed if possible
+  resolution_criteria: string;
+  tractability: "publicly_resolvable" | "requires_private_info" | "ambiguous";
+
+  evidence_quote: string;
+  source_span?: { start: number; end: number };
+
+  extracted_by: AuditorIdentity;
+  extracted_at: ISO8601;
+
+  // Filled in by resolution events. Multiple resolutions may exist; latest wins
+  // unless a dispute is open.
+  resolution_status: "open" | "resolved_true" | "resolved_false" | "resolved_partial" | "unresolvable";
+  latest_resolution_id: string | null;
+}
+
+
+// ---------- Prediction resolution ----------
+// Maps to suggested kind 30053. References a prediction; provides outcome evidence.
+
+export interface PredictionResolution {
+  id: string;
+  prediction_id: string;
+  resolved_by: AuditorIdentity;
+  resolved_at: ISO8601;
+  outcome: "true" | "false" | "partial" | "unresolvable";
+  // Evidence for the resolution: links, document hashes, references to other
+  // articles, public records, etc.
+  evidence: Array<{
+    kind: "url" | "nostr_event" | "document_hash" | "quote";
+    value: string;
+    description: string;
+  }>;
+  notes: string;
+  // Confidence in this resolution (resolutions can themselves be disputed).
+  confidence: Confidence;
+}
+
+
+// ---------- Author and publication ----------
+
+export interface Author {
+  id: string;                      // UUID, or NOSTR pubkey if author is NOSTR-native
+  name: string;
+  aliases: string[];
+  // Public exposure file for transparency (financial holdings, donations,
+  // prior employment, public commitments). Each item is sourced.
+  exposures: Array<{
+    kind: "financial_holding" | "donation" | "prior_employment" | "public_commitment" | "family_relationship" | "other";
+    description: string;
+    source_url: string;
+    as_of: ISO8601;
+  }>;
+  primary_publication_id: string | null;
+  beat_tags: string[];             // e.g., ["monetary_policy", "central_banks"]
+  notes_url?: string;              // public notes/clarifications page
+}
+
+export interface Publication {
+  id: string;
+  name: string;
+  homepage_url: string;
+  domains: string[];               // ["nytimes.com", "www.nytimes.com"]
+  // Ownership exposure file at publication level.
+  exposures: Array<{
+    kind: "ownership" | "controlling_investor" | "advertiser_dependence" | "other";
+    description: string;
+    source_url: string;
+    as_of: ISO8601;
+  }>;
+  notes_url?: string;
+}
+
+
+// ---------- Dossier rollup snapshot ----------
+// Maps to suggested kind 30054. Periodically materialized for fast lookup.
+// Should be reproducible from scratch from the underlying audits.
+
+export interface DossierSnapshot {
+  id: string;
+  subject_kind: "author" | "publication" | "beat" | "publication_x_beat";
+  subject_id: string;              // author/publication id; for beat just the tag
+  generated_at: ISO8601;
+  generated_by: AuditorIdentity;
+  // Window over which the rollup is computed
+  window_start: ISO8601;
+  window_end: ISO8601;
+  article_count: number;
+
+  // Aggregate scores. Each uses statistical shrinkage toward the population
+  // mean for low article counts; shrinkage_factor records how much the raw
+  // mean was pulled.
+  aggregate_score_mean: Score;
+  aggregate_score_median: Score;
+  aggregate_score_stdev: number;
+  shrinkage_factor: number;        // 0 = no shrinkage, 1 = fully shrunk to population mean
+
+  // Per-module score means, for dimension-level visibility
+  per_module_means: Partial<Record<ModuleName, Score>>;
+
+  // Prediction ledger summary for this subject
+  predictions: {
+    total: number;
+    resolved: number;
+    resolved_true: number;
+    resolved_false: number;
+    resolved_partial: number;
+    // Calibration: of confident predictions, fraction true; of hedged, fraction true; etc.
+    calibration: Record<HedgeLevel, { resolved: number; true_count: number; rate: number }>;
+  };
+
+  // Correction history summary for publications
+  corrections?: {
+    total: number;
+    prominently_acknowledged: number;
+    average_days_to_correct: number;
+  };
+
+  // Top recurring named sources, for sourcing pattern visibility
+  top_named_sources?: Array<{ name: string; appearances: number }>;
+}
+
+
+// ---------- Audit dispute / challenge ----------
+// Maps to suggested kind 30055. Anyone can file; adjudicators resolve.
+
+export interface AuditDispute {
+  id: string;
+  target_kind: "module_result" | "aggregate_audit" | "prediction_resolution" | "claim";
+  target_id: string;
+  filed_by: AuditorIdentity;
+  filed_at: ISO8601;
+
+  // What's contested and what evidence is presented.
+  dispute_summary: string;
+  contested_findings: string[];    // specific findings within the target
+  evidence: Array<{
+    kind: "url" | "nostr_event" | "document_hash" | "quote";
+    value: string;
+    description: string;
+  }>;
+
+  // Adjudication is a separate step, performed by a higher-trust reviewer
+  // or by consensus. Multiple adjudications can exist (e.g., from different
+  // independent reviewers); the dispute is resolved when convergence reached
+  // or escalated.
+  status: "open" | "under_review" | "upheld" | "rejected" | "partially_upheld" | "withdrawn";
+  adjudications: Array<{
+    adjudicator: AuditorIdentity;
+    decided_at: ISO8601;
+    decision: "upheld" | "rejected" | "partially_upheld";
+    reasoning: string;
+  }>;
+  // If upheld, this is the audit ID that supersedes the original
+  resulting_audit_id?: string;
+}
+
+
+// =============================================================================
+// Aggregation helpers (reference implementation contracts)
+// =============================================================================
+
+// Bayesian shrinkage formula for low-volume subjects.
+// Pulls a raw mean toward the population mean as sample size shrinks.
+//
+//   shrunk = (n / (n + k)) * raw_mean + (k / (n + k)) * population_mean
+//
+// where k is a tunable shrinkage constant (recommended starting value: 10).
+// At n=0, shrunk = population_mean. At n=k, halfway. As n grows, shrunk → raw.
+export interface ShrinkageParams {
+  k: number;
+  population_mean: Score;
+}
+
+// Cross-auditor disagreement metric for transparency.
+// Measures the spread across multiple auditors' scores of the same article.
+// Stored alongside aggregate audits so consumers can see "this article was
+// scored 67 by auditor A and 84 by auditor B" rather than a false consensus.
+export interface AuditorDisagreement {
+  article_hash: SHA256Hex;
+  module: ModuleName | "aggregate";
+  auditor_scores: Array<{
+    auditor: AuditorIdentity;
+    score: Score;
+    confidence: Confidence;
+  }>;
+  variance: number;
+  notes: string;
+}

--- a/docs/auditor-prototype/scorer/example-usage.js
+++ b/docs/auditor-prototype/scorer/example-usage.js
@@ -1,0 +1,60 @@
+// Example: programmatic use of the scorer.
+//
+// Run with:  ANTHROPIC_API_KEY=sk-ant-... node example-usage.js
+
+import { scoreArticle, formatSummary } from "./scorer.js";
+import { writeFile } from "node:fs/promises";
+
+const SAMPLE_ARTICLE = `# Fed officials signal patience as inflation eases
+
+WASHINGTON — Federal Reserve officials indicated Tuesday that they are
+prepared to hold interest rates steady for an extended period, even as
+new data showed consumer prices rose at their slowest pace in three years.
+
+The Consumer Price Index climbed 0.2% in April, bringing the annual
+inflation rate to 2.8%, the Labor Department reported. That is down
+from 3.1% in March and the lowest reading since early 2021.
+
+"We have made significant progress," one senior Fed official said,
+speaking on condition of anonymity to discuss internal deliberations.
+"But we want to see sustained evidence before we declare victory."
+
+Critics, however, argue that the central bank's caution risks a
+recession. Many economists worry that holding rates too high for too
+long could push unemployment above 5%.
+
+Treasury Secretary Janet Williams said the administration was
+"encouraged" by the data. Analysts expect the Fed to begin cutting
+rates by the end of the year.
+`;
+
+const SAMPLE_METADATA = {
+  source_url: "https://example.com/fed-inflation-2026-05-06",
+  headline: "Fed officials signal patience as inflation eases",
+  byline: "Sample Reporter",
+  publication_id: "example-publication",
+  publication_date: "2026-05-06",
+  language: "en",
+  capture_method: "manual_paste",
+};
+
+async function main() {
+  console.log("Scoring sample article...\n");
+
+  const result = await scoreArticle({
+    markdown: SAMPLE_ARTICLE,
+    metadata: SAMPLE_METADATA,
+  });
+
+  // Pretty summary to stdout.
+  console.log(formatSummary(result));
+
+  // Full structured result to disk.
+  await writeFile("sample-audit.json", JSON.stringify(result, null, 2), "utf8");
+  console.log("\nFull structured audit written to sample-audit.json");
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/docs/auditor-prototype/scorer/package.json
+++ b/docs/auditor-prototype/scorer/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "xray-auditor-scorer",
+  "version": "0.1.0",
+  "description": "Prototype per-article scorer for the X-Ray epistemic auditor. Orchestrates 8 surface-scan modules in parallel and aggregates into a final score with knowability ceiling.",
+  "type": "module",
+  "main": "scorer.js",
+  "scripts": {
+    "score": "node scorer.js",
+    "example": "node example-usage.js"
+  },
+  "bin": {
+    "xray-score": "scorer.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.30.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/docs/auditor-prototype/scorer/scorer.js
+++ b/docs/auditor-prototype/scorer/scorer.js
@@ -1,0 +1,551 @@
+// =============================================================================
+// X-Ray Epistemic Auditor — Prototype Per-Article Scorer
+// =============================================================================
+//
+// Orchestrates the 8 surface-scan modules in parallel, validates each output,
+// aggregates into a final article score with knowability ceiling, and writes
+// the result as a JSON file conforming to schema/audit-types.ts.
+//
+// USAGE:
+//   export ANTHROPIC_API_KEY=sk-ant-...
+//   node scorer.js --input article.md --metadata meta.json --output audit.json
+//
+// Or programmatically:
+//   import { scoreArticle } from "./scorer.js";
+//   const result = await scoreArticle({ markdown, metadata });
+//
+// =============================================================================
+
+import Anthropic from "@anthropic-ai/sdk";
+import { readFile, writeFile, readdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROMPTS_DIR = resolve(__dirname, "..", "prompts");
+
+// -----------------------------------------------------------------------------
+// Configuration
+// -----------------------------------------------------------------------------
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MAX_TOKENS = 8192;
+
+// Module → aggregation weight. Must sum to 1.0 across scoreable modules.
+// prediction_extraction does not produce a score; it feeds the ledger.
+const MODULE_WEIGHTS = {
+  headline_body_fidelity:   0.15,
+  asymmetric_language:      0.15,
+  number_hygiene:           0.10,
+  source_quality:           0.20,
+  internal_coherence:       0.10,
+  definitional_precision:   0.10,
+  omission:                 0.20,
+};
+
+// Module → prompt file. Filenames match the prompts/ directory layout.
+const MODULE_PROMPTS = {
+  headline_body_fidelity:   "01-headline-body-fidelity.md",
+  asymmetric_language:      "02-asymmetric-language.md",
+  number_hygiene:           "03-number-hygiene.md",
+  source_quality:           "04-source-quality.md",
+  internal_coherence:       "05-internal-coherence.md",
+  definitional_precision:   "06-definitional-precision.md",
+  omission:                 "07-omission.md",
+  prediction_extraction:    "08-prediction-extraction.md",
+};
+
+const SCOREABLE_MODULES = Object.keys(MODULE_WEIGHTS);
+const ALL_MODULES = Object.keys(MODULE_PROMPTS);
+
+// -----------------------------------------------------------------------------
+// Utilities
+// -----------------------------------------------------------------------------
+
+/**
+ * Normalize markdown for stable hashing across captures.
+ * - LF line endings
+ * - Trim trailing whitespace per line
+ * - Collapse runs of blank lines to a single blank line
+ * - Trim trailing whitespace at end of file
+ */
+function normalizeMarkdown(md) {
+  return md
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/\s+$/g, "");
+}
+
+function sha256Hex(s) {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+/**
+ * Strip a JSON object out of an LLM response that might (despite instructions)
+ * include preamble text or fenced code blocks. Throws if no valid JSON object
+ * can be extracted.
+ */
+function extractJson(text) {
+  const trimmed = text.trim();
+
+  // Try direct parse first (the happy path).
+  try {
+    return JSON.parse(trimmed);
+  } catch (_) {}
+
+  // Strip ```json or ``` fences.
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+  if (fenced) {
+    try { return JSON.parse(fenced[1]); } catch (_) {}
+  }
+
+  // Find first { and last } and try the slice.
+  const first = trimmed.indexOf("{");
+  const last = trimmed.lastIndexOf("}");
+  if (first !== -1 && last > first) {
+    try { return JSON.parse(trimmed.slice(first, last + 1)); } catch (_) {}
+  }
+
+  throw new Error("Could not extract JSON from model response");
+}
+
+/**
+ * Load a prompt file from prompts/ and split it at the "# ARTICLE" marker
+ * so we can inject the article content for the API call.
+ */
+async function loadPrompt(filename) {
+  const fullPath = join(PROMPTS_DIR, filename);
+  const content = await readFile(fullPath, "utf8");
+  // Each module prompt ends with a "# ARTICLE" header followed by where the
+  // article body should go. Everything before that is the system instructions.
+  const articleMarker = /^#+\s*ARTICLE\s*$/m;
+  const match = content.match(articleMarker);
+  if (!match) {
+    throw new Error(`Prompt ${filename} is missing the '# ARTICLE' marker`);
+  }
+  return content.slice(0, match.index).trim();
+}
+
+// -----------------------------------------------------------------------------
+// Module runner
+// -----------------------------------------------------------------------------
+
+/**
+ * Run a single module against the article. Returns a ModuleResult-shaped object.
+ */
+async function runModule({ client, model, module, articleMarkdown, articleHash }) {
+  const promptInstructions = await loadPrompt(MODULE_PROMPTS[module]);
+
+  const userMessage =
+    promptInstructions +
+    "\n\n# ARTICLE\n\n" +
+    articleMarkdown;
+
+  const startedAt = nowIso();
+  let response;
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: DEFAULT_MAX_TOKENS,
+      messages: [{ role: "user", content: userMessage }],
+    });
+  } catch (err) {
+    return {
+      module,
+      module_version: "1.0",
+      auditor: { kind: "model", id: `anthropic/${model}` },
+      run_at: startedAt,
+      score: null,
+      confidence: null,
+      findings: { error: err.message },
+      evidence_quotes: [],
+      auditor_caveats: [`API call failed: ${err.message}`],
+      _error: true,
+    };
+  }
+
+  const textBlocks = response.content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+
+  let parsed;
+  try {
+    parsed = extractJson(textBlocks);
+  } catch (err) {
+    return {
+      module,
+      module_version: "1.0",
+      auditor: { kind: "model", id: `anthropic/${model}` },
+      run_at: startedAt,
+      score: null,
+      confidence: null,
+      findings: { error: err.message, raw_response: textBlocks },
+      evidence_quotes: [],
+      auditor_caveats: [`JSON parse failed: ${err.message}`],
+      _error: true,
+    };
+  }
+
+  return {
+    article_hash: articleHash,
+    module,
+    module_version: parsed.version || "1.0",
+    auditor: { kind: "model", id: `anthropic/${model}` },
+    run_at: startedAt,
+    score: typeof parsed.score === "number" ? parsed.score : null,
+    confidence: typeof parsed.confidence === "number" ? parsed.confidence : null,
+    findings: parsed,
+    evidence_quotes: collectEvidenceQuotes(parsed),
+    auditor_caveats: parsed.auditor_caveats || [],
+  };
+}
+
+/**
+ * Walk a module's findings object and collect every `evidence_quote` field
+ * into a deduplicated list for cross-module reference.
+ */
+function collectEvidenceQuotes(findings) {
+  const quotes = new Set();
+  function walk(node) {
+    if (node === null || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      node.forEach(walk);
+      return;
+    }
+    for (const [k, v] of Object.entries(node)) {
+      if ((k === "evidence_quote" || k === "evidence_quote_a" || k === "evidence_quote_b") && typeof v === "string") {
+        quotes.add(v);
+      } else {
+        walk(v);
+      }
+    }
+  }
+  walk(findings);
+  return [...quotes].map((quote) => ({ quote }));
+}
+
+// -----------------------------------------------------------------------------
+// Aggregator
+// -----------------------------------------------------------------------------
+
+/**
+ * Combine module results into an AggregateAudit using documented weights and
+ * the knowability ceiling. The ceiling is heuristically derived here from the
+ * source_quality module's findings (publicly verifiable sources → high ceiling;
+ * heavy anonymous/classified sourcing → lower ceiling). For production, derive
+ * from a dedicated knowability module or human input.
+ */
+function aggregate({ articleHash, moduleResults, model }) {
+  const byModule = Object.fromEntries(moduleResults.map((r) => [r.module, r]));
+
+  // Estimate knowability ceiling from source_quality findings.
+  const sourceResult = byModule.source_quality;
+  let knowabilityCeiling = 95;
+  let knowabilityNotes = "Default ceiling; source_quality findings unavailable.";
+
+  if (sourceResult && !sourceResult._error && sourceResult.findings?.summary) {
+    const s = sourceResult.findings.summary;
+    const totalSources = s.total_sources || 0;
+    const namedRatio = totalSources > 0 ? (s.named_count || 0) / totalSources : 0;
+    const anonymousJustifiedRatio = totalSources > 0 ? (s.anonymous_justified_count || 0) / totalSources : 0;
+    const anonymousBareRatio = totalSources > 0
+      ? ((s.anonymous_count || 0) - (s.anonymous_justified_count || 0)) / totalSources
+      : 0;
+    const docsLinkedRatio = (s.documents_cited || 0) > 0
+      ? (s.documents_specifically_identified || 0) / s.documents_cited
+      : 1;
+
+    // Heuristic ceiling.
+    knowabilityCeiling = Math.round(
+      60 + 25 * namedRatio + 10 * docsLinkedRatio + 5 * anonymousJustifiedRatio - 15 * anonymousBareRatio
+    );
+    knowabilityCeiling = Math.max(40, Math.min(98, knowabilityCeiling));
+    knowabilityNotes =
+      `Ceiling derived from sourcing pattern: ${Math.round(namedRatio * 100)}% named, ` +
+      `${Math.round(anonymousBareRatio * 100)}% bare anonymous, ` +
+      `${Math.round(docsLinkedRatio * 100)}% of documents specifically identified.`;
+  }
+
+  // Weighted aggregate of scoreable modules.
+  let weightedSum = 0;
+  let totalWeightApplied = 0;
+  const moduleContributions = [];
+
+  for (const m of SCOREABLE_MODULES) {
+    const r = byModule[m];
+    const weight = MODULE_WEIGHTS[m];
+    if (!r || r._error || typeof r.score !== "number") {
+      moduleContributions.push({
+        module: m, module_result_id: null,
+        score: null, confidence: 0, weight: 0,
+      });
+      continue;
+    }
+    weightedSum += r.score * weight;
+    totalWeightApplied += weight;
+    moduleContributions.push({
+      module: m,
+      module_result_id: null, // would be set after persistence
+      score: r.score,
+      confidence: r.confidence ?? 0.5,
+      weight,
+    });
+  }
+
+  // Renormalize if some modules failed.
+  const rawWeighted = totalWeightApplied > 0
+    ? weightedSum / totalWeightApplied
+    : 0;
+
+  const ceilingBinding = rawWeighted > knowabilityCeiling;
+  const finalScore = Math.min(rawWeighted, knowabilityCeiling);
+
+  // Overall confidence: pipeline uncertainty stacks. Use min of module
+  // confidences, multiplied by the fraction of modules that succeeded.
+  const successfulModules = moduleContributions.filter((c) => c.score !== null);
+  const minConfidence = successfulModules.length
+    ? Math.min(...successfulModules.map((c) => c.confidence))
+    : 0;
+  const successFraction = successfulModules.length / SCOREABLE_MODULES.length;
+  const overallConfidence = Number((minConfidence * successFraction).toFixed(2));
+
+  // Surface top strengths and concerns.
+  const topStrengths = [];
+  const topConcerns = [];
+  for (const m of SCOREABLE_MODULES) {
+    const r = byModule[m];
+    if (!r || r._error) continue;
+    if (r.score >= 85) topStrengths.push(`${m}: ${r.score}`);
+    if (r.score <= 55) topConcerns.push(`${m}: ${r.score}`);
+  }
+
+  return {
+    article_hash: articleHash,
+    auditor: {
+      kind: "pipeline",
+      id: `xray-auditor-prototype/anthropic/${model}`,
+      display_name: "X-Ray Epistemic Auditor (prototype)",
+      constituents: SCOREABLE_MODULES.map((m) => ({
+        kind: "model",
+        id: `anthropic/${model}`,
+      })),
+    },
+    run_at: nowIso(),
+    module_contributions: moduleContributions,
+    knowability_ceiling: knowabilityCeiling,
+    knowability_notes: knowabilityNotes,
+    raw_weighted_score: Number(rawWeighted.toFixed(1)),
+    final_score: Number(finalScore.toFixed(1)),
+    ceiling_binding: ceilingBinding,
+    overall_confidence: overallConfidence,
+    top_strengths: topStrengths,
+    top_concerns: topConcerns,
+    disputes: [],
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Public API
+// -----------------------------------------------------------------------------
+
+/**
+ * Score an article. Returns { article, module_results, predictions, aggregate }.
+ *
+ * @param {object} params
+ * @param {string} params.markdown - The article markdown body.
+ * @param {object} [params.metadata] - Optional headline/byline/publication/etc.
+ * @param {string} [params.model] - Anthropic model id. Defaults to claude-sonnet-4-6.
+ * @param {string} [params.apiKey] - Override the ANTHROPIC_API_KEY env var.
+ */
+export async function scoreArticle({
+  markdown,
+  metadata = {},
+  model = DEFAULT_MODEL,
+  apiKey,
+}) {
+  if (!markdown || typeof markdown !== "string") {
+    throw new Error("scoreArticle requires `markdown` as a non-empty string");
+  }
+
+  const client = new Anthropic({ apiKey: apiKey || process.env.ANTHROPIC_API_KEY });
+
+  const normalized = normalizeMarkdown(markdown);
+  const articleHash = sha256Hex(normalized);
+
+  // Build the article object that gets persisted alongside results.
+  const article = {
+    hash: articleHash,
+    source_url: metadata.source_url || null,
+    headline: metadata.headline || null,
+    subhead: metadata.subhead || null,
+    byline_raw: metadata.byline || null,
+    author_ids: [],
+    publication_id: metadata.publication_id || null,
+    publication_date: metadata.publication_date || null,
+    language: metadata.language || "en",
+    word_count: normalized.split(/\s+/).filter(Boolean).length,
+    body_markdown: normalized,
+    captured_at: metadata.captured_at || nowIso(),
+    captured_by: { kind: "pipeline", id: "xray-auditor-prototype" },
+    capture_method: metadata.capture_method || "manual_paste",
+    archive_url: metadata.archive_url,
+  };
+
+  // Run all 8 modules in parallel.
+  console.error(`[scorer] Running ${ALL_MODULES.length} modules in parallel against ${model}...`);
+  const moduleResults = await Promise.all(
+    ALL_MODULES.map((module) =>
+      runModule({ client, model, module, articleMarkdown: normalized, articleHash })
+        .then((r) => {
+          const status = r._error ? "FAIL" : `score=${r.score ?? "n/a"} conf=${r.confidence ?? "n/a"}`;
+          console.error(`[scorer]   ${module.padEnd(28)} ${status}`);
+          return r;
+        })
+    )
+  );
+
+  // Predictions are extracted by module 08 but stored separately.
+  const predictionResult = moduleResults.find((r) => r.module === "prediction_extraction");
+  const predictions = (predictionResult && !predictionResult._error)
+    ? (predictionResult.findings.predictions || []).map((p, idx) => ({
+        ...p,
+        article_hash: articleHash,
+        attributed_to_author_id: null,
+        attributed_to_named_source: p.attributed_source_name || null,
+        attribution_kind: p.attributed_to,
+        prediction_text: p.prediction,
+        prediction_type: p.type,
+        resolution_horizon_iso: null, // would be parsed from horizon string
+        extracted_by: predictionResult.auditor,
+        extracted_at: predictionResult.run_at,
+        resolution_status: "open",
+        latest_resolution_id: null,
+      }))
+    : [];
+
+  // Aggregate.
+  const aggregate = aggregate_({ articleHash, moduleResults, model });
+
+  return { article, module_results: moduleResults, predictions, aggregate };
+}
+
+// Renamed to avoid shadowing the `aggregate` const in the API return.
+const aggregate_ = aggregate;
+
+// -----------------------------------------------------------------------------
+// Pretty-print summary for human consumption
+// -----------------------------------------------------------------------------
+
+export function formatSummary(result) {
+  const { article, module_results, predictions, aggregate } = result;
+  const lines = [];
+  lines.push("=".repeat(72));
+  lines.push("X-RAY EPISTEMIC AUDITOR — ARTICLE REPORT");
+  lines.push("=".repeat(72));
+  lines.push(`Headline:        ${article.headline || "(not provided)"}`);
+  lines.push(`Publication:     ${article.publication_id || "(not provided)"}`);
+  lines.push(`Date:            ${article.publication_date || "(not provided)"}`);
+  lines.push(`Word count:      ${article.word_count}`);
+  lines.push(`Article hash:    ${article.hash.slice(0, 16)}...`);
+  lines.push("");
+  lines.push("PER-MODULE SCORES");
+  lines.push("-".repeat(72));
+  for (const m of SCOREABLE_MODULES) {
+    const r = module_results.find((x) => x.module === m);
+    if (!r) continue;
+    if (r._error) {
+      lines.push(`  ${m.padEnd(28)} ERROR: ${r.findings.error || "unknown"}`);
+    } else {
+      const score = r.score ?? "n/a";
+      const conf = r.confidence != null ? r.confidence.toFixed(2) : "n/a";
+      lines.push(`  ${m.padEnd(28)} score=${String(score).padStart(3)}  conf=${conf}  weight=${MODULE_WEIGHTS[m]}`);
+    }
+  }
+  lines.push("");
+  lines.push("AGGREGATE");
+  lines.push("-".repeat(72));
+  lines.push(`  Raw weighted score:     ${aggregate.raw_weighted_score}`);
+  lines.push(`  Knowability ceiling:    ${aggregate.knowability_ceiling}  (${aggregate.knowability_notes})`);
+  lines.push(`  Final score:            ${aggregate.final_score}${aggregate.ceiling_binding ? "  (CEILING BINDING)" : ""}`);
+  lines.push(`  Overall confidence:     ${aggregate.overall_confidence}`);
+  lines.push("");
+  if (aggregate.top_strengths.length) {
+    lines.push("  Top strengths:");
+    for (const s of aggregate.top_strengths) lines.push(`    + ${s}`);
+  }
+  if (aggregate.top_concerns.length) {
+    lines.push("  Top concerns:");
+    for (const c of aggregate.top_concerns) lines.push(`    - ${c}`);
+  }
+  lines.push("");
+  lines.push(`PREDICTIONS EXTRACTED: ${predictions.length}`);
+  lines.push("-".repeat(72));
+  for (const p of predictions.slice(0, 5)) {
+    lines.push(`  [${p.hedge_level.padEnd(11)}] ${p.prediction_text}`);
+    lines.push(`               horizon: ${p.resolution_horizon}`);
+  }
+  if (predictions.length > 5) {
+    lines.push(`  ... and ${predictions.length - 5} more`);
+  }
+  lines.push("");
+  lines.push("=".repeat(72));
+  return lines.join("\n");
+}
+
+// -----------------------------------------------------------------------------
+// CLI entry point
+// -----------------------------------------------------------------------------
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      input:    { type: "string", short: "i" },
+      metadata: { type: "string", short: "m" },
+      output:   { type: "string", short: "o" },
+      model:    { type: "string" },
+      summary:  { type: "boolean", default: true },
+    },
+  });
+
+  if (!values.input) {
+    console.error("Usage: node scorer.js --input <article.md> [--metadata meta.json] [--output audit.json] [--model claude-sonnet-4-6]");
+    process.exit(1);
+  }
+
+  const markdown = await readFile(values.input, "utf8");
+  const metadata = values.metadata
+    ? JSON.parse(await readFile(values.metadata, "utf8"))
+    : {};
+
+  const result = await scoreArticle({
+    markdown,
+    metadata,
+    model: values.model || DEFAULT_MODEL,
+  });
+
+  if (values.output) {
+    await writeFile(values.output, JSON.stringify(result, null, 2), "utf8");
+    console.error(`[scorer] Wrote ${values.output}`);
+  }
+
+  if (values.summary) {
+    console.log(formatSummary(result));
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Supersedes the rev-1 kickoff (#57) now that the maintainer's actual epistemic-auditor framework is recovered from prior conversations.

## What's here

- **`docs/auditor-prototype/`** — the framework vendored verbatim (13 files): the eight surface-scan module prompts (headline-body fidelity, asymmetric language, number hygiene, source quality, internal coherence, definitional precision, omission, prediction extraction) + single-shot orchestrator, the full data schema (`audit-types.ts`: content-addressed articles, module results, aggregate audits with knowability ceiling, prediction ledger/resolutions, dossiers, disputes, auditor identity), and the working Node scorer.
- **`docs/EPISTEMIC_AUDIT_KICKOFF.md` rev 2** — rewritten around the framework. The honest reversals from rev 1 are on the record in the brief itself: numeric scores are IN (the framework's calibration discipline answers the Phase 10.1 concern; rev 1 had over-generalized that removal), and the auditor is primarily a model/pipeline, not a human checklist. What converged survives (audit/assessment firewall, evidence-bound findings, content-hash anchoring, time-series accumulation).
- The brief centers **eight integration problems** for the overnight design session — led by the mandatory kind remapping (the prototype's suggested 30050–30055 all collided with kinds shipped in Phases 9a/11) and the runs-where architecture question (companion CLI vs in-extension API vs manual tier vs hybrid).

Adversarially reviewed before landing (framework-fidelity / repo-fidelity / cold-start lenses, 12 findings fixed — including the knowability-ceiling provenance ambiguity where `prompts/00` and `scorer.js` genuinely disagree, now flagged as a maintainer review question rather than papered over).

Overnight scope unchanged: **design note only.**

Gates: build ✅ · 670/670 ✅ · lint 0 errors ✅ (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)