### PR TITLE
docs: Phase 13 kickoff rev 3 — recovered sub-READMEs vendored + brief updated

### DIFF
--- a/docs/EPISTEMIC_AUDIT_KICKOFF.md
+++ b/docs/EPISTEMIC_AUDIT_KICKOFF.md
@@ -1,8 +1,11 @@
 # Phase 13 — Epistemic audits: the X-Ray auditor, integrated
 
-**Status:** kickoff brief, 2026-06-11 (rev 2 — now grounded in the
-maintainer's recovered auditor framework; supersedes the rev-1
-reconstruction). This is the prompt for a *new session* to design
+**Status:** kickoff brief, 2026-06-11 (rev 3 — rev 2 grounded the
+brief in the maintainer's recovered auditor framework, superseding the
+rev-1 reconstruction; rev 3 incorporates the three subsequently
+recovered sub-READMEs: the per-entity kind map, the calibration
+anchors, the integration paths, and derive-don't-ask for the module
+findings schemas). This is the prompt for a *new session* to design
 Phase 13. **Design note ONLY this session** — the maintainer has
 explicitly scoped this run to producing `docs/EPISTEMIC_AUDIT_DESIGN.md`
 for review; **no feature code, no wire builders, no UI** until the
@@ -23,29 +26,47 @@ conversations, is **recovered and vendored in this repo** at
 
 - `docs/auditor-prototype/README.md` — the architecture and the design
   rationale, in the maintainer's own words. Authoritative.
