### PR TITLE
feat(audit): Phase 13.1 — model, hashing, findings schemas, ledger, beats, calibration

### DIFF
--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,49 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.1: the hash is parity-not-idempotence, and other slice-one calls
+
+**Tags:** design, pattern
+
+Slice 13.1 (`src/shared/audit/`) landed the model layer. The
+second-guessable calls:
+
+- **The canonical normalization is NOT idempotent — pinned, not
+  fixed.** Stripping the trailing space in `"\r \n"` manufactures a
+  fresh `\r\n` that a second pass would collapse. The vendored
+  scorer's algorithm has this property, so ours does too, verbatim:
+  the contract is *parity* (extension output ≡ CLI output, enforced by
+  extracting `normalizeMarkdown` from the vendored source at test
+  time), defined over exactly one pass. "Fixing" idempotence on either
+  side is a methodology change that forks every hash.
+- **Validator required-ness follows the design note's worked example,
+  not the prompts' canonical examples.** Discriminator enums, scoring
+  booleans, and every evidence quote are required; descriptive
+  enrichments (ids, notes, context) are typed but optional — a benign
+  model omission must not turn a paid run into a failed one. The one
+  strict block: module 04's seven summary counts (the ceiling
+  heuristic reads them by name). Module 08 *forbids* score/confidence
+  rather than omitting them — a scored prediction-extraction is
+  malformed.
+- **`beats-v1` ships as a JS module + JSON artifact with a sync
+  test**, not a JSON import — `with { type: 'json' }` needs Node
+  ≥20.10 and the engines floor is `>=20`; a two-file-one-test
+  arrangement has zero loader risk and keeps the published artifact.
+- **The adversarial review (three lenses, all findings
+  adversarially verified) caught three real correctness gaps** before
+  the PR: IndexedDB writes resolved on request success rather than
+  transaction commit (a silent-loss window on a ledger the module
+  itself calls precious); `IDBIndex.getAll(undefined)` is an
+  unbounded range, so an unguarded missing key would have widened
+  "audits for this article" into "the whole ledger"; and resolution
+  outcomes were stored unvalidated, where a typo'd outcome silently
+  degrades to "open" and vanishes from calibration. Plus the
+  humbling one: every "never bumps `updated`" test was tautological
+  (second-granularity timestamps) — mutation-verified, now
+  sentinel-based.
+
+---
+
 ## 2026-06-11 — Phase 13 design accepted: the resolutions, and the recovered constitution
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -970,6 +970,15 @@ kinds 30056–30061 confirmed (upstream registry checked clean
 NIP; beats become a curated versioned vocabulary (`beats-v1`).
 Implementation slices 13.1+ are in progress.
 
+- ✅ **13.1** Model + hashing + schemas + tests — canonical article
+  hash (vendored-scorer parity pinned by source-extracted vectors),
+  the eight derived findings validators (evidence-bound, module 08
+  score-forbidden), `xray-audits` IndexedDB ledger,
+  AuditRun/Prediction/Resolution models with the per-event publish
+  ledger, `beats-v1` vocabulary + alias normalizer, `calibration-v1`
+  math (logged, not activated), auditor-kind-parity tests;
+  three-lens adversarial review (7 confirmed findings fixed). — #62
+
 ---
 
 ## Abandonment criteria

--- a/src/shared/audit/article-hash.js
+++ b/src/shared/audit/article-hash.js
@@ -1,0 +1,68 @@
+// X-Ray — canonical article hash (Phase 13, slice 13.1).
+//
+// One normalization, one hash: SHA-256 (lowercase hex) over the UTF-8
+// bytes of the normalized article body markdown. The normalization is
+// the vendored scorer's `normalizeMarkdown` adopted VERBATIM
+// (docs/auditor-prototype/scorer/scorer.js) — the extension and the
+// CLI must never drift, and tests/article-hash.test.mjs pins this
+// implementation against vectors generated from the vendored source.
+//
+// The hash input is the article body markdown WITHOUT the X-Ray
+// metadata header (the leading `---…---` block carries an Archived
+// date, which would make the hash capture-time-dependent — the one
+// thing a content address must never be). Callers strip the header
+// (`reconstructArticleFromEvent`'s regex) before hashing; this module
+// hashes exactly what it is given.
+//
+// Spec: docs/EPISTEMIC_AUDIT_DESIGN.md §"Canonical article hash".
+
+import { Crypto } from '../crypto.js';
+
+/**
+ * Normalize markdown for stable hashing across captures. The vendored
+ * scorer's `normalizeMarkdown`, verbatim:
+ *   1. CRLF → LF.
+ *   2. Strip trailing spaces/tabs from every line.
+ *   3. Collapse runs of 3+ newlines to exactly 2.
+ *   4. Strip all trailing whitespace at end of input.
+ *
+ * @param {string} md - article body markdown (metadata header excluded)
+ * @returns {string} normalized markdown
+ */
+export function normalizeForHash(md) {
+    return String(md ?? '')
+        .replace(/\r\n/g, '\n')
+        .split('\n')
+        .map((line) => line.replace(/[ \t]+$/, ''))
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .replace(/\s+$/g, '');
+}
+
+/**
+ * Canonical article hash: SHA-256 hex over the UTF-8 bytes of the
+ * normalized markdown. This is the value carried in the `x` tag on
+ * every audit event (and on 30023s from slice 13.4 onward), and the
+ * cache key for audit runs.
+ *
+ * @param {string} md - article body markdown (metadata header excluded)
+ * @returns {Promise<string>} 64-char lowercase hex
+ */
+export async function articleHash(md) {
+    return Crypto.sha256(normalizeForHash(md));
+}
+
+/**
+ * Strip the X-Ray metadata header from published 30023 content,
+ * yielding the hash input for an already-published article. Exactly
+ * `reconstructArticleFromEvent`'s strip (event-builder.js) so the two
+ * paths cannot disagree about where the body starts.
+ *
+ * @param {string} content - full 30023 content (header + body)
+ * @returns {string} body markdown
+ */
+export function stripMetadataHeader(content) {
+    const text = String(content ?? '');
+    const headerMatch = text.match(/^---\n[\s\S]*?\n---\n\n?/);
+    return headerMatch ? text.substring(headerMatch[0].length) : text;
+}

--- a/src/shared/audit/audit-cache.js
+++ b/src/shared/audit/audit-cache.js
@@ -1,0 +1,175 @@
+// X-Ray — audit ledger storage (Phase 13, slice 13.1).
+//
+// IndexedDB database `xray-audits`, following archive-cache.js's
+// idempotent-open/upgrade pattern. Module findings JSON runs tens of
+// KB × 8 per run — chrome.storage.local's JSON-serialized single-key
+// maps should not carry that. Separate DB from `xray-archive` (same
+// rationale as `xray-portal`: different lifecycle, no coupled schema
+// bumps) — but unlike a reconcilable cache this one is PRECIOUS:
+// audits cost money to recompute, so it is export-included, never
+// droppable (docs/EPISTEMIC_AUDIT_DESIGN.md §"Local model and ledger").
+
+import { Utils } from '../utils.js';
+
+const DB_NAME = 'xray-audits';
+const DB_VERSION = 1;
+const RUNS_STORE = 'runs';
+const PREDICTIONS_STORE = 'predictions';
+const RESOLUTIONS_STORE = 'resolutions';
+
+function idb() {
+    if (typeof indexedDB === 'undefined') {
+        throw new Error('IndexedDB is not available in this context');
+    }
+    return indexedDB;
+}
+
+function req(request) {
+    return new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+    });
+}
+
+function tx(transaction) {
+    return new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onabort = () => reject(transaction.error);
+        transaction.onerror = () => reject(transaction.error);
+    });
+}
+
+let _dbPromise = null;
+
+export function openAuditDb() {
+    if (_dbPromise) return _dbPromise;
+    _dbPromise = new Promise((resolve, reject) => {
+        let open;
+        try { open = idb().open(DB_NAME, DB_VERSION); }
+        catch (err) { reject(err); return; }
+
+        open.onupgradeneeded = (ev) => {
+            const db = open.result;
+            const oldVersion = ev.oldVersion || 0;
+
+            // v1 — the three ledger stores (Phase 13.1).
+            if (oldVersion < 1) {
+                if (!db.objectStoreNames.contains(RUNS_STORE)) {
+                    const runs = db.createObjectStore(RUNS_STORE, { keyPath: 'id' });
+                    runs.createIndex('articleHash', 'articleHash', { unique: false });
+                    runs.createIndex('runAt', 'runAt', { unique: false });
+                }
+                if (!db.objectStoreNames.contains(PREDICTIONS_STORE)) {
+                    const preds = db.createObjectStore(PREDICTIONS_STORE, { keyPath: 'id' });
+                    preds.createIndex('articleHash', 'articleHash', { unique: false });
+                    preds.createIndex('resolutionStatus', 'resolution_status', { unique: false });
+                    preds.createIndex('horizonIso', 'horizon_iso', { unique: false });
+                }
+                if (!db.objectStoreNames.contains(RESOLUTIONS_STORE)) {
+                    const res = db.createObjectStore(RESOLUTIONS_STORE, { keyPath: 'id' });
+                    res.createIndex('predictionCoord', 'prediction_coord', { unique: false });
+                }
+            }
+        };
+        open.onsuccess = () => resolve(open.result);
+        open.onerror = () => reject(open.error);
+    });
+    return _dbPromise;
+}
+
+async function readStore(name) {
+    const db = await openAuditDb();
+    return db.transaction(name, 'readonly').objectStore(name);
+}
+
+// Writes await TRANSACTION COMMIT, not just request success — a
+// request's success event fires before the commit, which can still
+// fail (quota at flush, abort). This ledger is precious; a caller
+// told "saved" must mean durably saved (archive-cache.js's write
+// pattern).
+async function put(name, record) {
+    const db = await openAuditDb();
+    const transaction = db.transaction(name, 'readwrite');
+    transaction.objectStore(name).put(record);
+    await tx(transaction);
+    return record;
+}
+
+async function remove(name, id) {
+    const db = await openAuditDb();
+    const transaction = db.transaction(name, 'readwrite');
+    transaction.objectStore(name).delete(id);
+    await tx(transaction);
+}
+
+async function get(name, id) {
+    const s = await readStore(name);
+    const hit = await req(s.get(id));
+    return hit || null;
+}
+
+async function getAllByIndex(name, index, value) {
+    // IDBIndex.getAll(undefined|null) is an UNBOUNDED range — it would
+    // return the entire store. A missing key means "no matches", never
+    // "everything": a caller bug must not silently widen a per-article
+    // query into the whole ledger.
+    if (value === undefined || value === null) return [];
+    const s = await readStore(name);
+    return req(s.index(index).getAll(value));
+}
+
+async function getAll(name) {
+    const s = await readStore(name);
+    return req(s.getAll());
+}
+
+async function countStore(name) {
+    const s = await readStore(name);
+    return req(s.count());
+}
+
+// --- runs --------------------------------------------------------------------
+
+export function saveRun(record) { return put(RUNS_STORE, record); }
+export function getRun(id) { return get(RUNS_STORE, id); }
+export function runsByArticleHash(hash) { return getAllByIndex(RUNS_STORE, 'articleHash', hash); }
+export function listRuns() { return getAll(RUNS_STORE); }
+export function deleteRun(id) { return remove(RUNS_STORE, id); }
+export function countRuns() { return countStore(RUNS_STORE); }
+
+// --- predictions ---------------------------------------------------------------
+
+export function savePrediction(record) { return put(PREDICTIONS_STORE, record); }
+export function getPrediction(id) { return get(PREDICTIONS_STORE, id); }
+export function predictionsByArticleHash(hash) { return getAllByIndex(PREDICTIONS_STORE, 'articleHash', hash); }
+export function predictionsByStatus(status) { return getAllByIndex(PREDICTIONS_STORE, 'resolutionStatus', status); }
+export function listPredictions() { return getAll(PREDICTIONS_STORE); }
+export function deletePrediction(id) { return remove(PREDICTIONS_STORE, id); }
+
+// --- resolutions ----------------------------------------------------------------
+
+export function saveResolution(record) { return put(RESOLUTIONS_STORE, record); }
+export function getResolution(id) { return get(RESOLUTIONS_STORE, id); }
+export function resolutionsByPredictionCoord(coord) { return getAllByIndex(RESOLUTIONS_STORE, 'predictionCoord', coord); }
+export function listResolutions() { return getAll(RESOLUTIONS_STORE); }
+export function deleteResolution(id) { return remove(RESOLUTIONS_STORE, id); }
+
+// --- maintenance ----------------------------------------------------------------
+
+export async function clear() {
+    const db = await openAuditDb();
+    const transaction = db.transaction([RUNS_STORE, PREDICTIONS_STORE, RESOLUTIONS_STORE], 'readwrite');
+    transaction.objectStore(RUNS_STORE).clear();
+    transaction.objectStore(PREDICTIONS_STORE).clear();
+    transaction.objectStore(RESOLUTIONS_STORE).clear();
+    await tx(transaction);
+}
+
+/** Test hook: drop the memoized connection so a fresh fake DB attaches. */
+export function _resetForTests() {
+    if (_dbPromise) {
+        _dbPromise.then((db) => { try { db.close(); } catch (_) { /* noop */ } })
+            .catch((err) => Utils.error('audit-cache: reset close failed', err));
+    }
+    _dbPromise = null;
+}