-- `docs/auditor-prototype/prompts/00`–`08` — the eight surface-scan
-  module methodologies (versioned prompts with scoring rubrics and
-  structured-JSON output contracts) plus a single-shot orchestrator.
-- `docs/auditor-prototype/schema/audit-types.ts` — the full data
-  model: content-addressed articles, atomic claims, module results,
-  aggregate audits with knowability ceiling, prediction ledger +
-  resolutions, author/publication dossiers with Bayesian shrinkage,
-  audit disputes, auditor identity, cross-auditor disagreement.
+- `docs/auditor-prototype/prompts/` — the eight surface-scan module
+  methodologies (versioned prompts with scoring rubrics and
+  structured-JSON output contracts), a single-shot orchestrator, and a
+  README whose **calibration notes are load-bearing for display
+  design**: a score of 50 is a *meaningfully concerning* article, not
+  an average one (competent journalism's expected mean is 70–85);
+  confidence below 0.6 means "needs human review"; every finding must
+  carry an `evidence_quote` — "this is what makes the audit
+  auditable"; methodology changes bump the module version so dossiers
+  can show "rescored under v1.2" history.
+- `docs/auditor-prototype/schema/` — `audit-types.ts` (the canonical
+  data model: content-addressed articles, atomic claims, module
+  results, aggregate audits with knowability ceiling, prediction
+  ledger + resolutions, dossiers with Bayesian shrinkage, disputes,
+  auditor identity, cross-auditor disagreement) plus a README with the
+  entity diagram, the per-entity kind suggestions, the NOSTR mapping
+  notes (`d`/`e`/`p`/`t` tag schemes), and the design-decisions
+  rationale.
 - `docs/auditor-prototype/scorer/` — a working Node prototype that
   fans the eight modules out in parallel against the Anthropic API and
-  aggregates (weights, ceiling, confidence stacking).
+  aggregates (weights, ceiling, confidence stacking), plus a README
+  with cost notes (cache key = article hash; a cached audit needs no
+  recompute until the methodology version changes) and — read this
+  twice — a **"Wiring into X-Ray" section laying out two integration
+  paths**, each with its trade-offs.
 
-Three referenced artifacts were NOT recovered: `schema/README.md`
-(cited by the README for the per-entity kind suggestions),
-`schema/relational.sql` (cited in audit-types.ts's header), and the
-per-module findings JSON schemas in `schema/modules/` (cited by
-`ModuleResult.findings` — note the scorer's "validates each output"
-header is aspirational; the code only extracts JSON). Also unrecovered:
-the original conversation's prose on "governing principles, dimensions,
-knowability, calibration multiplier, dispute mechanics, accessibility
-tiers" (the README's final paragraph points to it). Where any of these
-would have answered a question — the module findings schemas bear
-directly on your module-result wire shape — put the question to the
+Two referenced artifacts remain unrecovered, both reconstructible:
+`schema/relational.sql` (audit-types.ts's header; the schema README
+says it can be code-generated from the types — treat as a non-loss)
+and the per-module findings JSON schemas in `schema/modules/` (absent,
+but both READMEs say they are *derived from the prompt output
+specifications* in `prompts/01`–`08` — your design note should derive
+them, not ask; note that the scorer's "validates each output" header
+AND the schema README's "the scorer prototype validates module
+outputs against these schemas before persisting" are both
+aspirational — the code only extracts JSON, as the scorer README's
+own Limitations section admits). Still genuinely
+unrecovered: the original conversation's prose on "governing
+principles, dimensions, knowability, calibration multiplier, dispute
+mechanics, accessibility tiers" (the main README's final paragraph
+points to it). Where THAT would have answered a question, ask the
 maintainer rather than inventing the answer.
 
 An earlier revision of this brief reconstructed the concept from first
@@ -111,11 +132,8 @@ calibration machinery only works if those signals never blend.
 
 ## Read next (and verify — don't take this brief's word for it)
 
-- `CLAUDE.md` — contexts, conventions, the `xray:*` bus. **CAUTION:**
-  parts are stale (pre-Phase-11): its event-builder kind list still
-  shows retired 30043 as live and omits 30054/30055, and its roadmap
-  line stops at Phase 9a/v0.5.0. On kinds and phase status, trust
-  `docs/ROADMAP.md`, `docs/ASSESSMENTS_DESIGN.md`, and the code.
+- `CLAUDE.md` — contexts, conventions, the `xray:*` bus (refreshed for
+  Phase 12 in PR #59; current as of this brief).
 - `docs/ASSESSMENTS_DESIGN.md` — the Phase 11 design this layer sits
   beside; its "why a new kind" section is the template for your
   kind-number arguments.
@@ -154,34 +172,55 @@ These are the actual design work. The framework's shape is the
 maintainer's settled intent (modulo its own not-yet-built list, above);
 its *integration into X-Ray* is not.
 
-1. **Kind remapping (mandatory).** `audit-types.ts` suggests kinds
-   30050–30055 — written before Phases 9a/11 shipped, and **every one
-   of those numbers is now taken** (30050 annotations, 30051
+1. **Kind remapping (mandatory).** The schema README assigns the six
+   entity families precisely — ModuleResult 30050 (×8 modules),
+   AggregateAudit 30051, PredictionEntry 30052, PredictionResolution
+   30053, DossierSnapshot 30054, AuditDispute 30055 — and itself says
+   the numbers "should be claimed via NIP proposal before formal
+   publishing." They were chosen before Phases 9a/11 shipped, and
+   **every one is now taken inside X-Ray** (30050 annotations, 30051
    fact-checks, 30052 ratings, 30053 topic-trust, 30054 assessments,
    30055 relationships; 30043 is retired-do-not-reuse). Free: 30042,
-   30044–30049, 30056+. The note must map the framework's six entity
-   families (module result, aggregate audit, prediction entry,
-   prediction resolution, dossier snapshot, dispute) onto new kinds —
+   30044–30049, 30056+. Map the same six families onto new kinds —
    or argue fewer kinds with `d`-tag discrimination — with
    ASSESSMENTS_DESIGN-grade rationale per choice, `d` recomputable
-   from public inputs, dual-read-friendly, flag-gated. Note which
-   entities are addressable (latest-wins is WRONG for audits — the
-   schema says "nothing overwrites prior audits; drift is queryable" —
-   so argue the addressable-vs-regular choice per entity carefully).
+   from public inputs, dual-read-friendly, flag-gated. Preserve the
+   schema README's tag grammar where it fits the house idiom (`d` =
+   article hash for module results / subject id for dossiers; `e` to
+   predecessors — dispute→audit, resolution→prediction; `p` auditor/
+   author pubkeys; `t` beat/publication/module). **And resolve the
+   framework's sharpest internal tension head-on:** the schema README
+   says "each entity becomes an addressable replaceable event," while
+   audit-types.ts mandates "all time-series... nothing overwrites
+   prior audits; drift is queryable" — at the same `d`, NIP-01
+   replacement would eat the history. Your `d` scheme (run
+   discriminator? supersession chains with both visible, as the
+   dispute section requires?) must reconcile these, per entity.
 2. **Where the model runs.** The scorer is a Node CLI calling the
-   Anthropic API. X-Ray the extension has no API dependency, no API
-   keys, and a hard local-first posture. Options to weigh (this is
-   the biggest open question — frame it, recommend, and ask):
-   (a) companion-tool architecture — the scorer stays outside the
-   extension, emits signed NOSTR events the extension/portal then
-   reads like any other corpus events; (b) in-extension calls to an
-   LLM API behind settings + the flag (key storage, cost, consent);
-   (c) a manual tier — the module *methodologies* double as guided
-   human checklists run in the reader (the unrecovered "accessibility
-   tiers" prose may have envisioned exactly this — ask); (d) hybrid.
-   Auditor identity must record which path produced each result —
-   the schema already supports model/human/pipeline/consensus, with
-   constituent auditors on the latter two.
+   Anthropic API; X-Ray the extension currently has no API dependency
+   and no key handling. The scorer README's "Wiring into X-Ray"
+   section lays out **two integration paths** (presented with
+   trade-offs, not as a ruling): (a) the service worker calls a
+   **hosted scorer endpoint** (thin wrapper around `scoreArticle`),
+   result rendered in the reader — the README says "capture panel,"
+   a surface removed with the FAB/in-page panel; the reader is its
+   successor — and optionally published as audit events;
+   (b) **local-first** — users supply their
+   own API key and the scorer logic runs client-side from the
+   background worker, no server. Either path yields identical
+   `audit-types.ts` shapes downstream. The design note should weigh
+   these two (key storage, consent, cost — the README budgets 1–3¢
+   per article on Sonnet, and prescribes caching by article hash
+   until a methodology version changes; also note a hosted endpoint
+   is a new trust dependency for a trust tool), may add a third
+   **manual tier** — the module methodologies double as guided human
+   checklists in the reader (the unrecovered "accessibility tiers"
+   prose may have envisioned this — ask) — and recommend. A
+   companion-CLI stopgap (the scorer as-is, emitting signed events
+   the portal reads) is compatible with (b) and worth costing as the
+   v1 stepping stone. Auditor identity must record which path
+   produced each result — the schema supports model/human/pipeline/
+   consensus, with constituent auditors on the latter two.
 3. **Article hashing, canonically.** One normalization, specified
    byte-for-byte in the note (the scorer's `normalizeMarkdown` is the
    candidate), its relationship to `html_snapshot_sha256`, and how a
@@ -223,10 +262,15 @@ its *integration into X-Ray* is not.
    disagreement is preserved as a sibling record rather than averaged
    away. The design note should make the display rule explicit — a
    score never renders without its confidence, and an aggregate never
-   without its ceiling context — and apply it to every UI surface,
-   especially the score badge (a surface your note *proposes*: the v1
-   trust-badge UI was removed in Phase 0/10 reframes, and the auditor
-   README's "metadata badge surface" line predates that removal).
+   without its ceiling context — and bake in the prompts README's
+   calibration anchors: 50 is *concerning*, not average (competent
+   journalism's expected mean is 70–85, so any color scale or badge
+   must not center on 50), and confidence < 0.6 renders as
+   "needs human review," not as a number. Apply it to every UI
+   surface, especially the score badge (a surface your note
+   *proposes*: the v1 trust-badge UI was removed in Phase 0/10
+   reframes, and the auditor README's "metadata badge surface" line
+   predates that removal).
 8. **Failure modes** (address each): score theater (a 0–100 number
    invites consumers to ignore the confidence — the display rule
    above is the mitigation; the knowability ceiling is the other
@@ -262,11 +306,15 @@ its *integration into X-Ray* is not.
   history docs; non-goals (network consensus, multi-auditor
   aggregation beyond disagreement display, adjudication runtime);
   slice plan for a later implementation run (model+tests → wire
-  builders+NIP draft → capture-time hashing → companion/manual audit
-  path → portal surfaces → publish, or as your design dictates); and
-  **review questions** — lead with the runs-where architecture and
-  any place the unrecovered philosophy prose (calibration multiplier
-  details, accessibility tiers) forced a guess.
+  builders+NIP draft → capture-time hashing → audit execution path
+  per your runs-where recommendation, with stopgap tiers as your
+  design dictates → portal surfaces → publish); and
+  **review questions** — lead with the runs-where architecture, the
+  knowability-ceiling provenance question (who sets it: the auditing
+  model, the pipeline heuristic, or a dedicated module — the two
+  recovered implementations disagree), and any place the unrecovered
+  philosophy prose (calibration multiplier details, accessibility
+  tiers) forced a guess.
 - **Run a multi-agent adversarial review over the design note itself**
   before opening the PR (lenses: framework fidelity — every deviation
   from `docs/auditor-prototype/` is flagged and justified, none is
@@ -274,9 +322,7 @@ its *integration into X-Ray* is not.
   against `main`; scope — small slices, nothing network-shaped,
   design-note-only honored). Fix what's confirmed.
 - ROADMAP gains a Phase 13 section (status: design under review) +
-  snapshot line. (Housekeeping: if the §Phase 12 section header still
-  says "(in progress)", fix it in passing — the snapshot is
-  authoritative.) JOURNAL records the second-guessable calls,
+  snapshot line. JOURNAL records the second-guessable calls,
   including the rev-1→rev-2 reversal on numeric scores (the kind of
   thing future readers will second-guess). Gate the push on
   `npm run build`, `npm test`, `npx --yes web-ext lint --source-dir .

--- a/docs/auditor-prototype/prompts/README.md
+++ b/docs/auditor-prototype/prompts/README.md
@@ -1,0 +1,65 @@
+# Surface-Scan Prompt Suite
+
+Eight surface-detectable dimensions of journalistic quality, plus a single-shot orchestrator. Each prompt is self-contained and returns structured JSON that the downstream scorer aggregates into a per-article report.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `00-orchestrator-single-shot.md` | Runs all dimensions in one prompt. Use for browser testing in Claude.ai. |
+| `01-headline-body-fidelity.md` | Does the headline accurately preview the body? |
+| `02-asymmetric-language.md` | Symmetric verb/adjective/framing across comparable parties? |
+| `03-number-hygiene.md` | Denominator, base rate, comparison class on every number? |
+| `04-source-quality.md` | Named vs anonymous; primary vs vague; contested claims sourced? |
+| `05-internal-coherence.md` | Contradictions, logical gaps, lead-body mismatch? |
+| `06-definitional-precision.md` | Contested terms defined or smuggled? |
+| `07-omission.md` | Who was quoted, who was missing, who spoke for whom? |
+| `08-prediction-extraction.md` | Extract testable predictions for the long-term ledger. |
+
+## Quickstart — testing in Claude.ai (browser)
+
+1. Open a new chat in claude.ai.
+2. Open `00-orchestrator-single-shot.md`. Copy the whole file.
+3. Paste into Claude.ai.
+4. Below it, paste the article markdown you want audited. (X-Ray's article capture produces the exact format expected.)
+5. Send. You'll get a single JSON report covering all dimensions.
+
+For deeper focus on one dimension, use the individual module prompts (`01`–`08`) the same way.
+
+## Why per-module prompts exist alongside the orchestrator
+
+The orchestrator is convenient but compresses; running modules independently gives:
+
+- **More careful per-dimension reasoning** (the model isn't context-juggling eight tasks).
+- **Parallel execution** in the production scorer (eight API calls in parallel = roughly the latency of one).
+- **Independent versioning.** When a module's methodology improves, only that module's score needs to be recomputed.
+- **Resilience.** If one module's call fails, the others still produce findings.
+- **Auditor diversity.** Different modules can be assigned to different model providers if you want cross-vendor cross-checks.
+
+In production the scorer runs the eight individual modules in parallel and aggregates the result. The orchestrator is for browser testing and quick spot-checks.
+
+## Output schema invariant
+
+Every module returns JSON with at minimum:
+
+```json
+{
+  "module": "<module_name>",
+  "version": "<semver>",
+  "score": 0-100,            // omitted by 08-prediction-extraction
+  "confidence": 0.0-1.0,     // omitted by 08-prediction-extraction
+  "auditor_caveats": [...]
+}
+```
+
+This invariant lets the scorer aggregate uniformly and lets the dossier track per-module drift over time.
+
+## Notes on calibration
+
+- A score of 50 is *not* the average article — it's a meaningfully concerning article. The expected mean for competent journalism is in the 70–85 range.
+- Confidence below 0.6 should be treated as "this dimension needs human review or additional evidence to score reliably."
+- All findings must include `evidence_quote` — direct quotes from the article. This is what makes the audit auditable.
+
+## Module versioning
+
+Each module declares a `version` field. When you change a prompt's methodology, bump the version. Stored audit results retain their version, so dossiers can show "rescored under v1.2" history. This is essential for long-term trust in the scorer itself.

--- a/docs/auditor-prototype/schema/README.md
+++ b/docs/auditor-prototype/schema/README.md
@@ -1,0 +1,103 @@
+# Dossier Schema
+
+The data model for the X-Ray epistemic auditor. Storage-agnostic but designed for NOSTR-native publishing.
+
+## Files
+
+- `audit-types.ts` — TypeScript type definitions for every entity. The canonical schema.
+
+## Entity overview
+
+```
+                  ┌──────────────────┐
+                  │     Article      │  content-addressed (SHA-256 of markdown)
+                  │   (kind 30023)   │
+                  └────────┬─────────┘
+                           │
+          ┌────────────────┼────────────────────┬────────────────┐
+          │                │                    │                │
+          ▼                ▼                    ▼                ▼
+   ┌──────────────┐ ┌─────────────┐  ┌──────────────────┐ ┌─────────────┐
+   │ AtomicClaim  │ │ ModuleResult │  │ PredictionEntry  │ │ Aggregate   │
+   │ (kind 30040) │ │ (kind 30050) │  │  (kind 30052)    │ │   Audit     │
+   └──────────────┘ │  × 8 modules │  └────────┬─────────┘ │(kind 30051) │
+                    └──────────────┘           │           └─────────────┘
+                                               ▼
+                                    ┌────────────────────┐
+                                    │ PredictionResolution│
+                                    │   (kind 30053)      │
+                                    └────────────────────┘
+
+           ┌─────────────────┐                     ┌──────────────────┐
+           │     Author      │ ─── rolled up ───▶  │ DossierSnapshot  │
+           │   Publication   │                     │  (kind 30054)    │
+           └─────────────────┘                     └──────────────────┘
+
+                    ┌──────────────────────┐
+                    │   AuditDispute       │  references any of the above
+                    │   (kind 30055)       │
+                    └──────────────────────┘
+```
+
+## Key design decisions
+
+### Articles are content-addressed by SHA-256 of normalized markdown
+
+URLs change. Outlets stealth-edit. Paywalls move. The hash anchors every downstream entity to the *exact text that was scored*. If the article is later edited and re-captured, it gets a new hash and a new audit lineage — the old audits are not silently invalidated, and the diff between the two captures is itself a notable artifact.
+
+X-Ray's existing capture pipeline produces clean markdown via Readability + Turndown; that output is suitable for hashing after a normalization pass (trim trailing whitespace, collapse blank-line runs, force LF line endings).
+
+### Per-module results are stored independently
+
+When a module's prompt or methodology improves, only that module's score for affected articles needs to be recomputed. The aggregate audit re-derives from whatever module results are current. Module results carry their `module_version` so historical audits remain valid under their original methodology.
+
+### Auditor identity is a first-class type
+
+`AuditorIdentity` covers four kinds: a model (e.g., `anthropic/claude-opus-4-7`), a human (NOSTR pubkey), a pipeline (a named orchestration with a manifest hash), or a consensus (multiple constituent auditors). Every score, claim extraction, prediction resolution, and dispute carries its auditor. This is what lets the system audit the auditors over time.
+
+### Disagreement is published, not averaged away
+
+When multiple auditors score the same article, the schema preserves all individual scores and their variance via `AuditorDisagreement`. Consumers can see "this article was scored 67 by one auditor and 84 by another" rather than a false consensus. This is the structural defense against ideological capture of the auditor itself.
+
+### Predictions are extracted at audit time and resolved later
+
+The `PredictionEntry` is created when the article is first audited. Its `resolution_status` starts as `"open"`. A `PredictionResolution` event fills it in later — possibly years later, possibly by a different auditor than extracted it. The dossier rollups compute the per-author and per-publication calibration: of confident predictions, what fraction resolved true; of hedged predictions, what fraction; etc. This is the long-game asset that makes the system durable.
+
+### Disputes don't silently change scores
+
+If an audit is challenged and the challenge is upheld, a *new* audit is created and the original is marked `superseded_by`. Both remain visible. The full history of how a score moved over time is the audit trail; nothing is overwritten.
+
+### Dossier snapshots are reproducible from raw data
+
+`DossierSnapshot` is a materialized rollup for fast lookup, but the canonical truth is always the underlying audits. Anyone can re-derive a snapshot from scratch given the same window and methodology. This is what makes the system reproducible by third parties — the central feature distinguishing it from a black-box ratings service.
+
+## NOSTR mapping notes
+
+X-Ray already publishes articles as `kind: 30023` (NIP-23 long-form) and plans `kind: 30040` for atomic claims. The auditor needs additional kinds; the suggested numbering (`30050`–`30055`) avoids collision with existing NIPs in the 30k addressable range, but should be claimed via NIP proposal before formal publishing.
+
+Each entity becomes an addressable replaceable event:
+- `d` tag: stable identifier (article hash for module results; subject ID for dossier snapshots)
+- `e` tag: references to predecessor events (e.g., dispute → audit, resolution → prediction)
+- `p` tag: pubkeys involved (auditor pubkey for human auditors, author pubkey when known)
+- `t` tag: topical tags (beat, publication, module name)
+
+This makes the entire audit corpus queryable across NOSTR relays the same way X-Ray already queries URL metadata.
+
+## Relational alternative
+
+For non-NOSTR storage (Postgres, SQLite), the same schema maps to tables straightforwardly:
+- One table per entity type (`articles`, `atomic_claims`, `module_results`, etc.)
+- `article_hash` as the foreign key on most tables
+- JSONB columns for `findings` and other variable-shape fields
+- Indexes on `(article_hash, module, auditor_id, run_at)` for module results
+- Indexes on `(subject_id, generated_at)` for dossier snapshots
+
+A relational migration sketch can be generated from `audit-types.ts` via standard codegen (e.g., `kysely-codegen` or `drizzle-kit`).
+
+## Validation
+
+The `findings` field on `ModuleResult` is `Record<string, unknown>` because the shape varies per module. Validate using per-module JSON Schemas derived from the prompt output specifications (in `prompts/01`–`prompts/08`). The scorer prototype validates module outputs against these schemas before persisting.
+
+## Versioning
+
+Every entity that captures methodology carries a version (`module_version`, the auditor's `id` includes model version). When the schema itself changes, bump a top-level schema version and migrate. The principle: nothing about a stored audit should become ambiguous as the system evolves.

--- a/docs/auditor-prototype/scorer/README.md
+++ b/docs/auditor-prototype/scorer/README.md
@@ -1,0 +1,115 @@
+# X-Ray Auditor — Prototype Scorer
+
+Orchestrates the eight surface-scan modules in parallel against the Anthropic API and aggregates results into a final article score conforming to `schema/audit-types.ts`.
+
+## Install
+
+```bash
+cd scorer
+npm install
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## CLI usage
+
+```bash
+# Minimal — markdown only
+node scorer.js --input path/to/article.md
+
+# With metadata file (recommended)
+node scorer.js --input article.md --metadata article-meta.json --output audit.json
+
+# Choose a different model
+node scorer.js --input article.md --model claude-opus-4-7
+```
+
+Sample `article-meta.json`:
+
+```json
+{
+  "source_url": "https://example.com/article",
+  "headline": "Article headline as published",
+  "subhead": "Optional subhead",
+  "byline": "By Sample Reporter",
+  "publication_id": "example-publication",
+  "publication_date": "2026-05-06",
+  "language": "en",
+  "capture_method": "xray_extension"
+}
+```
+
+## Programmatic usage
+
+```javascript
+import { scoreArticle, formatSummary } from "./scorer.js";
+
+const result = await scoreArticle({
+  markdown: articleText,
+  metadata: { headline: "...", byline: "...", /* ... */ },
+  model: "claude-sonnet-4-6",  // optional; this is the default
+});
+
+// result.aggregate.final_score        — number 0–100
+// result.aggregate.knowability_ceiling — number 0–100
+// result.aggregate.overall_confidence  — number 0.0–1.0
+// result.module_results                — array of 8 ModuleResult objects
+// result.predictions                   — array of PredictionEntry objects
+// result.article                       — Article object with hash and metadata
+
+console.log(formatSummary(result));
+```
+
+## Try it now
+
+```bash
+node example-usage.js
+```
+
+Runs the scorer against a sample article (intentionally containing several auditor-detectable issues — anonymous bare sourcing, weasel quantifiers, asymmetric language) and writes `sample-audit.json`.
+
+## How it works
+
+1. **Normalize and hash.** Article markdown is normalized (LF line endings, trimmed trailing whitespace, collapsed blank lines) and hashed with SHA-256. The hash anchors every downstream entity to the exact text scored.
+
+2. **Parallel module dispatch.** All eight prompts (`prompts/01`–`prompts/08`) are loaded and dispatched as parallel API calls. Each returns structured JSON conforming to its module's output schema.
+
+3. **JSON extraction with fallback.** The scorer tolerates non-conforming model output (preamble text, code fences) via progressive fallback parsing.
+
+4. **Knowability ceiling derivation.** The ceiling is computed heuristically from the source-quality findings: heavy named sourcing and document-linking → high ceiling; bare anonymous sourcing → lower ceiling. Replace this with a dedicated module (or human input) for production.
+
+5. **Weighted aggregation.** Scoreable modules combine using documented weights (`MODULE_WEIGHTS` in `scorer.js`). If a module fails, weights are renormalized across successful modules. Final score is capped at the knowability ceiling.
+
+6. **Confidence stacking.** Overall pipeline confidence is `min(module_confidences) × (successful_modules / total_modules)`. Pipeline-level uncertainty stacks; the aggregate is never more confident than its weakest contributor.
+
+7. **Predictions extracted.** Module 08's output is restructured into `PredictionEntry` records with `resolution_status: "open"`, ready to feed the long-term ledger when resolutions arrive.
+
+## Tunable knobs
+
+In `scorer.js`:
+
+- `DEFAULT_MODEL` — default Anthropic model (`claude-sonnet-4-6`). Use `claude-opus-4-7` for higher quality at higher cost; `claude-haiku-4-5-20251001` for fast/cheap triage scoring.
+- `DEFAULT_MAX_TOKENS` — output cap per module call. Increase for very long articles.
+- `MODULE_WEIGHTS` — aggregation weights. Sum must remain 1.0.
+- The knowability heuristic in `aggregate()` is the most opinionated piece. Read it, disagree with it, replace it.
+
+## Cost note
+
+Eight parallel calls per article. With `claude-sonnet-4-6` and a typical 1,500-word article, expect roughly 1–3 cents per audit at current pricing. With `claude-opus-4-7`, several times that. Cache aggressively in production: the article hash is the cache key, and a cached audit needs no recomputation unless the methodology version changes.
+
+## Wiring into X-Ray
+
+The X-Ray extension already produces normalized markdown (Readability + Turndown) and rich metadata. Two integration paths:
+
+- **Background-worker invocation.** When a user invokes the auditor from the capture panel, the service worker calls a hosted scorer endpoint (a thin wrapper around `scoreArticle`) with the captured markdown + metadata. Result is rendered in the panel and optionally published as a NOSTR audit event (kind 30050/30051).
+
+- **Local-first.** For users with their own API keys, the scorer can run entirely client-side from the extension's background worker. No server required. The trade-off: API key handling moves to the user, and parallel call latency depends on their network.
+
+Either path produces results in the same `audit-types.ts` shape, so downstream NOSTR publishing, dossier rollups, and dispute mechanisms are identical.
+
+## Limitations of this prototype
+
+- **No JSON Schema validation.** Module outputs are trusted to match the documented shape. Production should validate via per-module JSON Schemas (one per module, derived from the prompt output specs).
+- **No persistence layer.** Results are returned and optionally written to disk. Production needs a store (Postgres, IndexedDB, NOSTR relay) and dossier-rollup queries.
+- **No dispute mechanism.** The schema includes `AuditDispute` but the scorer doesn't yet handle re-scoring on dispute resolution.
+- **Single-auditor.** No multi-model consensus or human-in-the-loop. Production gains a lot from running the same article through Claude + GPT + a human and surfacing the disagreement.
+- **Knowability heuristic is crude.** It uses only source-quality findings. A dedicated knowability module (or beat-specific lookup table) would be more defensible.


### PR DESCRIPTION
The three remaining framework READMEs (prompts/schema/scorer) are recovered and vendored into `docs/auditor-prototype/`; the kickoff brief is updated to rev 3 around them.

What they settle: the **per-entity kind map** (confirming the full 30050–30055 collision with shipped X-Ray kinds and adding the d/e/p/t tag grammar), the **two integration paths** for the runs-where question (hosted endpoint vs local-first user-key — presented with trade-offs; the README's "capture panel" render target is flagged as a removed surface), the **calibration anchors** that gate badge design (50 = concerning, 70–85 = competent mean, confidence <0.6 = needs human review), and **derive-don't-ask** for the per-module findings schemas (both READMEs say they derive from the prompt output specs). The schema README also sharpens the framework's one real internal tension — addressable-replaceable events vs nothing-overwrites time-series — now a named design-note problem with the ceiling-provenance question added to the review-questions spec.

Remaining unrecovered: only the original conversation's philosophy prose (calibration multiplier details, accessibility tiers, dispute mechanics) — the brief routes those to maintainer questions.

Verified by a two-lens adversarial pass (README fidelity / revision seams; 8 findings fixed). CLAUDE.md staleness caution retired (refreshed in #59, merged).

Overnight scope unchanged: **design note only.**

Gates: build ✅ · 670/670 ✅ · lint 0 errors ✅ (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)