--- a/src/shared/audit/audit-model.js
+++ b/src/shared/audit/audit-model.js
@@ -1,0 +1,355 @@
+// X-Ray — audit local models (Phase 13, slice 13.1).
+//
+// The Phase-11 model discipline, applied to the audit ledger:
+// deterministic local ids, idempotent create, a `markPublished` family
+// that never bumps `updated`, and derived fields homed where mutation
+// is safe (the local record, never the wire). Storage is the
+// `xray-audits` IndexedDB (audit-cache.js).
+//
+// Auditor identity is auditor-KIND-agnostic throughout (RQ3): every
+// record carries `auditor: {kind, id}` opaquely — model, human,
+// pipeline, and consensus identities flow the same paths, and tests
+// pin that nothing here special-cases the kind.
+//
+// Identity notes (docs/EPISTEMIC_AUDIT_DESIGN.md §"Local model and
+// ledger"):
+//   - AuditRun:    audit_<sha16(articleHash|auditorId|runAt)>
+//   - Prediction:  pred_<sha16(articleHash|norm(text))> — local and
+//     wire identity coincide deliberately (no pre/post-publish ref
+//     duality: the article hash is known at extraction). `norm` is the
+//     claim-id discipline, exactly.
+//   - Resolution:  res_<sha16(predictionCoord)> — one per (resolver,
+//     prediction); the local record is the user's own authorship.
+
+import { Crypto } from '../crypto.js';
+import {
+    saveRun, getRun, runsByArticleHash,
+    savePrediction, getPrediction, predictionsByArticleHash,
+    saveResolution, getResolution, resolutionsByPredictionCoord
+} from './audit-cache.js';
+
+function nowSeconds() {
+    return Math.floor(Date.now() / 1000);
+}
+
+export const RESOLUTION_OUTCOMES = Object.freeze(['true', 'false', 'partial', 'unresolvable']);
+export const RUN_SOURCES = Object.freeze(['cli-import', 'background', 'manual']);
+
+function assertOutcome(outcome, fn) {
+    if (!RESOLUTION_OUTCOMES.includes(outcome)) {
+        throw new Error(`${fn}: outcome must be one of ${RESOLUTION_OUTCOMES.join(', ')} (got ${outcome})`);
+    }
+}
+
+async function sha16(s) {
+    return (await Crypto.sha256(String(s))).slice(0, 16);
+}
+
+// The claim-id discipline (claim-model.js), exactly: trim, collapse
+// every whitespace run to a single space, lowercase.
+export function normalizePredictionText(text) {
+    return String(text || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export async function generateAuditRunId(articleHash, auditorId, runAt) {
+    return `audit_${await sha16(`${articleHash}|${auditorId}|${runAt}`)}`;
+}
+
+export async function generatePredictionId(articleHash, predictionText) {
+    return `pred_${await sha16(`${articleHash}|${normalizePredictionText(predictionText)}`)}`;
+}
+
+export async function generateResolutionId(predictionCoord) {
+    return `res_${await sha16(String(predictionCoord || '').trim())}`;
+}
+
+/**
+ * Compare two dotted version strings ("1.0", "1.2.1") numerically.
+ * Returns -1 | 0 | 1.
+ */
+export function compareVersions(a, b) {
+    const pa = String(a || '0').split('.').map((n) => parseInt(n, 10) || 0);
+    const pb = String(b || '0').split('.').map((n) => parseInt(n, 10) || 0);
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+        const da = pa[i] || 0;
+        const db = pb[i] || 0;
+        if (da < db) return -1;
+        if (da > db) return 1;
+    }
+    return 0;
+}
+
+// --- AuditRun -------------------------------------------------------------------
+
+export const AuditRunModel = {
+    /**
+     * Idempotent create keyed on (articleHash, auditorId, runAt).
+     * `source` is one of 'cli-import' | 'background' | 'manual'.
+     * Returns the existing record untouched when the id already
+     * exists — re-importing the same run JSON is a no-op.
+     */
+    create: async ({ articleHash, auditor, runAt, source, moduleResults = [], aggregate = null }) => {
+        if (!articleHash || typeof articleHash !== 'string') {
+            throw new Error('AuditRunModel.create: articleHash required');
+        }
+        if (!auditor || typeof auditor.kind !== 'string' || typeof auditor.id !== 'string') {
+            throw new Error('AuditRunModel.create: auditor {kind, id} required');
+        }
+        if (!runAt) throw new Error('AuditRunModel.create: runAt required');
+        const src = source || 'manual';
+        if (!RUN_SOURCES.includes(src)) {
+            throw new Error(`AuditRunModel.create: source must be one of ${RUN_SOURCES.join(', ')} (got ${source})`);
+        }
+        const id = await generateAuditRunId(articleHash, auditor.id, runAt);
+        const existing = await getRun(id);
+        if (existing) return existing;
+        const record = {
+            id,
+            articleHash,
+            auditor: { ...auditor },
+            runAt,
+            source: src,
+            moduleResults,
+            aggregate,
+            // Per-event publish ledger: eventKey → {publishedAt,
+            // publishedEventId}. Keys: 'mod:<module>' ×8, 'agg',
+            // 'pred:<predictionId>' ×N — so a partially-published run
+            // (relay hiccup mid-batch) resumes rather than duplicating.
+            events: {},
+            created: nowSeconds(),
+            updated: nowSeconds()
+        };
+        await saveRun(record);
+        return record;
+    },
+
+    get: (id) => getRun(id),
+    getByArticleHash: (hash) => runsByArticleHash(hash),
+
+    /**
+     * Record one event's publication in the per-event ledger. Never
+     * bumps `updated` — publishing is not an edit, so post-publish
+     * edits still re-emit (the Phase 11 rule, per event).
+     */
+    markEventPublished: async (id, eventKey, eventId) => {
+        const record = await getRun(id);
+        if (!record) return null;
+        record.events = record.events || {};
+        record.events[eventKey] = {
+            publishedAt: nowSeconds(),
+            publishedEventId: eventId || null
+        };
+        await saveRun(record);
+        return record;
+    }
+};
+
+/**
+ * Pure staleness check: which of a run's module results were produced
+ * under an older methodology than the current vendored prompts?
+ * Returns [{module, storedVersion, currentVersion}]. Staleness is a
+ * DISPLAY state ("re-audit under v1.1 offered"), never an
+ * auto-recompute trigger — recompute costs the user money, and old
+ * results stay valid under their recorded version (P9, §8).
+ */
+export function staleModules(run, currentVersions) {
+    const out = [];
+    for (const r of (run && run.moduleResults) || []) {
+        const current = currentVersions && currentVersions[r.module];
+        if (!current || !r.module_version) continue;
+        if (compareVersions(r.module_version, current) < 0) {
+            out.push({ module: r.module, storedVersion: r.module_version, currentVersion: current });
+        }
+    }
+    return out;
+}
+
+/**
+ * Pure orphan check: a stored run is orphaned when the current capture
+ * of its URL hashes differently (stealth-edit surface). Display state
+ * only. Audits reference the hash, which outlives the capture — an
+ * orphaned audit is still a valid record of what was scored.
+ */
+export function isOrphaned(run, currentArticleHash) {
+    if (!run || !currentArticleHash) return false;
+    return run.articleHash !== currentArticleHash;
+}
+
+// --- Prediction -------------------------------------------------------------------
+
+export const PredictionModel = {
+    /**
+     * Idempotent create keyed on (articleHash, normalized text) — the
+     * wire `d` derivation, so local and wire identity coincide.
+     * `resolution_status` and `latest_resolution_id` are LOCAL DERIVED
+     * fields (audit-types' mutable fields, homed where mutation is
+     * safe); they start open/null and recompute from resolutions.
+     */
+    create: async (fields) => {
+        const { articleHash, text } = fields || {};
+        if (!articleHash || typeof articleHash !== 'string') {
+            throw new Error('PredictionModel.create: articleHash required');
+        }
+        if (!text || typeof text !== 'string') {
+            throw new Error('PredictionModel.create: text required');
+        }
+        const id = await generatePredictionId(articleHash, text);
+        const existing = await getPrediction(id);
+        if (existing) return existing;
+        const record = {
+            id,
+            articleHash,
+            text,
+            type: fields.type || 'explicit',
+            hedge_level: fields.hedge_level || 'hedged',
+            attributed_to: fields.attributed_to || 'article_voice',
+            attributed_source_name: fields.attributed_source_name || null,
+            condition: fields.condition || null,
+            horizon: fields.horizon || '',
+            horizon_iso: fields.horizon_iso || null,
+            criteria: fields.criteria || '',
+            tractability: fields.tractability || 'ambiguous',
+            evidence_quote: fields.evidence_quote || '',
+            anchor: fields.anchor || null,
+            claim_ref: fields.claim_ref || null,   // set on promotion (RQ6)
+            auditor: fields.auditor ? { ...fields.auditor } : null,
+            extracted_at: fields.extracted_at || null,
+            resolution_status: 'open',
+            latest_resolution_id: null,
+            publishedAt: null,
+            publishedEventId: null,
+            created: nowSeconds(),
+            updated: nowSeconds()
+        };
+        await savePrediction(record);
+        return record;
+    },
+
+    get: (id) => getPrediction(id),
+    getByArticleHash: (hash) => predictionsByArticleHash(hash),
+
+    /** Publish ledger mark — never bumps `updated`. */
+    markPublished: async (id, eventId) => {
+        const record = await getPrediction(id);
+        if (!record) return null;
+        record.publishedAt = nowSeconds();
+        if (eventId) record.publishedEventId = eventId;
+        await savePrediction(record);
+        return record;
+    },
+
+    /**
+     * Recompute the derived resolution fields from a set of resolution
+     * records (own + incoming 30059s). Persists without bumping
+     * `updated` — derivation is enrichment, not an edit.
+     */
+    updateDerived: async (id, resolutions) => {
+        const record = await getPrediction(id);
+        if (!record) return null;
+        const derived = deriveResolutionState(resolutions);
+        record.resolution_status = derived.status;
+        record.latest_resolution_id = derived.latestId;
+        await savePrediction(record);
+        return record;
+    }
+};
+
+/**
+ * Pure: derive {status, latestId} from resolution records
+ * [{id, outcome, resolved_at}]. Latest `resolved_at` wins — the
+ * audit-types rule ("multiple resolutions may exist; latest wins
+ * unless a dispute is open"; the dispute exception defers with the
+ * adjudication runtime, flagged in the design note).
+ */
+export function deriveResolutionState(resolutions) {
+    const usable = (resolutions || []).filter((r) => r && r.outcome && r.id);
+    if (usable.length === 0) return { status: 'open', latestId: null };
+    let latest = usable[0];
+    for (const r of usable) {
+        if ((r.resolved_at || 0) > (latest.resolved_at || 0)) latest = r;
+    }
+    const statusByOutcome = {
+        'true': 'resolved_true',
+        'false': 'resolved_false',
+        'partial': 'resolved_partial',
+        'unresolvable': 'unresolvable'
+    };
+    return {
+        status: statusByOutcome[latest.outcome] || 'open',
+        latestId: latest.id
+    };
+}
+
+// --- Resolution -------------------------------------------------------------------
+
+export const ResolutionModel = {
+    /**
+     * Idempotent create keyed on the prediction coordinate — one
+     * resolution per (resolver, prediction); editing your own
+     * resolution replaces it (the type's own latest-wins semantics).
+     */
+    create: async (fields) => {
+        const { predictionCoord } = fields || {};
+        if (!predictionCoord || typeof predictionCoord !== 'string') {
+            throw new Error('ResolutionModel.create: predictionCoord required');
+        }
+        // The outcome is the record's entire point — never defaulted,
+        // never stored unvalidated: an invalid value would silently
+        // degrade to "open" downstream and vanish from calibration.
+        assertOutcome(fields.outcome, 'ResolutionModel.create');
+        const id = await generateResolutionId(predictionCoord);
+        const existing = await getResolution(id);
+        if (existing) return existing;
+        const record = {
+            id,
+            prediction_coord: predictionCoord.trim(),
+            outcome: fields.outcome,
+            evidence: Array.isArray(fields.evidence) ? fields.evidence : [],
+            notes: fields.notes || '',
+            confidence: typeof fields.confidence === 'number' ? fields.confidence : null,
+            auditor: fields.auditor ? { ...fields.auditor } : null,
+            resolved_at: fields.resolved_at || nowSeconds(),
+            publishedAt: null,
+            publishedEventId: null,
+            created: nowSeconds(),
+            updated: nowSeconds()
+        };
+        await saveResolution(record);
+        return record;
+    },
+
+    get: (id) => getResolution(id),
+    getByPredictionCoord: (coord) => resolutionsByPredictionCoord(coord),
+
+    /** Publish ledger mark — never bumps `updated`. */
+    markPublished: async (id, eventId) => {
+        const record = await getResolution(id);
+        if (!record) return null;
+        record.publishedAt = nowSeconds();
+        if (eventId) record.publishedEventId = eventId;
+        await saveResolution(record);
+        return record;
+    },
+
+    /**
+     * The one mutable path: the resolver revising their own resolution
+     * (outcome/evidence/notes/confidence). DOES bump `updated`, so a
+     * post-publish revision re-emits — and the same `d` replaces the
+     * prior event on relays, by design (see the RQ5 tension note).
+     */
+    update: async (id, updates) => {
+        const record = await getResolution(id);
+        if (!record) return null;
+        if (updates && 'outcome' in updates) {
+            assertOutcome(updates.outcome, 'ResolutionModel.update');
+        }
+        const allowed = ['outcome', 'evidence', 'notes', 'confidence', 'resolved_at'];
+        for (const key of allowed) {
+            if (updates && key in updates) record[key] = updates[key];
+        }
+        record.updated = nowSeconds();
+        await saveResolution(record);
+        return record;
+    }
+};

--- a/src/shared/audit/beats-v1.json
+++ b/src/shared/audit/beats-v1.json
@@ -1,0 +1,41 @@
+{
+    "version": "beats-v1",
+    "description": "X-Ray epistemic-auditor beat vocabulary. Canonical kebab-case slugs bind dossier beat subjects; aliases normalize free-form t tags; unmapped tags never mint beats (RQ8, docs/EPISTEMIC_AUDIT_DESIGN.md). Flat for v1.",
+    "beats": [
+        "monetary-policy",
+        "bitcoin",
+        "banking",
+        "fiscal-policy",
+        "free-speech",
+        "religion",
+        "media-criticism",
+        "family-law",
+        "mens-issues",
+        "immigration",
+        "drug-policy",
+        "housing-policy",
+        "civil-asset-forfeiture",
+        "occupational-licensing",
+        "education-policy",
+        "courts-legal",
+        "elections",
+        "foreign-policy",
+        "national-security",
+        "tech-policy",
+        "ai",
+        "public-health",
+        "crime-justice",
+        "labor-economics"
+    ],
+    "aliases": {
+        "fed": "monetary-policy",
+        "federal-reserve": "monetary-policy",
+        "m2": "monetary-policy",
+        "btc": "bitcoin",
+        "lds": "religion",
+        "mormon": "religion"
+    },
+    "non_aliases": {
+        "crypto": "deliberately not aliased to bitcoin — not the same beat"
+    }
+}

--- a/src/shared/audit/beats.js
+++ b/src/shared/audit/beats.js
@@ -1,0 +1,90 @@
+// X-Ray — beat vocabulary, version beats-v1 (Phase 13, slice 13.1).
+//
+// The beat taxonomy is METHODOLOGY: versioned like the module prompts
+// (PHILOSOPHY.md P12), because fragmented beats silently shrink dossier
+// sample sizes and distort the §4 shrinkage math on reputation-bearing
+// rollups. Rules (RQ8, docs/EPISTEMIC_AUDIT_DESIGN.md §Beats):
+//
+//   - Dossier beat subjects MUST be canonical slugs from this list.
+//   - Free-form `t` tags ride events but never mint beats: the dossier
+//     builder normalizes via the alias map and surfaces unmapped tags
+//     in a review list instead of creating subjects from them.
+//   - Flat, single-level for v1 — hierarchy is a v2 problem.
+//
+// The same vocabulary is published verbatim as the JSON artifact
+// `beats-v1.json` beside this file (the third-party-consumable form);
+// tests/audit-beats.test.mjs asserts the two never drift. This module
+// is the single source of truth for code.
+
+export const BEATS_VERSION = 'beats-v1';
+
+// Canonical kebab-case slugs (maintainer-curated starter list, RQ8).
+export const BEATS = Object.freeze([
+    'monetary-policy',
+    'bitcoin',
+    'banking',
+    'fiscal-policy',
+    'free-speech',
+    'religion',
+    'media-criticism',
+    'family-law',
+    'mens-issues',
+    'immigration',
+    'drug-policy',
+    'housing-policy',
+    'civil-asset-forfeiture',
+    'occupational-licensing',
+    'education-policy',
+    'courts-legal',
+    'elections',
+    'foreign-policy',
+    'national-security',
+    'tech-policy',
+    'ai',
+    'public-health',
+    'crime-justice',
+    'labor-economics'
+]);
+
+// Alias → canonical slug. Deliberate non-alias: `crypto` does NOT map
+// to `bitcoin` — they are not the same beat (RQ8, verbatim).
+export const BEAT_ALIASES = Object.freeze({
+    'fed': 'monetary-policy',
+    'federal-reserve': 'monetary-policy',
+    'm2': 'monetary-policy',
+    'btc': 'bitcoin',
+    'lds': 'religion',
+    'mormon': 'religion'
+});
+
+const BEAT_SET = new Set(BEATS);
+
+/**
+ * True when `slug` is a canonical beats-v1 slug (exact match — callers
+ * normalize first).
+ */
+export function isCanonicalBeat(slug) {
+    return BEAT_SET.has(slug);
+}
+
+/**
+ * Normalize a free-form `t` tag toward the canonical vocabulary.
+ * Lowercases, trims, and collapses inner whitespace/underscores to
+ * hyphens before lookup. Returns the canonical slug, or null when the
+ * tag maps to nothing — null means "review list", never "new beat".
+ *
+ * @param {string} tag - free-form topic tag
+ * @returns {string|null} canonical slug or null
+ */
+export function normalizeBeat(tag) {
+    const cleaned = String(tag ?? '')
+        .trim()
+        .toLowerCase()
+        .replace(/[\s_]+/g, '-');
+    if (!cleaned) return null;
+    if (BEAT_SET.has(cleaned)) return cleaned;
+    if (Object.prototype.hasOwnProperty.call(BEAT_ALIASES, cleaned)) {
+        return BEAT_ALIASES[cleaned];
+    }
+    return null;
+}

--- a/src/shared/audit/calibration.js
+++ b/src/shared/audit/calibration.js
@@ -1,0 +1,143 @@
+// X-Ray — prediction-ledger calibration (Phase 13, slice 13.1).
+//
+// Two layers, per RQ4 (docs/EPISTEMIC_AUDIT_DESIGN.md §Calibration):
+//
+//   1. The per-hedge RATE TABLE — canonical for v1. Per hedge level:
+//      how many resolved, how many true, the rate. This is what the
+//      dossier block displays and the 30060 content carries.
+//
+//   2. `calibration-v1` — SPECIFIED NOW, LOGGED, NOT ACTIVATED. A
+//      proper scoring rule (Brier) over resolved predictions. The
+//      probability mapping is a published assumption (P12); the
+//      multiplier is never applied to any score in v1 — activation is
+//      a future, explicit decision once the ledger has volume, and
+//      display is gated behind MIN_RESOLVED_FOR_DISPLAY. There was no
+//      lost formula to recover: the original prose fixed only P7's
+//      ordering constraints (confident-wrong > hedged-wrong in cost;
+//      confident-right > hedged-right in credit), which Brier
+//      satisfies automatically.
+
+export const CALIBRATION_VERSION = 'calibration-v1';
+
+// Hedge level → implied probability assigned to the prediction as
+// stated. A published assumption (P12) — empirically recalibrating it
+// against the corpus later is itself a publishable finding.
+export const HEDGE_IMPLIED_PROBABILITY = Object.freeze({
+    confident: 0.90,
+    hedged: 0.70,
+    speculative: 0.55
+});
+
+// Below this many resolved predictions, a multiplier is noise dressed
+// as judgment (RQ4) — display nothing.
+export const MIN_RESOLVED_FOR_DISPLAY = 10;
+
+// 30059 outcome → Brier outcome value for the prediction as stated.
+// `unresolvable` is excluded from calibration entirely (null).
+//
+// Negative predictions need no special case: the answer's inversion
+// (confident "X won't happen" → p(X) = 0.10, scored against whether X
+// happened) is algebraically identical to scoring the prediction as
+// stated with its hedge probability — (0.10 − 1)² = (0.90 − 0)² — so
+// scoring p(prediction) against outcome(prediction) covers both signs.
+const OUTCOME_VALUES = Object.freeze({
+    'true': 1,
+    'false': 0,
+    'partial': 0.5
+});
+
+/**
+ * Brier score for one resolved prediction: (p − outcome)², lower is
+ * better. Returns null for unresolvable outcomes or unknown hedge
+ * levels (excluded from calibration, never defaulted).
+ *
+ * P7's ordering, verified in tests: confident-wrong 0.81 >
+ * hedged-wrong 0.49; confident-right 0.01 < hedged-right 0.09.
+ *
+ * @param {string} hedgeLevel - confident|hedged|speculative
+ * @param {string} outcome - true|false|partial|unresolvable
+ * @returns {number|null}
+ */
+export function brierScore(hedgeLevel, outcome) {
+    const p = HEDGE_IMPLIED_PROBABILITY[hedgeLevel];
+    if (p === undefined) return null;
+    if (!Object.prototype.hasOwnProperty.call(OUTCOME_VALUES, outcome)) return null;
+    const o = OUTCOME_VALUES[outcome];
+    return (p - o) * (p - o);
+}
+
+/**
+ * The canonical v1 rate table: per hedge level, {resolved, true_count,
+ * rate}. `partial` counts as resolved but not true; `unresolvable` is
+ * excluded. Input: [{hedge_level, outcome}].
+ *
+ * @param {Array<{hedge_level: string, outcome: string}>} resolutions
+ * @returns {object} { confident: {resolved, true_count, rate}, hedged: …, speculative: … }
+ */
+export function calibrationRateTable(resolutions) {
+    const table = {};
+    for (const level of Object.keys(HEDGE_IMPLIED_PROBABILITY)) {
+        table[level] = { resolved: 0, true_count: 0, rate: null };
+    }
+    for (const r of resolutions || []) {
+        const row = table[r.hedge_level];
+        if (!row) continue;
+        if (!Object.prototype.hasOwnProperty.call(OUTCOME_VALUES, r.outcome)) continue;
+        row.resolved += 1;
+        if (r.outcome === 'true') row.true_count += 1;
+    }
+    for (const level of Object.keys(table)) {
+        const row = table[level];
+        row.rate = row.resolved > 0 ? row.true_count / row.resolved : null;
+    }
+    return table;
+}
+
+/**
+ * The informational calibration-v1 block (RQ4): mean Brier over the
+ * scoreable resolutions, the count, and `multiplier: null` — ALWAYS
+ * null in v1; the field exists so the wire shape is stable when
+ * activation happens, and stays null until that explicit decision.
+ *
+ * @param {Array<{hedge_level: string, outcome: string}>} resolutions
+ * @returns {{version: string, mean_brier: number|null, resolved_count: number, multiplier: null}}
+ */
+export function calibrationV1(resolutions) {
+    let sum = 0;
+    let n = 0;
+    for (const r of resolutions || []) {
+        const b = brierScore(r.hedge_level, r.outcome);
+        if (b === null) continue;
+        sum += b;
+        n += 1;
+    }
+    return {
+        version: CALIBRATION_VERSION,
+        mean_brier: n > 0 ? Number((sum / n).toFixed(4)) : null,
+        resolved_count: n,
+        multiplier: null
+    };
+}
+
+/**
+ * The eventual multiplier — NOT ACTIVATED IN v1, exported only so its
+ * shape is pinned by tests and ready for the future activation
+ * decision: clamp(1 + β·(B_population − B_subject), 0.85, 1.15),
+ * β ≈ 0.5, applied to dossier rollups only — NEVER retroactively to
+ * article vintage scores (P9) — and displayed only at
+ * ≥ MIN_RESOLVED_FOR_DISPLAY resolved predictions. Nothing in v1
+ * calls this with intent to apply it.
+ *
+ * @param {number} subjectMeanBrier
+ * @param {number} populationMeanBrier
+ * @param {number} resolvedCount
+ * @param {number} [beta=0.5]
+ * @returns {number|null} the would-be multiplier, or null below the
+ *   display gate
+ */
+export function inactiveMultiplierV1(subjectMeanBrier, populationMeanBrier, resolvedCount, beta = 0.5) {
+    if (!(resolvedCount >= MIN_RESOLVED_FOR_DISPLAY)) return null;
+    if (typeof subjectMeanBrier !== 'number' || typeof populationMeanBrier !== 'number') return null;
+    const raw = 1 + beta * (populationMeanBrier - subjectMeanBrier);
+    return Math.min(1.15, Math.max(0.85, raw));
+}

--- a/src/shared/audit/findings-schemas.js
+++ b/src/shared/audit/findings-schemas.js
@@ -1,0 +1,426 @@
+// X-Ray — derived per-module findings schemas + validator (Phase 13,
+// slice 13.1).
+//
+// The framework's schema/modules/*.json files were never recovered;
+// both vendored READMEs state they are DERIVED from the prompt output
+// specifications in docs/auditor-prototype/prompts/01–08, so this
+// module derives them (docs/EPISTEMIC_AUDIT_DESIGN.md §"Derived
+// findings schemas"). The vendored scorer only extracts JSON — its own
+// Limitations section admits validation was aspirational; this closes
+// that gap.
+//
+// Required-ness policy (the design note's worked module-03 example,
+// applied uniformly): fields that drive scoring, identity, or
+// downstream consumers — enum discriminators, scoring booleans, the
+// claim/term/party text, every evidence quote — are required;
+// descriptive enrichments (ids, notes, context) are typed but
+// optional, so a benign omission doesn't turn a paid model run into a
+// failed one. Exception, per the design note: module 04's summary
+// block feeds the knowability-ceiling heuristic — all seven counts
+// are required, their names load-bearing.
+//
+// Evidence-bound (P3): every mandated evidence quote is
+// `minLength: 1` — a finding with an empty quote is invalid, not
+// merely weak. Module 08 carries NO score/confidence (predictions are
+// not scored at extraction); a scored prediction_extraction payload
+// is malformed and rejected.
+//
+// The walker is hand-rolled — the repo takes no schema-library
+// dependency; these shapes need only type/enum/const/required/range/
+// minLength checks. Unknown extra fields are tolerated (models add
+// color; tolerance here never weakens the required core).
+
+const SEVERITY = ['low', 'medium', 'high'];
+
+// --- tiny schema vocabulary -------------------------------------------------
+// type: 'string'|'number'|'integer'|'boolean'|'object'|'array', or an
+// array of those plus 'null'; const; enum; minimum/maximum (numbers);
+// minLength (strings — applied only when the value IS a string, so
+// ['string','null'] fields stay nullable); pattern; items; properties;
+// required.
+
+function str(extra = {}) { return { type: 'string', ...extra }; }
+function quote() { return { type: 'string', minLength: 1 }; }
+function nullableStr(extra = {}) { return { type: ['string', 'null'], ...extra }; }
+function nullableQuote() { return { type: ['string', 'null'], minLength: 1 }; }
+function int(extra = {}) { return { type: 'integer', ...extra }; }
+function bool() { return { type: 'boolean' }; }
+function en(values) { return { type: 'string', enum: values }; }
+function arr(items) { return { type: 'array', items }; }
+function obj(properties, required = []) { return { type: 'object', properties, required }; }
+function strArr() { return arr(str()); }
+
+// --- per-module payload schemas (beyond the shared envelope) ----------------
+
+const PAYLOADS = {
+    headline_body_fidelity: obj({
+        headline: quote(),
+        subhead: nullableStr(),
+        headline_implications: arr(obj({
+            id: int({ minimum: 0 }),
+            implication: quote(),
+            type: en(['factual', 'causal', 'evaluative', 'predictive']),
+            implied_strength: en(['definite', 'likely', 'hedged'])
+        }, ['implication', 'type', 'implied_strength'])),
+        body_findings: arr(obj({
+            implication_id: int({ minimum: 0 }),
+            support_status: en(['supported', 'partially_supported', 'unsupported', 'contradicted']),
+            evidence_quote: nullableQuote(),   // null permitted when support is absent
+            notes: str()
+        }, ['implication_id', 'support_status'])),
+        structural_issues: arr(obj({
+            type: en(['buried_qualification', 'inverted_emphasis', 'clickbait_framing',
+                      'actor_switching', 'modality_drift', 'other']),
+            description: quote(),
+            evidence_quote: quote(),
+            severity: en(SEVERITY)
+        }, ['type', 'description', 'evidence_quote', 'severity']))
+    }, ['headline', 'subhead', 'headline_implications', 'body_findings', 'structural_issues']),
+
+    asymmetric_language: obj({
+        has_contrast_structure: bool(),
+        parties_identified: arr(obj({
+            name: str(),
+            role: str()
+        }, ['name', 'role'])),
+        language_applied: arr(obj({
+            party: str(),
+            verbs: strArr(),
+            adjectives: strArr(),
+            epithets_or_labels: strArr(),
+            sourcing_verbs: strArr()
+        }, ['party'])),
+        asymmetry_findings: arr(obj({
+            dimension: en(['action_verbs', 'motivation_attribution', 'epithets',
+                           'sourcing_verbs', 'voice_agency', 'quantitative_framing']),
+            party_a: str(),
+            party_a_term: str(),
+            party_b: str(),
+            party_b_term: str(),
+            evidence_quote_a: quote(),
+            evidence_quote_b: quote(),
+            justified_by_underlying_facts: bool(),
+            justification_notes: nullableStr(),
+            severity: en(SEVERITY)
+        }, ['dimension', 'party_a', 'party_a_term', 'party_b', 'party_b_term',
+            'evidence_quote_a', 'evidence_quote_b', 'justified_by_underlying_facts',
+            'severity']))
+    }, ['has_contrast_structure', 'parties_identified', 'language_applied', 'asymmetry_findings']),
+
+    // Pinned to the design note's worked example, exactly.
+    number_hygiene: obj({
+        numerical_claims: arr(obj({
+            id: int(),
+            claim: str(),
+            value: str(),
+            context: str(),
+            denominator_test: en(['passed', 'failed', 'not_applicable']),
+            base_rate_test: en(['passed', 'failed', 'not_applicable']),
+            comparison_class_test: en(['passed', 'failed', 'not_applicable']),
+            additional_issues: strArr(),
+            evidence_quote: quote(),
+            notes: str()
+        }, ['claim', 'value', 'denominator_test', 'base_rate_test',
+            'comparison_class_test', 'evidence_quote'])),
+        summary: obj({
+            total_claims: int({ minimum: 0 }),
+            claims_failing_at_least_one_test: int({ minimum: 0 }),
+            most_common_failure: en(['denominator', 'base_rate', 'comparison_class', 'none'])
+        }, ['total_claims', 'claims_failing_at_least_one_test'])
+    }, ['numerical_claims', 'summary']),
+
+    source_quality: obj({
+        sources: arr(obj({
+            id: int(),
+            label: str(),
+            type: en(['named_primary', 'named_secondary', 'anonymous_justified',
+                      'anonymous_bare', 'document_cited', 'study_cited', 'expert_says_vague']),
+            anonymity_justification: nullableStr(),
+            relationship_to_matter: str(),
+            evidence_quote: quote()
+        }, ['id', 'label', 'type', 'evidence_quote'])),
+        claim_to_source_map: arr(obj({
+            claim: str(),
+            source_ids: arr(int()),
+            is_contested: bool(),
+            contested_reason: nullableStr(),
+            evidence_quote: quote()
+        }, ['claim', 'source_ids', 'is_contested', 'evidence_quote'])),
+        single_sourced_contested_claims: arr(obj({
+            claim: str(),
+            source_id: int(),
+            source_type: en(['named_primary', 'named_secondary', 'anonymous_justified',
+                             'anonymous_bare', 'document_cited', 'study_cited', 'expert_says_vague']),
+            evidence_quote: quote()
+        }, ['claim', 'source_id', 'source_type', 'evidence_quote'])),
+        primary_documents: arr(obj({
+            document: str(),
+            linked_or_quoted: bool(),
+            specific_enough_to_retrieve: bool(),
+            evidence_quote: quote()
+        }, ['document', 'linked_or_quoted', 'specific_enough_to_retrieve', 'evidence_quote'])),
+        // Load-bearing for the knowability-ceiling heuristic: all seven
+        // counts required, names pinned (scorer.js aggregate()).
+        summary: obj({
+            total_sources: int({ minimum: 0 }),
+            named_count: int({ minimum: 0 }),
+            anonymous_count: int({ minimum: 0 }),
+            anonymous_justified_count: int({ minimum: 0 }),
+            expert_says_vague_count: int({ minimum: 0 }),
+            documents_cited: int({ minimum: 0 }),
+            documents_specifically_identified: int({ minimum: 0 })
+        }, ['total_sources', 'named_count', 'anonymous_count', 'anonymous_justified_count',
+            'expert_says_vague_count', 'documents_cited', 'documents_specifically_identified'])
+    }, ['sources', 'claim_to_source_map', 'single_sourced_contested_claims',
+        'primary_documents', 'summary']),
+
+    internal_coherence: obj({
+        contradictions: arr(obj({
+            type: en(['factual', 'numerical', 'causal', 'tonal', 'modality',
+                      'quote_paraphrase', 'caption_text', 'lead_body']),
+            claim_a: str(),
+            claim_b: str(),
+            evidence_quote_a: quote(),
+            evidence_quote_b: quote(),
+            is_dialectic_intent: bool(),
+            severity: en(SEVERITY),
+            notes: str()
+        }, ['type', 'claim_a', 'claim_b', 'evidence_quote_a', 'evidence_quote_b',
+            'is_dialectic_intent', 'severity'])),
+        logical_gaps: arr(obj({
+            description: str(),
+            evidence_quote: quote(),
+            severity: en(SEVERITY)
+        }, ['description', 'evidence_quote', 'severity']))
+    }, ['contradictions', 'logical_gaps']),
+
+    definitional_precision: obj({
+        contested_terms: arr(obj({
+            term: str(),
+            occurrences: int(),
+            first_use_quote: quote(),
+            defined_in_text: bool(),
+            definition_quote: nullableStr(),
+            definition_quality: en(['explicit', 'contextual', 'absent']),
+            smuggled_assumption: nullableStr(),
+            load_bearing: bool(),
+            used_consistently: bool(),
+            severity_if_undefined: en(SEVERITY)
+        }, ['term', 'first_use_quote', 'defined_in_text', 'definition_quality',
+            'load_bearing', 'used_consistently', 'severity_if_undefined'])),
+        weasel_quantifiers: arr(obj({
+            term: str(),
+            evidence_quote: quote(),
+            backed_by_evidence: bool(),
+            severity: en(SEVERITY)
+        }, ['term', 'evidence_quote', 'backed_by_evidence', 'severity'])),
+        category_laundering: arr(obj({
+            category: str(),
+            evidence_quote: quote(),
+            treatment: str(),
+            severity: en(SEVERITY)
+        }, ['category', 'evidence_quote', 'severity']))
+    }, ['contested_terms', 'weasel_quantifiers', 'category_laundering']),
+
+    omission: obj({
+        topic_summary: str(),
+        voices_directly_quoted: arr(obj({
+            name_or_role: str(),
+            perspective_summary: str(),
+            quote_density: en(['high', 'medium', 'low']),
+            evidence_quote: quote()
+        }, ['name_or_role', 'perspective_summary', 'quote_density', 'evidence_quote'])),
+        voices_paraphrased_only: arr(obj({
+            name_or_role: str(),
+            perspective_summary: str(),
+            evidence_quote: quote()
+        }, ['name_or_role', 'perspective_summary', 'evidence_quote'])),
+        voices_referenced_but_silent: arr(obj({
+            name_or_role: str(),
+            absence_addressed: bool(),
+            absence_explanation: nullableStr()
+        }, ['name_or_role', 'absence_addressed'])),
+        natural_stakeholder_set: strArr(),
+        voices_expected_but_absent: arr(obj({
+            role: str(),
+            why_expected: str(),
+            absence_addressed: bool(),
+            severity: en(SEVERITY)
+        }, ['role', 'why_expected', 'absence_addressed', 'severity'])),
+        speaks_for_instances: arr(obj({
+            speaking_party: str(),
+            spoken_for_party: str(),
+            evidence_quote: quote(),
+            severity: en(SEVERITY)
+        }, ['speaking_party', 'spoken_for_party', 'evidence_quote', 'severity'])),
+        quotation_balance_notes: str()
+    }, ['topic_summary', 'voices_directly_quoted', 'voices_paraphrased_only',
+        'voices_referenced_but_silent', 'natural_stakeholder_set',
+        'voices_expected_but_absent', 'speaks_for_instances']),
+
+    prediction_extraction: obj({
+        predictions: arr(obj({
+            id: int({ minimum: 0 }),
+            prediction: quote(),
+            type: en(['explicit', 'implicit', 'conditional', 'negative', 'counterfactual']),
+            hedge_level: en(['confident', 'hedged', 'speculative']),
+            attributed_to: en(['article_voice', 'named_source', 'vague_attribution']),
+            attributed_source_name: nullableStr(),
+            condition: nullableStr(),
+            resolution_horizon: str(),
+            resolution_criteria: str(),
+            tractability: en(['publicly_resolvable', 'requires_private_info', 'ambiguous']),
+            evidence_quote: quote()
+        }, ['prediction', 'type', 'hedge_level', 'attributed_to',
+            'resolution_horizon', 'resolution_criteria', 'tractability',
+            'evidence_quote'])),
+        summary: obj({
+            total_predictions: int({ minimum: 0 }),
+            explicit_count: int({ minimum: 0 }),
+            implicit_count: int({ minimum: 0 }),
+            confident_count: int({ minimum: 0 }),
+            hedged_count: int({ minimum: 0 }),
+            speculative_count: int({ minimum: 0 }),
+            publicly_resolvable_count: int({ minimum: 0 })
+        }, ['total_predictions'])
+    }, ['predictions', 'summary'])
+};
+
+export const MODULE_NAMES = Object.freeze(Object.keys(PAYLOADS));
+
+// prediction_extraction does not score (the ledger does, later).
+export const SCOREABLE_MODULES = Object.freeze(
+    MODULE_NAMES.filter((m) => m !== 'prediction_extraction')
+);
+
+const SEMVER_PATTERN = /^\d+\.\d+(\.\d+)?$/;
+
+// --- walker ------------------------------------------------------------------
+
+function typeOf(value) {
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    return typeof value;
+}
+
+function typeMatches(value, type) {
+    const t = typeOf(value);
+    if (type === 'integer') return t === 'number' && Number.isInteger(value);
+    if (type === 'number') return t === 'number' && Number.isFinite(value);
+    return t === type;
+}
+
+function walk(value, schema, path, errors) {
+    const types = Array.isArray(schema.type) ? schema.type : (schema.type ? [schema.type] : null);
+    if (types && !types.some((t) => typeMatches(value, t))) {
+        errors.push({ path, message: `expected ${types.join('|')}, got ${typeOf(value)}` });
+        return;
+    }
+    if (value === null) return;   // nullable and null — nothing further to check
+
+    if ('const' in schema && value !== schema.const) {
+        errors.push({ path, message: `expected "${schema.const}", got "${value}"` });
+    }
+    if (schema.enum && !schema.enum.includes(value)) {
+        errors.push({ path, message: `"${value}" not in [${schema.enum.join(', ')}]` });
+    }
+    if (typeof value === 'string') {
+        if (schema.minLength !== undefined && value.length < schema.minLength) {
+            errors.push({ path, message: `shorter than minLength ${schema.minLength}` });
+        }
+        if (schema.pattern && !schema.pattern.test(value)) {
+            errors.push({ path, message: `does not match ${schema.pattern}` });
+        }
+    }
+    if (typeof value === 'number') {
+        if (schema.minimum !== undefined && value < schema.minimum) {
+            errors.push({ path, message: `below minimum ${schema.minimum}` });
+        }
+        if (schema.maximum !== undefined && value > schema.maximum) {
+            errors.push({ path, message: `above maximum ${schema.maximum}` });
+        }
+    }
+    if (Array.isArray(value) && schema.items) {
+        value.forEach((item, i) => walk(item, schema.items, `${path}[${i}]`, errors));
+    }
+    if (typeOf(value) === 'object' && schema.properties) {
+        for (const key of schema.required || []) {
+            if (!(key in value)) {
+                errors.push({ path: `${path}.${key}`, message: 'required field missing' });
+            }
+        }
+        for (const [key, sub] of Object.entries(schema.properties)) {
+            if (key in value) walk(value[key], sub, `${path}.${key}`, errors);
+        }
+        // Unknown extra fields are tolerated by design.
+    }
+}
+
+// --- public API ---------------------------------------------------------------
+
+/**
+ * Validate one module's findings payload (the parsed content JSON of a
+ * 30056, or one module object out of a scorer export) against its
+ * derived schema — envelope first, payload second.
+ *
+ * Auditor identity never appears in findings JSON (it rides event
+ * tags), so validation is auditor-kind-agnostic by construction: a
+ * human-authored payload validates identically to a model's (RQ3).
+ *
+ * @param {string} moduleName - one of MODULE_NAMES
+ * @param {object} payload - the findings object
+ * @returns {{valid: boolean, errors: Array<{path: string, message: string}>}}
+ */
+export function validateFindings(moduleName, payload) {
+    const errors = [];
+    const schema = PAYLOADS[moduleName];
+    if (!schema) {
+        return { valid: false, errors: [{ path: '$', message: `unknown module "${moduleName}"` }] };
+    }
+    if (typeOf(payload) !== 'object') {
+        return { valid: false, errors: [{ path: '$', message: `expected object, got ${typeOf(payload)}` }] };
+    }
+
+    // Envelope: module / version / auditor_caveats on everything.
+    walk(payload.module, { type: 'string', const: moduleName }, '$.module', errors);
+    if (!('module' in payload)) errors.push({ path: '$.module', message: 'required field missing' });
+    if (!('version' in payload)) {
+        errors.push({ path: '$.version', message: 'required field missing' });
+    } else {
+        walk(payload.version, { type: 'string', pattern: SEMVER_PATTERN }, '$.version', errors);
+    }
+    if (!('auditor_caveats' in payload)) {
+        errors.push({ path: '$.auditor_caveats', message: 'required field missing' });
+    } else {
+        walk(payload.auditor_caveats, arr(str()), '$.auditor_caveats', errors);
+    }
+
+    // Envelope: score/confidence — required 01–07, FORBIDDEN on 08.
+    if (moduleName === 'prediction_extraction') {
+        if ('score' in payload) {
+            errors.push({ path: '$.score', message: 'prediction_extraction is not scored — score is forbidden' });
+        }
+        if ('confidence' in payload) {
+            errors.push({ path: '$.confidence', message: 'prediction_extraction is not scored — confidence is forbidden' });
+        }
+    } else {
+        if (!('score' in payload)) {
+            errors.push({ path: '$.score', message: 'required field missing' });
+        } else {
+            walk(payload.score, { type: 'number', minimum: 0, maximum: 100 }, '$.score', errors);
+        }
+        if (!('confidence' in payload)) {
+            errors.push({ path: '$.confidence', message: 'required field missing' });
+        } else {
+            walk(payload.confidence, { type: 'number', minimum: 0, maximum: 1 }, '$.confidence', errors);
+        }
+        if ('confidence_notes' in payload) {
+            walk(payload.confidence_notes, str(), '$.confidence_notes', errors);
+        }
+    }
+
+    // Payload.
+    walk(payload, { type: 'object', properties: schema.properties, required: schema.required }, '$', errors);
+
+    return { valid: errors.length === 0, errors };
+}

--- a/tests/audit-article-hash.test.mjs
+++ b/tests/audit-article-hash.test.mjs
@@ -1,0 +1,115 @@
+// Phase 13.1 — canonical article hash.
+//
+// The load-bearing test: normalizeForHash must be byte-identical to
+// the VENDORED scorer's normalizeMarkdown (docs/auditor-prototype/
+// scorer/scorer.js). We extract that function from the vendored
+// source at test time and run both over a hostile corpus — the
+// extension and the CLI can never drift without this failing.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+
+import { normalizeForHash, articleHash, stripMetadataHeader } from '../src/shared/audit/article-hash.js';
+
+const scorerSource = await readFile(
+    new URL('../docs/auditor-prototype/scorer/scorer.js', import.meta.url), 'utf8');
+
+const match = scorerSource.match(/function normalizeMarkdown\(md\) \{\n([\s\S]*?)\n\}/);
+assert.ok(match, 'vendored scorer must contain normalizeMarkdown — if this fails, the vendored source moved');
+// eslint-disable-next-line no-new-func
+const vendoredNormalize = new Function('md', match[1]);
+
+const CORPUS = [
+    '',
+    'plain text',
+    'line one\nline two',
+    'crlf line\r\nanother\r\n',
+    'trailing spaces   \nand tabs\t\t\nmixed \t \n',
+    'one\n\n\n\n\nfive blank-collapsed\n\n\ndone',
+    '\n\nleading blanks preserved\ntext',
+    'trailing whitespace at end\n\n\n   \t\n',
+    '# Heading\n\nParagraph with **bold** and [link](https://x.example).\n\n- item\n- item\n',
+    'unicode — em-dash, naïve café, 日本語テキスト, 🎯 emoji\n',
+    'inner   spaces   preserved\nbut not at eol   \n',
+    'lone\rcarriage return survives',          // \r without \n is NOT normalized — pinned
+    '```\ncode  block  \n\n\n\ninside fences collapses too\n```\n',
+    'a'.repeat(10000) + '  \n' + 'b'.repeat(10000) + '\n\n\n\n' + 'c',
+    // Whitespace-class discriminators: these inputs distinguish the
+    // spec's [ \t]+$ per-line strip from a too-eager \s+$ — NBSP,
+    // U+2028/U+2029, and ideographic space at EOL must SURVIVE the
+    // per-line strip (Turndown output from captured HTML really
+    // contains NBSP).
+    'nbsp at eol\u00a0\nnext line',
+    'line sep at eol\u2028\nnext',
+    'para sep at eol\u2029\nnext',
+    'ideographic space\u3000\nnext',
+    'cr then space\r \nnext',
+    // End-of-input discriminators for the final \s+$ strip (which IS
+    // \s-classed and eats all of these at end of input).
+    'ends with bare cr\r',
+    'ends with space ',
+    'ends with nbsp\u00a0'
+];
+
+test('normalizeForHash matches the vendored scorer normalizeMarkdown over the corpus', () => {
+    for (const input of CORPUS) {
+        assert.equal(normalizeForHash(input), vendoredNormalize(input),
+            `divergence on input: ${JSON.stringify(input.slice(0, 60))}`);
+    }
+});
+
+test('normalizeForHash: ONE pass is the spec — and it is not idempotent, pinned', () => {
+    // The canonical hash is defined over exactly one normalization
+    // pass (both the extension and the vendored CLI do one). The
+    // algorithm itself is NOT idempotent: stripping the trailing
+    // space in "\r \n" manufactures a new "\r\n" pair that a second
+    // pass would collapse. Pin the counterexample so nobody "fixes"
+    // either side unilaterally — changing the normalization is a
+    // methodology change (new hashes), not a refactor.
+    const pathological = 'cr then space\r \nnext';
+    const once = normalizeForHash(pathological);
+    assert.equal(once, 'cr then space\r\nnext');
+    assert.notEqual(normalizeForHash(once), once, 'second pass collapses the manufactured CRLF');
+    assert.equal(once, vendoredNormalize(pathological), 'parity, not idempotence, is the contract');
+
+    // Everything without that interaction IS stable under a second pass.
+    for (const input of CORPUS) {
+        if (input.includes('\r ')) continue;
+        const normalized = normalizeForHash(input);
+        assert.equal(normalizeForHash(normalized), normalized,
+            `unexpected non-idempotence on: ${JSON.stringify(input.slice(0, 40))}`);
+    }
+});
+
+test('articleHash equals node:crypto SHA-256 of the normalized UTF-8 bytes', async () => {
+    for (const input of CORPUS) {
+        const expected = createHash('sha256')
+            .update(normalizeForHash(input), 'utf8').digest('hex');
+        assert.equal(await articleHash(input), expected);
+    }
+});
+
+test('articleHash is stable across capture-formatting noise', async () => {
+    const a = await articleHash('Body text.\nSecond line.\n');
+    const b = await articleHash('Body text.   \r\nSecond line.\n\n\n');
+    assert.equal(a, b, 'CRLF/trailing-ws/blank-run noise must not change the hash');
+});
+
+test('articleHash differs on real content change', async () => {
+    const a = await articleHash('The minister said yes.');
+    const b = await articleHash('The minister said no.');
+    assert.notEqual(a, b);
+});
+
+test('stripMetadataHeader removes exactly the published header block', () => {
+    const content = '---\n**Source**: [T](https://e.x)\n**Archived**: June 11, 2026\n---\n\nBody starts here.\n';
+    assert.equal(stripMetadataHeader(content), 'Body starts here.\n');
+    // No header → unchanged (local captures hash the body directly).
+    assert.equal(stripMetadataHeader('No header at all.'), 'No header at all.');
+    // Header strip + hash: the Archived date must not affect the hash.
+    const v1 = stripMetadataHeader('---\n**Archived**: June 11, 2026\n---\n\nSame body.');
+    const v2 = stripMetadataHeader('---\n**Archived**: June 12, 2026\n---\n\nSame body.');
+    assert.equal(v1, v2);
+});

--- a/tests/audit-beats.test.mjs
+++ b/tests/audit-beats.test.mjs
@@ -1,0 +1,61 @@
+// Phase 13.1 — beats-v1 vocabulary (RQ8).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { BEATS, BEAT_ALIASES, BEATS_VERSION, isCanonicalBeat, normalizeBeat } from '../src/shared/audit/beats.js';
+
+test('beats-v1: 24 canonical kebab-case slugs, maintainer-curated', () => {
+    assert.equal(BEATS.length, 24);
+    for (const slug of BEATS) {
+        assert.match(slug, /^[a-z0-9]+(-[a-z0-9]+)*$/, `non-kebab slug: ${slug}`);
+    }
+    assert.ok(BEATS.includes('monetary-policy'));
+    assert.ok(BEATS.includes('civil-asset-forfeiture'));
+    assert.ok(BEATS.includes('ai'));
+});
+
+test('beats-v1: every alias maps to a canonical slug', () => {
+    for (const [alias, target] of Object.entries(BEAT_ALIASES)) {
+        assert.ok(isCanonicalBeat(target), `alias ${alias} → non-canonical ${target}`);
+        assert.ok(!isCanonicalBeat(alias), `alias ${alias} must not itself be canonical`);
+    }
+});
+
+test('normalizeBeat: canonical slugs pass through; aliases map', () => {
+    assert.equal(normalizeBeat('bitcoin'), 'bitcoin');
+    assert.equal(normalizeBeat('fed'), 'monetary-policy');
+    assert.equal(normalizeBeat('federal-reserve'), 'monetary-policy');
+    assert.equal(normalizeBeat('m2'), 'monetary-policy');
+    assert.equal(normalizeBeat('btc'), 'bitcoin');
+    assert.equal(normalizeBeat('lds'), 'religion');
+    assert.equal(normalizeBeat('mormon'), 'religion');
+});
+
+test('normalizeBeat: cleans case, whitespace, underscores before lookup', () => {
+    assert.equal(normalizeBeat('  Federal Reserve '), 'monetary-policy');
+    assert.equal(normalizeBeat('MONETARY_POLICY'), 'monetary-policy');
+    assert.equal(normalizeBeat('Tech Policy'), 'tech-policy');
+});
+
+test('normalizeBeat: crypto is DELIBERATELY not bitcoin (RQ8 verbatim)', () => {
+    assert.equal(normalizeBeat('crypto'), null);
+});
+
+test('normalizeBeat: unmapped tags return null — review list, never a new beat', () => {
+    assert.equal(normalizeBeat('monetarypolicy'), null);
+    assert.equal(normalizeBeat('some-novel-topic'), null);
+    assert.equal(normalizeBeat(''), null);
+    assert.equal(normalizeBeat(null), null);
+});
+
+test('beats-v1.json artifact never drifts from the code vocabulary', async () => {
+    const artifact = JSON.parse(await readFile(
+        new URL('../src/shared/audit/beats-v1.json', import.meta.url), 'utf8'));
+    assert.equal(artifact.version, BEATS_VERSION);
+    assert.deepEqual(artifact.beats, [...BEATS]);
+    assert.deepEqual(artifact.aliases, { ...BEAT_ALIASES });
+    assert.ok(artifact.non_aliases && 'crypto' in artifact.non_aliases,
+        'the deliberate crypto non-alias must stay documented in the artifact');
+});

--- a/tests/audit-cache.test.mjs
+++ b/tests/audit-cache.test.mjs
@@ -1,0 +1,95 @@
+// Phase 13.1 — xray-audits IndexedDB cache.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Install fake-indexeddb BEFORE the cache module is imported so the
+// module's `indexedDB` lookup lands on the fake.
+await import('fake-indexeddb/auto');
+
+const {
+    openAuditDb, clear,
+    saveRun, getRun, runsByArticleHash, listRuns, deleteRun, countRuns,
+    savePrediction, getPrediction, predictionsByArticleHash, predictionsByStatus,
+    saveResolution, getResolution, resolutionsByPredictionCoord
+} = await import('../src/shared/audit/audit-cache.js');
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+
+test.beforeEach(async () => { await clear(); });
+
+test('openAuditDb is idempotent — one connection promise', async () => {
+    const a = openAuditDb();
+    const b = openAuditDb();
+    assert.equal(a, b);
+    const db = await a;
+    assert.equal(db.name, 'xray-audits');
+});
+
+test('runs: CRUD + articleHash index', async () => {
+    await saveRun({ id: 'audit_1', articleHash: HASH_A, runAt: '2026-06-11T20:00:00Z' });
+    await saveRun({ id: 'audit_2', articleHash: HASH_A, runAt: '2026-06-11T21:00:00Z' });
+    await saveRun({ id: 'audit_3', articleHash: HASH_B, runAt: '2026-06-11T22:00:00Z' });
+
+    assert.equal((await getRun('audit_1')).runAt, '2026-06-11T20:00:00Z');
+    assert.equal(await getRun('nope'), null);
+    assert.equal((await runsByArticleHash(HASH_A)).length, 2);
+    assert.equal((await listRuns()).length, 3);
+    assert.equal(await countRuns(), 3);
+
+    await deleteRun('audit_2');
+    assert.equal((await runsByArticleHash(HASH_A)).length, 1);
+});
+
+test('runs: put replaces same id (idempotent republish of the record)', async () => {
+    await saveRun({ id: 'audit_1', articleHash: HASH_A, note: 'v1' });
+    await saveRun({ id: 'audit_1', articleHash: HASH_A, note: 'v2' });
+    assert.equal(await countRuns(), 1);
+    assert.equal((await getRun('audit_1')).note, 'v2');
+});
+
+test('predictions: indexes on articleHash and resolution_status', async () => {
+    await savePrediction({ id: 'pred_1', articleHash: HASH_A, resolution_status: 'open', horizon_iso: '2026-12-31' });
+    await savePrediction({ id: 'pred_2', articleHash: HASH_A, resolution_status: 'resolved_true', horizon_iso: null });
+    await savePrediction({ id: 'pred_3', articleHash: HASH_B, resolution_status: 'open', horizon_iso: '2027-01-15' });
+
+    assert.equal((await predictionsByArticleHash(HASH_A)).length, 2);
+    const open = await predictionsByStatus('open');
+    assert.deepEqual(open.map((p) => p.id).sort(), ['pred_1', 'pred_3']);
+    assert.equal((await getPrediction('pred_2')).resolution_status, 'resolved_true');
+});
+
+test('index queries with undefined/null keys return [], never the whole store', async () => {
+    await saveRun({ id: 'audit_1', articleHash: HASH_A });
+    await saveRun({ id: 'audit_2', articleHash: HASH_B });
+    await savePrediction({ id: 'pred_1', articleHash: HASH_A, resolution_status: 'open' });
+    // IDBIndex.getAll(undefined) is an unbounded range — unguarded, a
+    // caller bug would widen "audits for this article" into "every
+    // audit in the ledger".
+    assert.deepEqual(await runsByArticleHash(undefined), []);
+    assert.deepEqual(await runsByArticleHash(null), []);
+    assert.deepEqual(await predictionsByArticleHash(undefined), []);
+    assert.deepEqual(await predictionsByStatus(null), []);
+    assert.deepEqual(await resolutionsByPredictionCoord(undefined), []);
+});
+
+test('resolutions: predictionCoord index', async () => {
+    const coord = `30058:${'c'.repeat(64)}:pred_1`;
+    await saveResolution({ id: 'res_1', prediction_coord: coord, outcome: 'true' });
+    await saveResolution({ id: 'res_2', prediction_coord: coord, outcome: 'false' });
+    await saveResolution({ id: 'res_3', prediction_coord: 'other', outcome: 'partial' });
+
+    assert.equal((await resolutionsByPredictionCoord(coord)).length, 2);
+    assert.equal((await getResolution('res_3')).outcome, 'partial');
+});
+
+test('clear empties all three stores', async () => {
+    await saveRun({ id: 'audit_1', articleHash: HASH_A });
+    await savePrediction({ id: 'pred_1', articleHash: HASH_A, resolution_status: 'open' });
+    await saveResolution({ id: 'res_1', prediction_coord: 'x', outcome: 'true' });
+    await clear();
+    assert.equal(await countRuns(), 0);
+    assert.equal(await getPrediction('pred_1'), null);
+    assert.equal(await getResolution('res_1'), null);
+});

--- a/tests/audit-calibration.test.mjs
+++ b/tests/audit-calibration.test.mjs
@@ -1,0 +1,102 @@
+// Phase 13.1 — calibration-v1 (RQ4): specified now, logged, NOT
+// activated. These tests pin the published assumption and P7's
+// ordering, and pin that the multiplier never activates in v1.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    CALIBRATION_VERSION, HEDGE_IMPLIED_PROBABILITY, MIN_RESOLVED_FOR_DISPLAY,
+    brierScore, calibrationRateTable, calibrationV1, inactiveMultiplierV1
+} from '../src/shared/audit/calibration.js';
+
+function close(actual, expected, label) {
+    assert.ok(Math.abs(actual - expected) < 1e-9, `${label}: ${actual} !== ~${expected}`);
+}
+
+test('the published probability mapping (RQ4, verbatim)', () => {
+    assert.equal(CALIBRATION_VERSION, 'calibration-v1');
+    assert.deepEqual({ ...HEDGE_IMPLIED_PROBABILITY },
+        { confident: 0.90, hedged: 0.70, speculative: 0.55 });
+});
+
+test('Brier worked costs from the RQ4 answer, exactly', () => {
+    close(brierScore('confident', 'false'), 0.81, 'confident-wrong');
+    close(brierScore('hedged', 'false'), 0.49, 'hedged-wrong');
+    close(brierScore('confident', 'true'), 0.01, 'confident-right');
+    close(brierScore('hedged', 'true'), 0.09, 'hedged-right');
+});
+
+test('P7 ordering falls out automatically', () => {
+    // Confident-wrong costs more than hedged-wrong costs more than
+    // speculative-wrong; confident-right beats hedged-right beats
+    // speculative-right (lower Brier = better).
+    assert.ok(brierScore('confident', 'false') > brierScore('hedged', 'false'));
+    assert.ok(brierScore('hedged', 'false') > brierScore('speculative', 'false'));
+    assert.ok(brierScore('confident', 'true') < brierScore('hedged', 'true'));
+    assert.ok(brierScore('hedged', 'true') < brierScore('speculative', 'true'));
+});
+
+test('negative predictions need no special case — the inversion is algebraic', () => {
+    // Confident "X won't happen", X happens → prediction false:
+    // (0.10 − 1)² = (0.90 − 0)² = 0.81. Scoring the prediction as
+    // stated covers both signs.
+    close(brierScore('confident', 'false'), Math.pow(0.10 - 1, 2), 'inversion identity');
+});
+
+test('partial scores against 0.5; unresolvable and unknowns are excluded', () => {
+    close(brierScore('confident', 'partial'), 0.16, 'confident-partial');
+    close(brierScore('speculative', 'partial'), 0.0025, 'speculative-partial');
+    assert.equal(brierScore('confident', 'unresolvable'), null);
+    assert.equal(brierScore('confident', 'nonsense'), null);
+    assert.equal(brierScore('bold', 'true'), null, 'unknown hedge level excluded, never defaulted');
+});
+
+test('rate table: the canonical v1 display — resolved/true/rate per hedge', () => {
+    const table = calibrationRateTable([
+        { hedge_level: 'confident', outcome: 'true' },
+        { hedge_level: 'confident', outcome: 'false' },
+        { hedge_level: 'confident', outcome: 'partial' },
+        { hedge_level: 'hedged', outcome: 'true' },
+        { hedge_level: 'hedged', outcome: 'unresolvable' },   // excluded
+        { hedge_level: 'speculative', outcome: 'false' }
+    ]);
+    assert.deepEqual(table.confident, { resolved: 3, true_count: 1, rate: 1 / 3 });
+    assert.deepEqual(table.hedged, { resolved: 1, true_count: 1, rate: 1 });
+    assert.deepEqual(table.speculative, { resolved: 1, true_count: 0, rate: 0 });
+});
+
+test('rate table: empty ledger yields null rates, zero counts', () => {
+    const table = calibrationRateTable([]);
+    for (const level of ['confident', 'hedged', 'speculative']) {
+        assert.deepEqual(table[level], { resolved: 0, true_count: 0, rate: null });
+    }
+});
+
+test('calibrationV1: mean Brier + count, multiplier ALWAYS null in v1', () => {
+    const block = calibrationV1([
+        { hedge_level: 'confident', outcome: 'false' },   // 0.81
+        { hedge_level: 'confident', outcome: 'true' },    // 0.01
+        { hedge_level: 'hedged', outcome: 'unresolvable' } // excluded
+    ]);
+    assert.equal(block.version, 'calibration-v1');
+    assert.equal(block.resolved_count, 2);
+    close(block.mean_brier, 0.41, 'mean of 0.81 and 0.01');
+    assert.equal(block.multiplier, null, 'logged, not activated — multiplier stays null');
+
+    const empty = calibrationV1([]);
+    assert.equal(empty.mean_brier, null);
+    assert.equal(empty.resolved_count, 0);
+    assert.equal(empty.multiplier, null);
+});
+
+test('inactiveMultiplierV1: shape pinned for the future activation decision', () => {
+    assert.equal(MIN_RESOLVED_FOR_DISPLAY, 10);
+    // Below the display gate: null, no matter how good the record.
+    assert.equal(inactiveMultiplierV1(0.0, 0.5, 9), null);
+    // clamp(1 + 0.5·(B_pop − B_subject), 0.85, 1.15):
+    close(inactiveMultiplierV1(0.2, 0.3, 10), 1.05, 'better than population');
+    close(inactiveMultiplierV1(0.3, 0.2, 10), 0.95, 'worse than population');
+    assert.equal(inactiveMultiplierV1(0.0, 1.0, 10), 1.15, 'upper clamp');
+    assert.equal(inactiveMultiplierV1(1.0, 0.0, 10), 0.85, 'lower clamp');
+});

--- a/tests/audit-findings-schemas.test.mjs
+++ b/tests/audit-findings-schemas.test.mjs
@@ -1,0 +1,328 @@
+// Phase 13.1 — derived per-module findings schemas. The validators
+// close the gap the scorer README's Limitations section admits (the
+// prototype only extracts JSON; "validates each output" was
+// aspirational).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MODULE_NAMES, SCOREABLE_MODULES, validateFindings } from '../src/shared/audit/findings-schemas.js';
+
+function envelope(module, scored = true) {
+    const base = { module, version: '1.0', auditor_caveats: ['Surface scan only; substantive claims not verified.'] };
+    return scored ? { ...base, score: 80, confidence: 0.8, confidence_notes: 'clear structure' } : base;
+}
+
+const MINIMAL = {
+    headline_body_fidelity: {
+        headline: 'H', subhead: null,
+        headline_implications: [], body_findings: [], structural_issues: []
+    },
+    asymmetric_language: {
+        has_contrast_structure: false,
+        parties_identified: [], language_applied: [], asymmetry_findings: []
+    },
+    number_hygiene: {
+        numerical_claims: [],
+        summary: { total_claims: 0, claims_failing_at_least_one_test: 0 }
+    },
+    source_quality: {
+        sources: [], claim_to_source_map: [], single_sourced_contested_claims: [],
+        primary_documents: [],
+        summary: {
+            total_sources: 0, named_count: 0, anonymous_count: 0,
+            anonymous_justified_count: 0, expert_says_vague_count: 0,
+            documents_cited: 0, documents_specifically_identified: 0
+        }
+    },
+    internal_coherence: { contradictions: [], logical_gaps: [] },
+    definitional_precision: { contested_terms: [], weasel_quantifiers: [], category_laundering: [] },
+    omission: {
+        topic_summary: 'Local zoning fight.',
+        voices_directly_quoted: [], voices_paraphrased_only: [],
+        voices_referenced_but_silent: [], natural_stakeholder_set: [],
+        voices_expected_but_absent: [], speaks_for_instances: []
+    },
+    prediction_extraction: { predictions: [], summary: { total_predictions: 0 } }
+};
+
+function minimalPayload(module) {
+    const scored = module !== 'prediction_extraction';
+    return { ...envelope(module, scored), ...structuredClone(MINIMAL[module]) };
+}
+
+test('eight modules, seven scoreable', () => {
+    assert.equal(MODULE_NAMES.length, 8);
+    assert.equal(SCOREABLE_MODULES.length, 7);
+    assert.ok(!SCOREABLE_MODULES.includes('prediction_extraction'));
+});
+
+test('every module: minimal conforming payload validates', () => {
+    for (const module of MODULE_NAMES) {
+        const { valid, errors } = validateFindings(module, minimalPayload(module));
+        assert.ok(valid, `${module}: ${JSON.stringify(errors)}`);
+    }
+});
+
+test('envelope: module mismatch, bad version, missing caveats all fail', () => {
+    const p = minimalPayload('number_hygiene');
+    assert.ok(!validateFindings('number_hygiene', { ...p, module: 'omission' }).valid);
+    assert.ok(!validateFindings('number_hygiene', { ...p, version: 'v1' }).valid);
+    const noCaveats = { ...p };
+    delete noCaveats.auditor_caveats;
+    assert.ok(!validateFindings('number_hygiene', noCaveats).valid,
+        'a module that emits findings without caveats is broken (PHILOSOPHY §2)');
+});
+
+test('envelope: score/confidence required and range-checked on scoreable modules', () => {
+    const p = minimalPayload('internal_coherence');
+    assert.ok(!validateFindings('internal_coherence', { ...p, score: 101 }).valid);
+    assert.ok(!validateFindings('internal_coherence', { ...p, score: -1 }).valid);
+    assert.ok(!validateFindings('internal_coherence', { ...p, confidence: 1.5 }).valid);
+    const noScore = { ...p };
+    delete noScore.score;
+    assert.ok(!validateFindings('internal_coherence', noScore).valid);
+});
+
+test('prediction_extraction: score/confidence are FORBIDDEN, not optional', () => {
+    const p = minimalPayload('prediction_extraction');
+    assert.ok(validateFindings('prediction_extraction', p).valid);
+    assert.ok(!validateFindings('prediction_extraction', { ...p, score: 75 }).valid,
+        'a scored prediction_extraction is malformed — predictions are not scored at extraction');
+    assert.ok(!validateFindings('prediction_extraction', { ...p, confidence: 0.9 }).valid);
+});
+
+test('module 03: full claim item validates; broken items fail precisely', () => {
+    const item = {
+        id: 1, claim: 'Crime rose 30%', value: '30%', context: 'year over year',
+        denominator_test: 'failed', base_rate_test: 'not_applicable',
+        comparison_class_test: 'passed', additional_issues: [],
+        evidence_quote: 'crime rose by 30 percent', notes: 'no denominator given'
+    };
+    const ok = minimalPayload('number_hygiene');
+    ok.numerical_claims = [item];
+    ok.summary = { total_claims: 1, claims_failing_at_least_one_test: 1, most_common_failure: 'denominator' };
+    assert.ok(validateFindings('number_hygiene', ok).valid);
+
+    const badEnum = structuredClone(ok);
+    badEnum.numerical_claims[0].denominator_test = 'maybe';
+    assert.ok(!validateFindings('number_hygiene', badEnum).valid);
+
+    const emptyQuote = structuredClone(ok);
+    emptyQuote.numerical_claims[0].evidence_quote = '';
+    assert.ok(!validateFindings('number_hygiene', emptyQuote).valid,
+        'evidence-bound: an empty evidence quote is invalid (P3)');
+
+    const noQuote = structuredClone(ok);
+    delete noQuote.numerical_claims[0].evidence_quote;
+    assert.ok(!validateFindings('number_hygiene', noQuote).valid);
+
+    // Descriptive enrichments are optional — their absence is benign.
+    const lean = structuredClone(ok);
+    delete lean.numerical_claims[0].id;
+    delete lean.numerical_claims[0].context;
+    delete lean.numerical_claims[0].notes;
+    delete lean.summary.most_common_failure;
+    assert.ok(validateFindings('number_hygiene', lean).valid,
+        'a benign omission must not turn a paid run into a failed one');
+});
+
+test('module 01: nullable evidence_quote is null-or-nonempty, never empty', () => {
+    const p = minimalPayload('headline_body_fidelity');
+    p.headline_implications = [{ id: 0, implication: 'X causes Y', type: 'causal', implied_strength: 'definite' }];
+    p.body_findings = [{ implication_id: 0, support_status: 'unsupported', evidence_quote: null }];
+    assert.ok(validateFindings('headline_body_fidelity', p).valid,
+        'null evidence_quote is the unsupported-implication case');
+
+    p.body_findings[0].evidence_quote = '';
+    assert.ok(!validateFindings('headline_body_fidelity', p).valid,
+        'empty string is not null — evidence-bound');
+});
+
+test('module 04: the ceiling-heuristic summary counts are load-bearing — all required', () => {
+    const p = minimalPayload('source_quality');
+    delete p.summary.documents_specifically_identified;
+    assert.ok(!validateFindings('source_quality', p).valid);
+});
+
+test('module 08: prediction items pin the ledger enums', () => {
+    const p = minimalPayload('prediction_extraction');
+    p.predictions = [{
+        id: 0, prediction: 'Rates will fall by December.',
+        type: 'explicit', hedge_level: 'confident', attributed_to: 'named_source',
+        attributed_source_name: 'Chair Powell', condition: null,
+        resolution_horizon: 'by the end of the year',
+        resolution_criteria: 'Fed funds target below current by Dec 31',
+        tractability: 'publicly_resolvable',
+        evidence_quote: 'rates will come down before December'
+    }];
+    p.summary.total_predictions = 1;
+    assert.ok(validateFindings('prediction_extraction', p).valid);
+
+    p.predictions[0].hedge_level = 'certain';
+    assert.ok(!validateFindings('prediction_extraction', p).valid,
+        'hedge enum is the calibration input — unknown values must fail');
+});
+
+// Populated canonical payloads for the modules the minimal test only
+// exercises empty — built field-for-field from the vendored prompts'
+// output specs. THE import-path make-or-break: a real paid run's
+// output must validate, so a wrongly-required field or item-schema
+// typo here fails loudly.
+const POPULATED = {
+    asymmetric_language: {
+        has_contrast_structure: true,
+        parties_identified: [
+            { name: 'Sen. Alice Hale', role: 'bill sponsor' },
+            { name: 'Gov. Tom Rusk', role: 'opponent' }
+        ],
+        language_applied: [
+            { party: 'Sen. Alice Hale', verbs: ['stated', 'outlined'], adjectives: ['measured'], epithets_or_labels: [], sourcing_verbs: ['said'] },
+            { party: 'Gov. Tom Rusk', verbs: ['lashed out', 'claimed'], adjectives: ['combative'], epithets_or_labels: ['hardliner'], sourcing_verbs: ['insisted'] }
+        ],
+        asymmetry_findings: [{
+            dimension: 'sourcing_verbs',
+            party_a: 'Sen. Alice Hale', party_a_term: 'said',
+            party_b: 'Gov. Tom Rusk', party_b_term: 'insisted',
+            evidence_quote_a: 'Hale said the bill would cap fees',
+            evidence_quote_b: 'Rusk insisted the numbers were wrong',
+            justified_by_underlying_facts: false,
+            justification_notes: null,
+            severity: 'medium'
+        }]
+    },
+    source_quality: {
+        sources: [
+            { id: 1, label: 'Treasury spokesperson', type: 'named_primary', anonymity_justification: null, relationship_to_matter: 'official statement', evidence_quote: 'a Treasury spokesperson said' },
+            { id: 2, label: 'people familiar with the matter', type: 'anonymous_bare', anonymity_justification: null, relationship_to_matter: 'unclear', evidence_quote: 'according to people familiar with the matter' }
+        ],
+        claim_to_source_map: [{
+            claim: 'The department will revise the rule',
+            source_ids: [1], is_contested: false, contested_reason: null,
+            evidence_quote: 'will revise the rule, the spokesperson said'
+        }],
+        single_sourced_contested_claims: [{
+            claim: 'Officials knew in March', source_id: 2, source_type: 'anonymous_bare',
+            evidence_quote: 'officials knew as early as March'
+        }],
+        primary_documents: [{
+            document: 'the draft rule', linked_or_quoted: false,
+            specific_enough_to_retrieve: false, evidence_quote: 'a draft rule circulated last week'
+        }],
+        summary: {
+            total_sources: 2, named_count: 1, anonymous_count: 1,
+            anonymous_justified_count: 0, expert_says_vague_count: 0,
+            documents_cited: 1, documents_specifically_identified: 0
+        }
+    },
+    internal_coherence: {
+        contradictions: [{
+            type: 'numerical',
+            claim_a: 'costs rose 12%', claim_b: 'costs nearly doubled',
+            evidence_quote_a: 'rose 12 percent over the year',
+            evidence_quote_b: 'costs nearly doubled in a year',
+            is_dialectic_intent: false, severity: 'high',
+            notes: 'same metric, same period'
+        }],
+        logical_gaps: [{
+            description: 'conclusion assumes causation from a single correlation',
+            evidence_quote: 'because enrollment fell, the policy failed',
+            severity: 'medium'
+        }]
+    },
+    definitional_precision: {
+        contested_terms: [{
+            term: 'misinformation', occurrences: 4,
+            first_use_quote: 'a wave of misinformation',
+            defined_in_text: false, definition_quote: null,
+            definition_quality: 'absent',
+            smuggled_assumption: 'that the contested claims are settled false',
+            load_bearing: true, used_consistently: false,
+            severity_if_undefined: 'high'
+        }],
+        weasel_quantifiers: [{
+            term: 'many experts', evidence_quote: 'many experts agree',
+            backed_by_evidence: false, severity: 'medium'
+        }],
+        category_laundering: [{
+            category: 'assault-style weapons',
+            evidence_quote: 'assault-style weapons were used',
+            treatment: 'undefined category presented as settled',
+            severity: 'medium'
+        }]
+    },
+    omission: {
+        topic_summary: 'School closure fight in the district.',
+        voices_directly_quoted: [{
+            name_or_role: 'union president', perspective_summary: 'opposes the closure',
+            quote_density: 'high', evidence_quote: '"this will gut the district," she said'
+        }],
+        voices_paraphrased_only: [{
+            name_or_role: 'district spokesperson', perspective_summary: 'cites budget pressure',
+            evidence_quote: 'the district pointed to budget shortfalls'
+        }],
+        voices_referenced_but_silent: [{
+            name_or_role: 'parents', absence_addressed: false, absence_explanation: null
+        }],
+        natural_stakeholder_set: ['teachers', 'parents', 'students', 'district officials'],
+        voices_expected_but_absent: [{
+            role: 'students', why_expected: 'directly affected by the closure',
+            absence_addressed: false, severity: 'medium'
+        }],
+        speaks_for_instances: [{
+            speaking_party: 'union president', spoken_for_party: 'teachers',
+            evidence_quote: 'teachers want answers, she said', severity: 'low'
+        }],
+        quotation_balance_notes: 'union voices dominate direct quotation'
+    }
+};
+
+test('populated canonical payloads validate for every list-heavy module', () => {
+    for (const [module, payload] of Object.entries(POPULATED)) {
+        const full = { ...envelope(module, true), ...structuredClone(payload) };
+        const { valid, errors } = validateFindings(module, full);
+        assert.ok(valid, `${module}: a real run's output must pass — ${JSON.stringify(errors)}`);
+    }
+});
+
+test('the scorer-export WRAPPER level is rejected — importers must validate findings, not the wrapper', () => {
+    // scorer.js wraps payloads as ModuleResult: {module, module_version,
+    // auditor, run_at, score, confidence, findings, ...}. Validating
+    // the wrapper instead of wrapper.findings is the easy importer bug
+    // (module_version vs version) — it must FAIL, loudly.
+    const wrapper = {
+        module: 'omission', module_version: '1.0',
+        auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' },
+        run_at: '2026-06-11T20:14:00Z', score: 70, confidence: 0.8,
+        findings: { ...envelope('omission', true), ...structuredClone(MINIMAL.omission) },
+        evidence_quotes: [], auditor_caveats: []
+    };
+    assert.ok(!validateFindings('omission', wrapper).valid);
+    assert.ok(validateFindings('omission', wrapper.findings).valid,
+        'the wrapped findings themselves are the validatable unit');
+});
+
+test('the scorer failed-run shape is rejected, never mistaken for findings', () => {
+    // runModule's error path emits findings: {error: "..."} — that is a
+    // failed run (stored with score null, excluded from aggregation),
+    // not a validatable payload.
+    assert.ok(!validateFindings('omission', { error: 'API call failed: 529' }).valid);
+});
+
+test('unknown extra fields are tolerated; unknown modules are not', () => {
+    const p = { ...minimalPayload('omission'), model_color_commentary: 'extra' };
+    assert.ok(validateFindings('omission', p).valid);
+    assert.ok(!validateFindings('sentiment_analysis', p).valid);
+});
+
+test('auditor-kind parity: validation is auditor-blind by construction (RQ3)', () => {
+    // Identity rides event tags, never findings JSON — so a payload a
+    // human author produced under the guided checklist validates by
+    // exactly the same rules. Nothing here can special-case the kind.
+    const p = minimalPayload('definitional_precision');
+    const asHuman = { ...p, auditor: { kind: 'human', id: 'a'.repeat(64) } };
+    const asModel = { ...p, auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' } };
+    assert.deepEqual(validateFindings('definitional_precision', asHuman),
+        validateFindings('definitional_precision', asModel));
+    assert.ok(validateFindings('definitional_precision', asHuman).valid);
+});

--- a/tests/audit-model.test.mjs
+++ b/tests/audit-model.test.mjs
@@ -1,0 +1,206 @@
+// Phase 13.1 — audit local models: deterministic ids, idempotent
+// create, markPublished-never-bumps-updated, staleness/orphan display
+// states, derived resolution fields, and auditor-kind parity (RQ3).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+await import('fake-indexeddb/auto');
+
+const { clear, saveRun, savePrediction, saveResolution } = await import('../src/shared/audit/audit-cache.js');
+const {
+    normalizePredictionText, generateAuditRunId, generatePredictionId,
+    generateResolutionId, compareVersions,
+    AuditRunModel, staleModules, isOrphaned,
+    PredictionModel, deriveResolutionState, ResolutionModel
+} = await import('../src/shared/audit/audit-model.js');
+
+const HASH = 'a'.repeat(64);
+const RUN_AT = '2026-06-11T20:14:00Z';
+
+// "Never bumps updated" cannot be asserted by comparing two
+// nowSeconds() values — create and mark run in the same second, so
+// the assertion would pass even if the bump happened. Instead the
+// stored record's `updated` is rewritten to a sentinel in the past;
+// any bump moves it off the sentinel and the test bites.
+const SENTINEL = 1_000_000;
+
+// The four AuditorIdentity kinds — every model path must treat them
+// identically (RQ3: nothing assumes model/pipeline).
+const AUDITORS = [
+    { kind: 'model', id: 'anthropic/claude-sonnet-4-6' },
+    { kind: 'human', id: 'f'.repeat(64) },
+    { kind: 'pipeline', id: 'xray-auditor/0.1.0/anthropic/claude-sonnet-4-6' },
+    { kind: 'consensus', id: 'xray-panel-v1' }
+];
+
+test.beforeEach(async () => { await clear(); });
+
+test('normalizePredictionText is the claim-id discipline, exactly', () => {
+    assert.equal(normalizePredictionText('  Rates  Will\tFALL\n by  December '),
+        'rates will fall by december');
+    assert.equal(normalizePredictionText(''), '');
+});
+
+test('prediction id converges across phrasing noise — the ledger survives re-extraction', async () => {
+    const a = await generatePredictionId(HASH, 'Rates will fall by December');
+    const b = await generatePredictionId(HASH, '  rates  WILL fall   by december ');
+    assert.equal(a, b);
+    assert.match(a, /^pred_[0-9a-f]{16}$/);
+    const otherHash = await generatePredictionId('b'.repeat(64), 'Rates will fall by December');
+    assert.notEqual(a, otherHash, 'stealth edits fork the ledger per text version — deliberately');
+});
+
+test('compareVersions: numeric, not lexicographic', () => {
+    assert.equal(compareVersions('1.0', '1.1'), -1);
+    assert.equal(compareVersions('1.2', '1.10'), -1);
+    assert.equal(compareVersions('1.0.0', '1.0'), 0);
+    assert.equal(compareVersions('2.0', '1.9.9'), 1);
+});
+
+test('AuditRunModel.create: idempotent on (articleHash, auditorId, runAt)', async () => {
+    const first = await AuditRunModel.create({
+        articleHash: HASH, auditor: AUDITORS[0], runAt: RUN_AT,
+        source: 'cli-import', moduleResults: [{ module: 'omission', module_version: '1.0', score: 70 }]
+    });
+    const again = await AuditRunModel.create({
+        articleHash: HASH, auditor: AUDITORS[0], runAt: RUN_AT,
+        source: 'cli-import', moduleResults: []
+    });
+    assert.equal(first.id, again.id);
+    assert.equal(again.moduleResults.length, 1, 're-import of the same run is a no-op');
+
+    const differentRun = await AuditRunModel.create({
+        articleHash: HASH, auditor: AUDITORS[0], runAt: '2026-06-12T09:00:00Z', source: 'cli-import'
+    });
+    assert.notEqual(first.id, differentRun.id, 'a new run is a new record — time series, never overwrite');
+});
+
+test('auditor-kind parity: all four kinds flow create/publish identically (RQ3)', async () => {
+    for (const auditor of AUDITORS) {
+        const run = await AuditRunModel.create({
+            articleHash: HASH, auditor, runAt: RUN_AT, source: 'manual'
+        });
+        assert.deepEqual(run.auditor, auditor);
+        await saveRun({ ...run, updated: SENTINEL });
+        const marked = await AuditRunModel.markEventPublished(run.id, 'agg', 'e'.repeat(64));
+        assert.ok(marked.events.agg.publishedAt > 0);
+        assert.equal(marked.updated, SENTINEL, `publish must not bump updated (${auditor.kind})`);
+    }
+});
+
+test('per-event publish ledger: partial publish resumes, never duplicates', async () => {
+    const run = await AuditRunModel.create({
+        articleHash: HASH, auditor: AUDITORS[2], runAt: RUN_AT, source: 'cli-import'
+    });
+    await saveRun({ ...run, updated: SENTINEL });
+    await AuditRunModel.markEventPublished(run.id, 'mod:omission', '1'.repeat(64));
+    await AuditRunModel.markEventPublished(run.id, 'mod:source_quality', '2'.repeat(64));
+    const after = await AuditRunModel.get(run.id);
+    assert.deepEqual(Object.keys(after.events).sort(), ['mod:omission', 'mod:source_quality']);
+    assert.equal(after.events['mod:omission'].publishedEventId, '1'.repeat(64));
+    assert.equal(after.updated, SENTINEL, 'two ledger marks, zero updated bumps');
+});
+
+test('staleModules: version bump invalidates nothing, offers re-audit', () => {
+    const run = {
+        moduleResults: [
+            { module: 'omission', module_version: '1.0' },
+            { module: 'source_quality', module_version: '1.1' }
+        ]
+    };
+    const stale = staleModules(run, { omission: '1.1', source_quality: '1.1' });
+    assert.deepEqual(stale, [{ module: 'omission', storedVersion: '1.0', currentVersion: '1.1' }]);
+    assert.deepEqual(staleModules(run, {}), [], 'no current versions → nothing stale');
+});
+
+test('isOrphaned: stealth-edit display state, hash outlives the capture', () => {
+    const run = { articleHash: HASH };
+    assert.equal(isOrphaned(run, HASH), false);
+    assert.equal(isOrphaned(run, 'b'.repeat(64)), true);
+    assert.equal(isOrphaned(run, null), false, 'no current capture → not orphaned, just unanchored');
+});
+
+test('PredictionModel: idempotent create; publish and derive never bump updated', async () => {
+    const fields = {
+        articleHash: HASH, text: 'Rates will fall by December.',
+        type: 'explicit', hedge_level: 'confident', tractability: 'publicly_resolvable',
+        evidence_quote: 'rates will come down', auditor: AUDITORS[0]
+    };
+    const p1 = await PredictionModel.create(fields);
+    const p2 = await PredictionModel.create({ ...fields, hedge_level: 'speculative' });
+    assert.equal(p1.id, p2.id);
+    assert.equal(p2.hedge_level, 'confident', 'idempotent create returns the EXISTING record');
+    assert.equal(p1.resolution_status, 'open');
+
+    await savePrediction({ ...p1, updated: SENTINEL });
+    const marked = await PredictionModel.markPublished(p1.id, 'e'.repeat(64));
+    assert.equal(marked.updated, SENTINEL, 'publish must not bump updated');
+    assert.ok(marked.publishedAt > 0);
+
+    const derived = await PredictionModel.updateDerived(p1.id, [
+        { id: 'res_x', outcome: 'true', resolved_at: 100 }
+    ]);
+    assert.equal(derived.resolution_status, 'resolved_true');
+    assert.equal(derived.latest_resolution_id, 'res_x');
+    assert.equal(derived.updated, SENTINEL, 'derivation is enrichment, not an edit');
+});
+
+test('deriveResolutionState: latest resolved_at wins; outcomes map to statuses', () => {
+    assert.deepEqual(deriveResolutionState([]), { status: 'open', latestId: null });
+    const state = deriveResolutionState([
+        { id: 'r1', outcome: 'false', resolved_at: 100 },
+        { id: 'r2', outcome: 'partial', resolved_at: 300 },
+        { id: 'r3', outcome: 'true', resolved_at: 200 }
+    ]);
+    assert.deepEqual(state, { status: 'resolved_partial', latestId: 'r2' });
+    assert.equal(deriveResolutionState([{ id: 'r', outcome: 'unresolvable', resolved_at: 1 }]).status,
+        'unresolvable');
+});
+
+test('ResolutionModel: one per prediction coord; update bumps, markPublished does not', async () => {
+    const coord = `30058:${'d'.repeat(64)}:pred_abc`;
+    const r1 = await ResolutionModel.create({
+        predictionCoord: coord, outcome: 'false', auditor: AUDITORS[1],
+        evidence: [{ kind: 'url', value: 'https://e.x/outcome', description: 'the result' }]
+    });
+    const r2 = await ResolutionModel.create({ predictionCoord: coord, outcome: 'true' });
+    assert.equal(r1.id, r2.id, 'one resolution per (resolver, prediction)');
+    assert.equal(r2.outcome, 'false');
+
+    await saveResolution({ ...r1, updated: SENTINEL });
+    const marked = await ResolutionModel.markPublished(r1.id, 'e'.repeat(64));
+    assert.equal(marked.updated, SENTINEL, 'publish must not bump updated');
+
+    const updated = await ResolutionModel.update(r1.id, { outcome: 'partial' });
+    assert.equal(updated.outcome, 'partial');
+    assert.ok(updated.updated > SENTINEL, 'self-revision IS an edit — it re-emits');
+});
+
+test('create() guards: malformed input throws, never persists a garbage id', async () => {
+    await assert.rejects(AuditRunModel.create({ auditor: AUDITORS[0], runAt: RUN_AT }),
+        /articleHash required/);
+    await assert.rejects(AuditRunModel.create({ articleHash: HASH, auditor: { kind: 'model' }, runAt: RUN_AT }),
+        /auditor \{kind, id\} required/);
+    await assert.rejects(AuditRunModel.create({ articleHash: HASH, auditor: AUDITORS[0] }),
+        /runAt required/);
+    await assert.rejects(AuditRunModel.create({ articleHash: HASH, auditor: AUDITORS[0], runAt: RUN_AT, source: 'import' }),
+        /source must be one of/);
+    await assert.rejects(PredictionModel.create({ articleHash: HASH }),
+        /text required/);
+    await assert.rejects(PredictionModel.create({ text: 'X will happen' }),
+        /articleHash required/);
+    await assert.rejects(ResolutionModel.create({ outcome: 'true' }),
+        /predictionCoord required/);
+});
+
+test('resolution outcomes are validated, never defaulted — a typo must not vanish from calibration', async () => {
+    const coord = `30058:${'e'.repeat(64)}:pred_xyz`;
+    await assert.rejects(ResolutionModel.create({ predictionCoord: coord }),
+        /outcome must be one of/, 'omitted outcome must throw, not default to unresolvable');
+    await assert.rejects(ResolutionModel.create({ predictionCoord: coord, outcome: 'True' }),
+        /outcome must be one of/);
+    const r = await ResolutionModel.create({ predictionCoord: coord, outcome: 'true' });
+    await assert.rejects(ResolutionModel.update(r.id, { outcome: 'resolved_true' }),
+        /outcome must be one of/);
+});


### PR DESCRIPTION
Slice **13.1** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — the model layer. **Stacked on #61** (base = the design branch; retarget to `main` when #61 merges). No UI, no wire format, no manifest change.

## What's in it

| Piece | The contract it pins |
| --- | --- |
| `audit/article-hash.js` | The canonical hash: the vendored scorer's `normalizeMarkdown` **verbatim** + SHA-256 hex. The test extracts the function from the vendored source at run time and pins byte-parity over a hostile corpus — the extension and CLI cannot drift without CI failing. Discovered + pinned: the normalization is **not idempotent** (`\r \n` → manufactured CRLF); the contract is parity over exactly one pass (JOURNAL). |
| `audit/findings-schemas.js` | The eight derived per-module validators (the unrecovered `schema/modules/*.json`, derived per the design note). Module 03 = the design's worked example exactly; module 04's seven ceiling-heuristic counts all required; module 08 **forbids** score/confidence; every mandated `evidence_quote` is `minLength: 1` (P3). Populated canonical payloads validate per module; the scorer-export wrapper level and failed-run `{error}` shape are rejected. |
| `audit/audit-cache.js` | IndexedDB `xray-audits` (runs/predictions/resolutions). Writes await **transaction commit**, not request success; `undefined`/`null` index keys return `[]` — an unbounded `getAll` would have widened "audits for this article" into the whole ledger. |
| `audit/audit-model.js` | AuditRun / Prediction / Resolution: deterministic ids, idempotent create, enum-validated inputs (outcomes never defaulted — a typo'd outcome would silently vanish from calibration), the per-event publish ledger (`markPublished` family never bumps `updated` — **sentinel-tested** after mutation testing proved the naive assertions tautological), staleness/orphan display states, derived resolution fields. Auditor-kind-agnostic (RQ3), parity-tested across all four identity kinds. |
| `audit/beats.js` + `beats-v1.json` | RQ8's curated vocabulary: 24 slugs + alias map (`crypto` deliberately ≠ `bitcoin`), free-form tags normalize-or-null (never mint beats), JSON artifact sync-tested against the module. |
| `audit/calibration.js` | RQ4's `calibration-v1`, **logged not activated**: hedge→probability mapping, Brier (P7 ordering pinned at 0.81/0.49/0.01/0.09 exactly), rate table, multiplier shape pinned but always `null` in v1 behind the ≥10-resolved gate. |

## Verification

- 56 new tests; full suite **726 pass / 0 fail**; build + `web-ext lint` clean (0 errors).
- Three-lens adversarial review (design-fidelity / correctness / test-adequacy), every non-nit finding adversarially verified: **7 confirmed, 7 fixed pre-PR** — including the transaction-commit gap, the unbounded-range guard, outcome validation, and the tautological-timestamp tests (details in the JOURNAL entry).

Next slices per the design note: 13.2 (wire core 30056/30057 + flag + NIP draft), 13.3 (30058–30061 + dossier math).

🤖 Generated with [Claude Code](https://claude.com/claude-code)