### PR TITLE
feat(audit): Phase 13.2 — wire core: kinds 30056/30057, epistemicAuditing flag, NIP draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Sections per release: **Added** (new features), **Changed**
 
 ## [Unreleased]
 
+### Added
+
+- **Phase 13.1/13.2 — epistemic-audit foundation** (flag-gated,
+  default off; `docs/EPISTEMIC_AUDIT_DESIGN.md`). The audit model
+  layer (`src/shared/audit/`): canonical article hash (byte-parity
+  with the vendored scorer's normalization), eight derived
+  findings-schema validators, the `xray-audits` IndexedDB ledger,
+  beats-v1 vocabulary, calibration-v1 math (logged, not activated) —
+  and the wire core: builders + parsers for **two new event kinds**,
+  30056 AuditModuleResult and 30057 AggregateAudit, specified in
+  `docs/NIP_DRAFT.md`. **Wire-format note for event consumers:** the
+  new kinds carry the indexed `x` tag (SHA-256 of normalized article
+  markdown, NIP-94 precedent) as their article anchor; audit events
+  never carry assessment vocabulary (`stance`, `L`/`l` labels) and
+  MUST NOT be merged with 30051 fact-checks or 30054 assessments.
+  Nothing publishes until the `epistemicAuditing` flag (default
+  `false`) is enabled; no UI ships in these slices.
+
 ### Fixed
 
 - **Hardening from the Phase 12.7 adversarial review** (three lenses,

--- a/docs/EPISTEMIC_AUDIT_DESIGN.md
+++ b/docs/EPISTEMIC_AUDIT_DESIGN.md
@@ -503,8 +503,8 @@ One per (auditor, article, run). The badge-surface record.
     ["r", "<article-r-verbatim>"],
     ["i", "<normalized-url>"], ["k", "web"],
     ["run-at", "2026-06-11T20:14:05Z"],
-    ["score", "64.5"],                       // final, post-ceiling
-    ["raw-score", "71.2"],
+    ["score", "80"],                         // final, post-ceiling: min(raw, ceiling)
+    ["raw-score", "85.4"],
     ["ceiling", "80"],
     ["ceiling-binding", "true"],             // present only when raw > ceiling
     ["ceiling-source", "heuristic:source-quality/1.0"],

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,53 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.2: the wire core enforces what the design promises
+
+**Tags:** design
+
+Kinds 30056/30057 (`src/shared/audit/builders.js` + NIP_DRAFT
+sections). The calls worth a paper trail:
+
+- **Builders validate findings BEFORE building.** `buildModuleResultEvent`
+  runs the slice-13.1 schema validator and throws on failure — the
+  RQ1 "never sign what you haven't verified" invariant moved as far
+  upstream as it can go. A consequence: `score`/`confidence`/`version`
+  are read from the validated findings rather than passed separately,
+  so the tags can never disagree with the content, and a
+  prediction_extraction event structurally cannot carry score tags.
+- **The firewall is enforced by construction, not convention** — the
+  builders emit a closed tag vocabulary, and tests pin that no audit
+  event ever carries `stance`/`rating-value`/`L`/`l`.
+- **`ceiling-binding` presence-is-the-signal.** The design note's
+  illustrative 30057 example showed the tag alongside a non-binding
+  raw/ceiling pair; the builder computes `raw > ceiling` and the NIP
+  text says "present ONLY when". The example was illustrative-sloppy;
+  the computed rule governs.
+- **Parsers demand the auditor block.** A 30056/30057 without a
+  parseable `auditor` tag is structurally unusable (null), because an
+  unattributed audit defeats the auditing-the-auditors layer — but
+  unknown auditor *kinds* are rejected rather than defaulted, same
+  posture as outcomes in 13.1.
+- **The three-lens adversarial review confirmed 19 findings (0
+  refuted), all fixed pre-PR.** The instructive ones: the canonical
+  30057 example in both the design note and the NIP draft was
+  *internally inconsistent* (score 64.5 / raw 71.2 / ceiling 80 with
+  `ceiling-binding: true` — binding requires raw > ceiling), now a
+  coherent binding trio and a builder invariant (`finalScore ≤
+  min(raw, ceiling)`, ≤ not == since pipeline degradation may lower
+  it); parser module detection trusted t-tag ORDER, which NIP-01
+  doesn't specify — `findings.module` (const-checked in the envelope)
+  is now authoritative with t-disagreement → null; `Date.parse` as an
+  "ISO-8601" gate accepts `"Jun 11 2026 (x|y)"` — a pipe-bearing
+  runAt would have corrupted the `|`-delimited `d` preimage, now a
+  strict regex; and beats reaching indexed `t` tags unvalidated could
+  collide with module names and poison the relay-side module filter.
+  Mutation testing again earned its keep: nine surviving-mutant test
+  holes (zero-score falsy drops, unparsed lineage roles, first-array-
+  element-only walker masking) now bite.
+
+---
+
 ## 2026-06-11 — 13.1: the hash is parity-not-idempotence, and other slice-one calls
 
 **Tags:** design, pattern

--- a/docs/NIP_DRAFT.md
+++ b/docs/NIP_DRAFT.md
@@ -6,7 +6,7 @@ Web Content Annotations, Fact-Checks, and Topic Trust
 
 `draft` `optional`
 
-This NIP defines eight event kinds and one tag extension that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, and helpfulness votes — and lets readers query, rank, and surface that metadata in context.
+This NIP defines ten event kinds and one tag extension that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, and epistemic-audit records (per-module surface-scan results and aggregate article audits, content-addressed to the exact text scored) — and lets readers query, rank, and surface that metadata in context.
 
 It composes with rather than replaces:
 
@@ -335,6 +335,82 @@ Addressable. A typed link between two claims — the cross-source contradiction 
 - `r` tags carry each claim's `r` verbatim, `i` tags the normalized forms (values deduplicated when both claims share a URL); one `k` = `web` accompanies them. Relationship events anchor to the claims (via `a`), not to pages — the URL tags exist for `#r`-join convenience and MAY be omitted when an endpoint's URL is unknown.
 - Surfacing rule: a `contradicts` link SHOULD surface a warning indicator on **both** claims wherever they render.
 
+## Kind 30056 — AuditModuleResult
+
+Addressable. One surface-scan module's structured findings for one article text, under one versioned methodology, from one run. An epistemic audit examines the *published artifact's craft and support* — headline fidelity, language symmetry, number hygiene, source quality, internal coherence, definitional precision, omission geometry, prediction extraction — never the truth of its claims. The audited artifact is identified by content hash, not URL: outlets stealth-edit, and an audit must stay anchored to exactly the text it scored.
+
+```jsonc
+{
+  "kind": 30056,
+  "tags": [
+    ["d", "mod:<sha256(article_hash + '|' + module + '|' + module_version + '|' + run_at).slice(0,16)>"],
+    ["x", "<sha256 of normalized article markdown>"],
+    ["a", "30023:<capturer-pubkey>:<article-d>", "<relay-hint>"],   // optional article pointer
+    ["r", "<article-url-verbatim>"],
+    ["i", "<normalized-url>"], ["k", "web"],
+    ["t", "source_quality"],                 // the module name — indexed
+    ["module-version", "1.0"],
+    ["run-at", "2026-06-11T20:14:00Z"],
+    ["score", "62"],                         // 0–100; omitted by prediction_extraction
+    ["confidence", "0.78"],                  // 0.0–1.0; omitted by prediction_extraction
+    ["model-params", "temperature=0"],       // optional run metadata
+    ["auditor", "model", "anthropic/claude-sonnet-4-6"],
+    ["client", "<client>"]
+  ],
+  "content": "<the module's findings JSON + top-level evidence_quotes[] index>"
+}
+```
+
+- **`x` is the canonical article hash**: SHA-256 (lowercase hex) of the normalized article markdown — CRLF→LF, trailing spaces/tabs stripped per line, runs of 3+ newlines collapsed to 2, trailing whitespace stripped at end of input; defined over exactly **one** normalization pass, computed over the article body excluding any client metadata header. `x` is single-letter and relay-indexed (NIP-94 precedent: the SHA-256 of the thing); `{"kinds":[30056,30057],"#x":["<hash>"]}` is the one-filter "everything auditing this exact text" query. `r`/`i` are convenience joins that MAY go stale as URLs drift; the hash is the identity.
+- The `d` MUST be recomputable from the event's own tags: `mod:` + the first 16 hex of SHA-256 over `<x> | <t module name> | <module-version> | <run-at>` (`|`-joined, verbatim tag values).
+- **Time-series constraint (normative for every audit kind):** relays keep only the latest event per `(pubkey, kind, d)`, so audit-bearing `d`s MUST carry methodology version and/or run identity — a re-run or a version bump derives a NEW `d` (this scheme does so via `module-version` + `run-at`), prior-methodology audits persist as distinct addressable events, and supersession is expressed exclusively through explicit reference tags on the newer event, never through relay replacement. Republishing the same `d` is permitted only as an idempotent re-emit of the same run.
+- `t` carries the module name (one of the eight; relay-indexed). Additional `t` values MAY mirror the article's topic/beat tags; beat *semantics* for audit kinds derive from matching `t` values against the publisher's published beat vocabulary — collisions with generic hashtags are expected and harmless.
+- `score`/`confidence` mirror the content payload. `prediction_extraction` events carry **neither** — that module extracts a prediction ledger and is not scored.
+- `content` is the module's findings JSON: a shared envelope (`module`, `version`, `score` + `confidence` except on prediction_extraction, mandatory `auditor_caveats[]` — what this scan could not determine) plus per-module finding arrays in which **every finding carries a verbatim `evidence_quote`** from the audited text. A finding that cannot quote the words it is about does not exist. A deduplicated top-level `evidence_quotes[]` index rides beside the findings.
+- **Auditor identity tags**: `["auditor", "<model|human|pipeline|consensus>", "<id>"]`, plus repeatable `["auditor-constituent", "<kind>", "<id>"]` for pipeline/consensus auditors and an optional `["auditor-manifest", "<sha256>"]` (hash of the orchestration config: prompt set, weights, versions). Human auditors additionally carry an indexed `["p", "<pubkey>", "", "auditor"]`. The auditor tags record what *produced* the result; the signing pubkey records who *published* it. Human and machine auditors use identical wire shapes.
+- **Firewall:** an audit module result scores craft under a published methodology — never a claim's truth. It is a different aggregation signal from kind 30051 (FactCheck — a truth verdict) and kind 30054 (Assessment — a personal stance); consumers MUST NOT merge them. Audit kinds never carry `stance`, `rating-value`, or `L`/`l` assessment labels; 30051/30054 never carry `score`/`confidence`/`ceiling`.
+- Multi-letter tags (`module-version`, `run-at`, `score`, `confidence`, `auditor`, …) are not relay-indexed; standard queries filter on `#x` / `#a` / `#t` / `#p` + `kinds`, everything else client-side.
+
+## Kind 30057 — AggregateAudit
+
+Addressable. The combined article audit: per-module contributions under documented weights, capped by a **knowability ceiling** — the maximum score achievable given how verifiable the artifact's claims are in principle, so careful work on hard-to-verify topics is not penalized and easy topics cannot coast.
+
+```jsonc
+{
+  "kind": 30057,
+  "tags": [
+    ["d", "agg:<sha256(article_hash + '|' + auditor_id + '|' + run_at).slice(0,16)>"],
+    ["x", "<article-hash>"],
+    ["a", "30023:<capturer-pubkey>:<article-d>", "<relay-hint>"],
+    ["r", "<article-url-verbatim>"],
+    ["i", "<normalized-url>"], ["k", "web"],
+    ["run-at", "2026-06-11T20:14:05Z"],
+    ["score", "80"],                         // final, post-ceiling
+    ["raw-score", "85.4"],
+    ["ceiling", "80"],
+    ["ceiling-binding", "true"],             // present ONLY when raw > ceiling
+    ["ceiling-source", "heuristic:source-quality/1.0"],
+    ["confidence", "0.71"],
+    ["a", "30056:<auditor-pubkey>:<mod-d>", "<relay-hint>", "source_quality"],  // ×N modules
+    ["e", "<30056-event-id>", "<relay-hint>", "source_quality"],   // optional convenience
+    ["e", "<prior-30057-event-id>", "", "supersedes"],             // optional
+    ["e", "<dispute-event-id>", "", "resolves-dispute"],           // optional
+    ["auditor", "pipeline", "xray-auditor/0.1.0/anthropic/claude-sonnet-4-6"],
+    ["auditor-constituent", "model", "anthropic/claude-sonnet-4-6"],
+    ["client", "<client>"]
+  ],
+  "content": "{ \"module_contributions\": [...], \"knowability_notes\": \"...\", \"model_estimated_ceiling\": null, \"top_strengths\": [...], \"top_concerns\": [...] }"
+}
+```
+
+- The `d` MUST be recomputable from the event's own tags: `agg:` + the first 16 hex of SHA-256 over `<x> | <auditor id> | <run-at>`, where the auditor id is the `auditor` tag's third slot. The 30056 time-series constraint applies: every run is a new `d`; nothing overwrites.
+- **Ceiling semantics:** the reference aggregation sets `score = min(raw-score, ceiling)`; `score` MUST NOT exceed either `raw-score` or `ceiling` (pipeline-level degradation MAY lower it further). `ceiling-binding` is present only when `raw-score > ceiling` — presence is the signal. `ceiling-source` MUST state the ceiling's provenance: `heuristic:<name>/<version>` (deterministically recomputable from the referenced module results — the reference implementation's canonical source for pipeline runs), `model` (the auditing model's judgment — calibration runs), `module:<coordinate>` (a dedicated knowability module), or `human`. `model_estimated_ceiling` in the content is advisory and never binds.
+- **Module references are `a` coordinates first** (role-marked with the module name; durable across idempotent republish), with `e` ids as optional convenience. The weights publish inside `module_contributions`, so the aggregation is auditable from the event alone: weighted sum over present modules, renormalized, capped at the ceiling.
+- **Supersession is a forward reference:** a newer audit `e`-tags its predecessor with role `supersedes` (and role `resolves-dispute` when it answers an upheld challenge). The superseded audit is never edited and remains visible; consumers derive lineage by querying forward references.
+- **Disagreement is data:** multiple 30057s for the same `x` from different auditors are siblings. Consumers MUST NOT average them into a single consensus number; surface the spread.
+- A score SHOULD never render without its confidence, and an aggregate never without its ceiling context — the wire carries both precisely so displays have no excuse.
+- The 30056 firewall clause applies identically: consumers MUST NOT merge aggregate audit scores with 30051 verdicts or 30054 stances.
+
 ## Kind 30023 — `responds-to` tag (extension)
 
 A long-form article (kind 30023) MAY declare that it responds to one or more other pieces of content. Each response is a separate `responds-to` tag:
@@ -366,6 +442,7 @@ A client wishing to display all metadata for a URL SHOULD issue these filters in
 ```jsonc
 [
   { "kinds": [30040, 30050, 30051, 30052, 30054, 30055], "#r": ["<url>"], "limit": 200 },
+  { "kinds": [30056, 30057], "#r": ["<url>"], "limit": 100 },
   { "kinds": [9802], "#r": ["<url>"], "limit": 100 },
   { "kinds": [1111], "#i": ["<url>"], "limit": 200 },
   { "kinds": [1985], "#r": ["<url>"], "limit": 100 },
@@ -383,6 +460,8 @@ Other standard queries:
 { "kinds": [30040, 30054], "#p": ["<entity-pubkey>"], "limit": 200 }   // claims about an entity + their assessments
 { "kinds": [30054, 30055], "#a": ["30040:<pubkey>:<d>"], "limit": 100 } // judgments + links targeting one claim
 { "kinds": [30054], "#l": ["misleading"], "limit": 100 }                // everything labeled `misleading`
+{ "kinds": [30056, 30057], "#x": ["<article-hash>"], "limit": 100 }     // every audit of this exact text
+{ "kinds": [30057], "#t": ["monetary-policy"], "limit": 100 }           // aggregate audits on a beat
 ```
 
 A client wishing to display helpfulness aggregates for a set of metadata events SHOULD then issue a follow-up `#a` query against kind 9803 keyed by the addressable coordinates of those events.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -978,6 +978,14 @@ Implementation slices 13.1+ are in progress.
   ledger, `beats-v1` vocabulary + alias normalizer, `calibration-v1`
   math (logged, not activated), auditor-kind-parity tests;
   three-lens adversarial review (7 confirmed findings fixed). — #62
+- ✅ **13.2** Wire audit core — `buildModuleResultEvent` (30056) +
+  `buildAggregateAuditEvent` (30057) with pure null-on-invalid
+  parsers (findings schema-validated before building — never sign
+  what you haven't verified; firewall held by construction: no
+  assessment vocabulary emitted), the `epistemicAuditing` flag
+  (default off), NIP_DRAFT §30056/§30057 incl. the canonical-hash
+  `x` tag and the RQ5 time-series `d` constraint, CHANGELOG
+  wire-change callout. — #63
 
 ---
 

--- a/src/shared/audit/builders.js
+++ b/src/shared/audit/builders.js
@@ -1,0 +1,518 @@
+// X-Ray — audit wire builders + parsers, kinds 30056/30057 (Phase 13,
+// slice 13.2).
+//
+// The Phase-11 builder contract, exactly: each builder returns
+// `{event, body, dTag}` with an unsigned NIP-01 event, deterministic
+// `d` recomputable by hand from the event's own public tags, and
+// throw-on-invalid inputs with greppable messages. Parsers are pure
+// and return null on structurally unusable events.
+//
+// Wire shapes: docs/EPISTEMIC_AUDIT_DESIGN.md §"Wire shapes". The
+// audit/assessment FIREWALL is enforced here in code: audit events
+// never carry `stance`, `rating-value`, or `L`/`l` assessment-label
+// tags — and the builders only emit the vocabulary below, so the
+// firewall holds by construction.
+//
+// `d`-scheme constraint (RQ5, draft-NIP normative): audit-bearing
+// kinds carry methodology version and/or run identity in `d` — at the
+// same `d`, relays keep only the latest event per (pubkey, kind, d),
+// so a reused `d` would silently drop the prior audit. Supersession is
+// expressed exclusively through explicit `e` references, never relay
+// replacement.
+
+import { normalize } from '../metadata/url-normalizer.js';
+import { MODULE_NAMES, validateFindings } from './findings-schemas.js';
+
+const KIND_MODULE_RESULT = 30056;
+const KIND_AGGREGATE_AUDIT = 30057;
+
+export const AUDITOR_KINDS = Object.freeze(['model', 'human', 'pipeline', 'consensus']);
+
+// ceiling-source closed grammar (RQ2; NIP-normative): the versioned
+// deterministic heuristic (the pipeline default), the auditing model's
+// judgment (calibration runs), a dedicated knowability module's result
+// coordinate, or a human.
+const CEILING_SOURCE_HEURISTIC_RE = /^heuristic:[a-z0-9-]+\/\d+\.\d+(\.\d+)?$/;
+
+export function isValidCeilingSource(value) {
+    if (typeof value !== 'string') return false;
+    if (value === 'model' || value === 'human') return true;
+    if (CEILING_SOURCE_HEURISTIC_RE.test(value)) return true;
+    if (value.startsWith('module:') && COORD_RE.test(value.slice('module:'.length))) return true;
+    return false;
+}
+
+function nowSeconds() {
+    return Math.floor(Date.now() / 1000);
+}
+
+async function sha256Hex(s) {
+    const bytes = new TextEncoder().encode(s);
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function sha16(s) {
+    return (await sha256Hex(s)).slice(0, 16);
+}
+
+function tag(name, ...values) {
+    return [name, ...values.map((v) => (v === null || v === undefined ? '' : String(v)))];
+}
+
+const HASH64_RE = /^[0-9a-f]{64}$/;
+const COORD_RE = /^\d+:[0-9a-f]{64}:.+$/;
+
+function assertArticleHash(value, fn) {
+    if (typeof value !== 'string' || !HASH64_RE.test(value)) {
+        throw new Error(`${fn}: articleHash must be 64 lowercase hex (got ${value})`);
+    }
+}
+
+function assertAuditor(auditor, fn) {
+    if (!auditor || !AUDITOR_KINDS.includes(auditor.kind) || typeof auditor.id !== 'string' || !auditor.id) {
+        throw new Error(`${fn}: auditor must be {kind: ${AUDITOR_KINDS.join('|')}, id} (got ${JSON.stringify(auditor)})`);
+    }
+    if (auditor.kind === 'human' && !HASH64_RE.test(auditor.id)) {
+        throw new Error(`${fn}: a human auditor id must be a 64-hex pubkey (got ${auditor.id})`);
+    }
+}
+
+// Strict ISO-8601 — Date.parse alone is uselessly lenient (V8 accepts
+// "2026", "March 7, 2026", even pipe-bearing strings via the legacy
+// parenthesized-comment rule), and runAt both rides the wire verbatim
+// and feeds the `|`-delimited d preimage.
+const ISO8601_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+function assertRunAt(runAt, fn) {
+    if (typeof runAt !== 'string' || !ISO8601_RE.test(runAt) || Number.isNaN(Date.parse(runAt))) {
+        throw new Error(`${fn}: runAt must be an ISO-8601 timestamp string (got ${runAt})`);
+    }
+}
+
+// Beats become indexed t tags; on 30056 the module name is ALSO a t
+// tag, so an unvalidated beat that collides with a module name would
+// pollute the relay-side module filter and make the d-recompute
+// ambiguous. Beats are free-form per RQ8 (they never mint dossier
+// subjects), but they must be nonempty strings, deduplicated, and
+// never module names.
+function cleanBeats(beats, fn) {
+    if (!Array.isArray(beats)) {
+        throw new Error(`${fn}: beats must be an array of tag strings`);
+    }
+    const out = [];
+    for (const b of beats) {
+        if (typeof b !== 'string' || !b.trim()) {
+            throw new Error(`${fn}: beats entries must be nonempty strings (got ${JSON.stringify(b)})`);
+        }
+        const beat = b.trim();
+        if (MODULE_NAMES.includes(beat)) {
+            throw new Error(`${fn}: beat "${beat}" collides with a module name — module names are reserved t values on audit kinds`);
+        }
+        if (!out.includes(beat)) out.push(beat);
+    }
+    return out;
+}
+
+function assertRange(value, lo, hi, name, fn) {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < lo || value > hi) {
+        throw new Error(`${fn}: ${name} must be a number in [${lo}, ${hi}] (got ${value})`);
+    }
+}
+
+/**
+ * Auditor identity tag block, shared by every audit kind: the
+ * `auditor` tag (kind + id), repeatable `auditor-constituent`s for
+ * pipeline/consensus, an optional `auditor-manifest` (SHA-256 of the
+ * orchestration config), and — for human auditors — an indexed
+ * `["p", <pubkey>, "", "auditor"]`. The signing pubkey remains the
+ * accountability anchor; these tags record what PRODUCED the result
+ * (producer ≠ publisher, RQ1).
+ */
+function auditorTags({ auditor, constituents = [], manifestHash = null }, fn) {
+    assertAuditor(auditor, fn);
+    const tags = [tag('auditor', auditor.kind, auditor.id)];
+    for (const c of constituents) {
+        assertAuditor(c, `${fn} (constituent)`);
+        tags.push(tag('auditor-constituent', c.kind, c.id));
+    }
+    if (manifestHash !== null && manifestHash !== undefined) {
+        tags.push(tag('auditor-manifest', manifestHash));
+    }
+    if (auditor.kind === 'human') {
+        tags.push(tag('p', auditor.id, '', 'auditor'));
+    }
+    return tags;
+}
+
+/** Article-anchor tag block: x + optional a/r/i/k (the Phase-11 URL rule). */
+function articleTags({ articleHash, articleCoord = null, relayHint = '', articleUrl = '' }, fn) {
+    const tags = [tag('x', articleHash)];
+    if (articleCoord) {
+        if (!COORD_RE.test(articleCoord) || !articleCoord.startsWith('30023:')) {
+            throw new Error(`${fn}: articleCoord must be a 30023:pubkey:d coordinate (got ${articleCoord})`);
+        }
+        tags.push(tag('a', articleCoord, relayHint));
+    }
+    if (articleUrl) {
+        tags.push(tag('r', articleUrl));            // verbatim — the #r join key
+        tags.push(tag('i', normalize(articleUrl))); // NIP-73, normalization-stable
+        tags.push(tag('k', 'web'));
+    }
+    return tags;
+}
+
+/**
+ * The vendored scorer's evidence-quote walker (collectEvidenceQuotes),
+ * verbatim semantics: walk the findings for every evidence_quote /
+ * evidence_quote_a / evidence_quote_b string, deduplicated, for the
+ * cross-module reference index that rides the content JSON.
+ */
+export function collectEvidenceQuotes(findings) {
+    const quotes = new Set();
+    function walkNode(node) {
+        if (node === null || typeof node !== 'object') return;
+        if (Array.isArray(node)) {
+            node.forEach(walkNode);
+            return;
+        }
+        for (const [k, v] of Object.entries(node)) {
+            if ((k === 'evidence_quote' || k === 'evidence_quote_a' || k === 'evidence_quote_b') && typeof v === 'string') {
+                if (v) quotes.add(v);
+            } else {
+                walkNode(v);
+            }
+        }
+    }
+    walkNode(findings);
+    return [...quotes].map((quote) => ({ quote }));
+}
+
+/** `d` for a 30056: mod:<sha16(articleHash|module|moduleVersion|runAt)>. */
+export async function deriveModuleResultDTag(articleHash, module, moduleVersion, runAt) {
+    return 'mod:' + (await sha16(`${articleHash}|${module}|${moduleVersion}|${runAt}`));
+}
+
+/** `d` for a 30057: agg:<sha16(articleHash|auditorId|runAt)>. */
+export async function deriveAggregateAuditDTag(articleHash, auditorId, runAt) {
+    return 'agg:' + (await sha16(`${articleHash}|${auditorId}|${runAt}`));
+}
+
+/**
+ * Build a kind-30056 ModuleResult event. One per (article, module,
+ * methodology version, run).
+ *
+ * The findings payload is VALIDATED against the module's derived
+ * schema before anything is built — you never sign what you haven't
+ * verified (RQ1). `score`/`confidence`/`version` are read from the
+ * validated findings (single source; the tags mirror them), so a
+ * prediction_extraction event structurally cannot carry score tags.
+ *
+ * @returns {Promise<{event: object, body: string, dTag: string}>}
+ */
+export async function buildModuleResultEvent({
+    articleHash,
+    module,
+    runAt,
+    findings,
+    evidenceQuotes = null,
+    articleCoord = null,
+    relayHint = '',
+    articleUrl = '',
+    beats = [],
+    auditor,
+    constituents = [],
+    manifestHash = null,
+    modelParams = null,
+    createdAt = nowSeconds()
+} = {}) {
+    const FN = 'buildModuleResultEvent';
+    assertArticleHash(articleHash, FN);
+    if (!MODULE_NAMES.includes(module)) {
+        throw new Error(`${FN}: module must be one of ${MODULE_NAMES.join(', ')} (got ${module})`);
+    }
+    assertRunAt(runAt, FN);
+
+    const { valid, errors } = validateFindings(module, findings);
+    if (!valid) {
+        throw new Error(`${FN}: findings failed schema validation — ${errors.map((e) => `${e.path}: ${e.message}`).join('; ')}`);
+    }
+
+    const moduleVersion = findings.version;
+    const dTag = await deriveModuleResultDTag(articleHash, module, moduleVersion, runAt);
+
+    const tags = [tag('d', dTag)];
+    tags.push(...articleTags({ articleHash, articleCoord, relayHint, articleUrl }, FN));
+    tags.push(tag('t', module));                       // the module name — indexed
+    for (const b of cleanBeats(beats, FN)) tags.push(tag('t', b));   // article beat mirrors (RQ8)
+    tags.push(tag('module-version', moduleVersion));
+    tags.push(tag('run-at', runAt));
+    if (typeof findings.score === 'number') tags.push(tag('score', findings.score));
+    if (typeof findings.confidence === 'number') tags.push(tag('confidence', findings.confidence));
+    if (modelParams) tags.push(tag('model-params', modelParams));   // LLM-variance posture
+    tags.push(...auditorTags({ auditor, constituents, manifestHash }, FN));
+    tags.push(tag('client', 'xray'));
+
+    const quotes = evidenceQuotes === null ? collectEvidenceQuotes(findings) : evidenceQuotes;
+    const body = JSON.stringify({ ...findings, evidence_quotes: quotes });
+
+    return {
+        event: { kind: KIND_MODULE_RESULT, created_at: createdAt, tags, content: body },
+        body,
+        dTag
+    };
+}
+
+/**
+ * Build a kind-30057 AggregateAudit event. One per (auditor, article,
+ * run) — the badge-surface record.
+ *
+ * Module references are `a` coordinates first (durable under
+ * idempotent republish), with `e` ids as optional convenience.
+ * Supersession and dispute resolution are FORWARD `e`-tag roles on
+ * this new event — the superseded audit is never edited (P9).
+ * `ceiling-binding` is present only when the ceiling binds.
+ *
+ * @returns {Promise<{event: object, body: string, dTag: string}>}
+ */
+export async function buildAggregateAuditEvent({
+    articleHash,
+    runAt,
+    finalScore,
+    rawScore,
+    ceiling,
+    ceilingSource,
+    confidence,
+    knowabilityNotes = '',
+    modelEstimatedCeiling = null,
+    moduleContributions = [],
+    topStrengths = [],
+    topConcerns = [],
+    articleCoord = null,
+    relayHint = '',
+    articleUrl = '',
+    beats = [],
+    supersedesEventId = null,
+    resolvesDisputeEventId = null,
+    auditor,
+    constituents = [],
+    manifestHash = null,
+    createdAt = nowSeconds()
+} = {}) {
+    const FN = 'buildAggregateAuditEvent';
+    assertArticleHash(articleHash, FN);
+    assertRunAt(runAt, FN);
+    assertAuditor(auditor, FN);
+    assertRange(finalScore, 0, 100, 'finalScore', FN);
+    assertRange(rawScore, 0, 100, 'rawScore', FN);
+    assertRange(ceiling, 0, 100, 'ceiling', FN);
+    assertRange(confidence, 0, 1, 'confidence', FN);
+    if (!isValidCeilingSource(ceilingSource)) {
+        throw new Error(`${FN}: ceilingSource must be "heuristic:<name>/<version>", "model", "module:<coordinate>", or "human" — the wire never publishes a ceiling without valid provenance (RQ2; got ${ceilingSource})`);
+    }
+    // The NIP's ceiling semantics: score = min(raw, ceiling). Tolerate
+    // float dust but never an internally contradictory event.
+    if (finalScore > ceiling + 1e-9 || finalScore > rawScore + 1e-9) {
+        throw new Error(`${FN}: finalScore must not exceed min(rawScore, ceiling) — score = min(raw, ceiling) is the wire semantics (got final=${finalScore}, raw=${rawScore}, ceiling=${ceiling})`);
+    }
+    if (modelEstimatedCeiling !== null) {
+        assertRange(modelEstimatedCeiling, 0, 100, 'modelEstimatedCeiling', FN);
+    }
+    for (const c of moduleContributions) {
+        if (!MODULE_NAMES.includes(c.module)) {
+            throw new Error(`${FN}: contribution module must be one of ${MODULE_NAMES.join(', ')} (got ${c.module})`);
+        }
+        if (!c.coord || !COORD_RE.test(c.coord) || !c.coord.startsWith(`${KIND_MODULE_RESULT}:`)) {
+            throw new Error(`${FN}: contribution coord must be a 30056 coordinate (got ${c.coord})`);
+        }
+        // null is the sanctioned unscored/failed-module marker; undefined
+        // is a caller bug and throws via assertRange's typeof check.
+        if (c.score !== null) assertRange(c.score, 0, 100, `contribution score (${c.module})`, FN);
+        assertRange(c.confidence, 0, 1, `contribution confidence (${c.module})`, FN);
+        assertRange(c.weight, 0, 1, `contribution weight (${c.module})`, FN);
+    }
+
+    const dTag = await deriveAggregateAuditDTag(articleHash, auditor.id, runAt);
+    const ceilingBinding = rawScore > ceiling;
+
+    const tags = [tag('d', dTag)];
+    tags.push(...articleTags({ articleHash, articleCoord, relayHint, articleUrl }, FN));
+    for (const b of cleanBeats(beats, FN)) tags.push(tag('t', b));
+    tags.push(tag('run-at', runAt));
+    tags.push(tag('score', finalScore));               // final, post-ceiling
+    tags.push(tag('raw-score', rawScore));
+    tags.push(tag('ceiling', ceiling));
+    if (ceilingBinding) tags.push(tag('ceiling-binding', 'true'));
+    tags.push(tag('ceiling-source', ceilingSource));
+    tags.push(tag('confidence', confidence));
+    for (const c of moduleContributions) {
+        tags.push(tag('a', c.coord, relayHint, c.module));            // durable refs
+    }
+    for (const c of moduleContributions) {
+        if (c.eventId) tags.push(tag('e', c.eventId, relayHint, c.module));   // optional convenience
+    }
+    if (supersedesEventId) tags.push(tag('e', supersedesEventId, '', 'supersedes'));
+    if (resolvesDisputeEventId) tags.push(tag('e', resolvesDisputeEventId, '', 'resolves-dispute'));
+    tags.push(...auditorTags({ auditor, constituents, manifestHash }, FN));
+    tags.push(tag('client', 'xray'));
+
+    const body = JSON.stringify({
+        module_contributions: moduleContributions.map((c) => ({
+            module: c.module,
+            score: c.score,
+            confidence: c.confidence,
+            weight: c.weight,
+            ref: c.coord
+        })),
+        knowability_notes: knowabilityNotes,
+        model_estimated_ceiling: modelEstimatedCeiling,   // advisory (RQ2); never binds
+        top_strengths: topStrengths,
+        top_concerns: topConcerns
+    });
+
+    return {
+        event: { kind: KIND_AGGREGATE_AUDIT, created_at: createdAt, tags, content: body },
+        body,
+        dTag
+    };
+}
+
+// --- parsers -------------------------------------------------------------------
+
+function firstTag(tags, name) {
+    const t = tags.find((x) => x[0] === name);
+    return t ? t[1] : '';
+}
+
+function parseAuditorBlock(tags) {
+    const a = tags.find((x) => x[0] === 'auditor');
+    if (!a || !AUDITOR_KINDS.includes(a[1]) || !a[2]) return null;
+    return {
+        auditor: { kind: a[1], id: a[2] },
+        constituents: tags.filter((x) => x[0] === 'auditor-constituent' && x[1] && x[2])
+            .map((x) => ({ kind: x[1], id: x[2] })),
+        manifestHash: firstTag(tags, 'auditor-manifest') || null
+    };
+}
+
+function numberOrNull(raw) {
+    if (raw === '') return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Parse a kind-30056 event. Pure; returns null when structurally
+ * unusable (wrong kind, missing d/x/module/version/run-at or auditor,
+ * unparseable content). Soft-degrades everything else.
+ */
+export function parseModuleResultEvent(event) {
+    if (!event || event.kind !== KIND_MODULE_RESULT) return null;
+    const tags = event.tags || [];
+    const id = firstTag(tags, 'd');
+    const articleHash = firstTag(tags, 'x');
+    const moduleVersion = firstTag(tags, 'module-version');
+    const runAt = firstTag(tags, 'run-at');
+    const auditorBlock = parseAuditorBlock(tags);
+    if (!id || !articleHash || !moduleVersion || !runAt || !auditorBlock) return null;
+
+    let findings;
+    try { findings = JSON.parse(event.content); } catch (_) { return null; }
+    if (!findings || typeof findings !== 'object' || Array.isArray(findings)) return null;
+
+    // Module identity: the content envelope's const-checked
+    // `findings.module` is authoritative (t-tag ORDER is not specified
+    // by NIP-01, so first-t-match would mis-bucket third-party events
+    // whose beat tags precede the module tag). The t tag must agree
+    // when it identifies a module — a mis-tagged event is structurally
+    // untrustworthy, not soft-degradable.
+    const contentModule = typeof findings.module === 'string' && MODULE_NAMES.includes(findings.module)
+        ? findings.module : '';
+    const tValues = tags.filter((x) => x[0] === 't').map((x) => x[1]);
+    const tModule = tValues.find((v) => MODULE_NAMES.includes(v)) || '';
+    const module = contentModule || tModule;
+    if (!module) return null;
+    if (contentModule && tModule && contentModule !== tModule) return null;
+
+    const articleA = tags.find((x) => x[0] === 'a' && String(x[1]).startsWith('30023:'));
+    return {
+        id,
+        articleHash,
+        module,
+        moduleVersion,
+        runAt,
+        score: numberOrNull(firstTag(tags, 'score')),
+        confidence: numberOrNull(firstTag(tags, 'confidence')),
+        modelParams: firstTag(tags, 'model-params') || null,
+        ...auditorBlock,
+        articleCoord: (articleA && articleA[1]) || null,
+        url: firstTag(tags, 'r') || null,
+        beats: tValues.filter((v) => v !== module),
+        findings,
+        evidenceQuotes: Array.isArray(findings.evidence_quotes) ? findings.evidence_quotes : [],
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        eventId: event.id || null
+    };
+}
+
+/**
+ * Parse a kind-30057 event. Pure; null when structurally unusable.
+ * `superseded`/`disputed` lineage is derived by consumers from OTHER
+ * events' forward references — an addressable event cannot carry
+ * backpointers written after signing.
+ */
+export function parseAggregateAuditEvent(event) {
+    if (!event || event.kind !== KIND_AGGREGATE_AUDIT) return null;
+    const tags = event.tags || [];
+    const id = firstTag(tags, 'd');
+    const articleHash = firstTag(tags, 'x');
+    const runAt = firstTag(tags, 'run-at');
+    const score = numberOrNull(firstTag(tags, 'score'));
+    const ceiling = numberOrNull(firstTag(tags, 'ceiling'));
+    const ceilingSource = firstTag(tags, 'ceiling-source');
+    const auditorBlock = parseAuditorBlock(tags);
+    if (!id || !articleHash || !runAt || score === null || ceiling === null || !ceilingSource || !auditorBlock) {
+        return null;
+    }
+
+    let content = {};
+    try { content = JSON.parse(event.content) || {}; } catch (_) { /* tags carry the score story */ }
+
+    const moduleRefs = tags
+        .filter((x) => x[0] === 'a' && String(x[1]).startsWith(`${KIND_MODULE_RESULT}:`))
+        .map((x) => ({ coord: x[1], module: x[3] || null }));
+    const articleA = tags.find((x) => x[0] === 'a' && String(x[1]).startsWith('30023:'));
+    const eRole = (role) => {
+        const t = tags.find((x) => x[0] === 'e' && x[3] === role);
+        return (t && t[1]) || null;
+    };
+
+    return {
+        id,
+        articleHash,
+        runAt,
+        finalScore: score,
+        rawScore: numberOrNull(firstTag(tags, 'raw-score')),
+        ceiling,
+        ceilingBinding: firstTag(tags, 'ceiling-binding') === 'true',
+        ceilingSource,
+        confidence: numberOrNull(firstTag(tags, 'confidence')),
+        ...auditorBlock,
+        articleCoord: (articleA && articleA[1]) || null,
+        url: firstTag(tags, 'r') || null,
+        beats: tags.filter((x) => x[0] === 't').map((x) => x[1]),
+        moduleRefs,
+        supersedesEventId: eRole('supersedes'),
+        resolvesDisputeEventId: eRole('resolves-dispute'),
+        moduleContributions: Array.isArray(content.module_contributions) ? content.module_contributions : [],
+        knowabilityNotes: content.knowability_notes || '',
+        modelEstimatedCeiling: typeof content.model_estimated_ceiling === 'number' ? content.model_estimated_ceiling : null,
+        topStrengths: Array.isArray(content.top_strengths) ? content.top_strengths : [],
+        topConcerns: Array.isArray(content.top_concerns) ? content.top_concerns : [],
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        eventId: event.id || null
+    };
+}

--- a/src/shared/metadata/feature-flags.js
+++ b/src/shared/metadata/feature-flags.js
@@ -37,7 +37,15 @@ export const FLAGS_DEFAULTS = Object.freeze({
   // kind 30054 assessments, kind 30055 claim relationships, and the
   // kind-1985 label mirror. Local capture/badges/rollups/export are
   // never gated — they're the product.
-  assessmentPublishing: false
+  assessmentPublishing: false,
+
+  // Phase 13 (docs/EPISTEMIC_AUDIT_DESIGN.md): gates the PUBLISH paths
+  // for the audit kinds (30056 module results, 30057 aggregate audits,
+  // and the 30058–30061 family as their slices land). Local
+  // import/render/ledger is never gated — the Phase 11 split. Audit
+  // EXECUTION additionally requires a user-supplied API key, which is
+  // its own consent gate on top of this flag.
+  epistemicAuditing: false
 });
 
 /**

--- a/tests/audit-builders.test.mjs
+++ b/tests/audit-builders.test.mjs
@@ -1,0 +1,518 @@
+// Phase 13.2 — wire builders + parsers for kinds 30056/30057.
+// Pinned-tag-vocabulary tests (the Phase-11 idiom): the exact tag
+// shapes are wire format — anyone consuming X-Ray events depends on
+// them, so every change here is deliberate.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+import {
+    buildModuleResultEvent, buildAggregateAuditEvent,
+    parseModuleResultEvent, parseAggregateAuditEvent,
+    deriveModuleResultDTag, deriveAggregateAuditDTag,
+    collectEvidenceQuotes
+} from '../src/shared/audit/builders.js';
+
+const HASH = 'a'.repeat(64);
+const RUN_AT = '2026-06-11T20:14:00Z';
+const PIPELINE = { kind: 'pipeline', id: 'xray-auditor/0.1.0/anthropic/claude-sonnet-4-6' };
+const MODEL = { kind: 'model', id: 'anthropic/claude-sonnet-4-6' };
+const HUMAN = { kind: 'human', id: 'b'.repeat(64) };
+const URL = 'https://example.com/story?utm_source=feed';
+
+function sha16(s) {
+    return createHash('sha256').update(s, 'utf8').digest('hex').slice(0, 16);
+}
+
+function firstTag(event, name) {
+    return event.tags.find((t) => t[0] === name);
+}
+
+function tagsNamed(event, name) {
+    return event.tags.filter((t) => t[0] === name);
+}
+
+const COHERENCE_FINDINGS = {
+    module: 'internal_coherence', version: '1.0',
+    score: 62, confidence: 0.78, confidence_notes: 'clean structure',
+    auditor_caveats: ['Surface scan only.'],
+    contradictions: [{
+        type: 'numerical', claim_a: 'rose 12%', claim_b: 'nearly doubled',
+        evidence_quote_a: 'rose 12 percent', evidence_quote_b: 'nearly doubled',
+        is_dialectic_intent: false, severity: 'high'
+    }],
+    logical_gaps: []
+};
+
+const PREDICTION_FINDINGS = {
+    module: 'prediction_extraction', version: '1.0',
+    auditor_caveats: ['Horizons approximate.'],
+    predictions: [{
+        prediction: 'Rates will fall by December.', type: 'explicit',
+        hedge_level: 'confident', attributed_to: 'article_voice',
+        resolution_horizon: 'by the end of the year',
+        resolution_criteria: 'target below current on Dec 31',
+        tractability: 'publicly_resolvable',
+        evidence_quote: 'rates will come down before December'
+    }],
+    summary: { total_predictions: 1 }
+};
+
+test('30056: full tag shape', async () => {
+    const { event, body, dTag } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS,
+        articleCoord: `30023:${'c'.repeat(64)}:1234567890abcdef`,
+        relayHint: 'wss://relay.example',
+        articleUrl: URL, beats: ['monetary-policy'],
+        auditor: MODEL, modelParams: 'temperature=0'
+    });
+
+    assert.equal(event.kind, 30056);
+    assert.equal(dTag, 'mod:' + sha16(`${HASH}|internal_coherence|1.0|${RUN_AT}`),
+        'd recomputable by hand from hash|module|version|runAt');
+    assert.deepEqual(firstTag(event, 'd'), ['d', dTag]);
+    assert.deepEqual(firstTag(event, 'x'), ['x', HASH]);
+    assert.deepEqual(firstTag(event, 'a'), ['a', `30023:${'c'.repeat(64)}:1234567890abcdef`, 'wss://relay.example']);
+    // r verbatim + i normalized + k web — the Phase-11 URL rule.
+    assert.deepEqual(firstTag(event, 'r'), ['r', URL]);
+    assert.deepEqual(firstTag(event, 'i'), ['i', 'https://example.com/story']);
+    assert.deepEqual(firstTag(event, 'k'), ['k', 'web']);
+    // t carries the module name (indexed) + beat mirrors.
+    assert.deepEqual(tagsNamed(event, 't'), [
+        ['t', 'internal_coherence'],
+        ['t', 'monetary-policy']
+    ]);
+    assert.deepEqual(firstTag(event, 'module-version'), ['module-version', '1.0']);
+    assert.deepEqual(firstTag(event, 'run-at'), ['run-at', RUN_AT]);
+    assert.deepEqual(firstTag(event, 'score'), ['score', '62']);
+    assert.deepEqual(firstTag(event, 'confidence'), ['confidence', '0.78']);
+    assert.deepEqual(firstTag(event, 'model-params'), ['model-params', 'temperature=0']);
+    assert.deepEqual(firstTag(event, 'auditor'), ['auditor', 'model', MODEL.id]);
+    assert.deepEqual(firstTag(event, 'client'), ['client', 'xray']);
+
+    // Content = findings + the deduplicated evidence-quote index.
+    const content = JSON.parse(body);
+    assert.equal(content.score, 62);
+    assert.deepEqual(content.evidence_quotes,
+        [{ quote: 'rose 12 percent' }, { quote: 'nearly doubled' }]);
+
+    // FIREWALL: no assessment vocabulary, ever. And no p tag for
+    // non-human auditors — a model id is not a pubkey.
+    for (const name of ['stance', 'rating-value', 'L', 'l', 'p']) {
+        assert.equal(firstTag(event, name), undefined, `this event must not carry ${name}`);
+    }
+});
+
+test('30056: invalid findings never build — you never sign what you have not verified (RQ1)', async () => {
+    const broken = structuredClone(COHERENCE_FINDINGS);
+    broken.contradictions[0].evidence_quote_a = '';
+    await assert.rejects(buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: broken, auditor: MODEL
+    }), /failed schema validation/);
+
+    await assert.rejects(buildModuleResultEvent({
+        articleHash: HASH, module: 'not_a_module', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL
+    }), /module must be one of/);
+
+    await assert.rejects(buildModuleResultEvent({
+        articleHash: 'short', module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL
+    }), /articleHash must be 64 lowercase hex/);
+
+    await assert.rejects(buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: 'yesterday-ish',
+        findings: COHERENCE_FINDINGS, auditor: MODEL
+    }), /runAt must be an ISO-8601/);
+
+    // Date.parse alone is lenient — strict ISO-8601 is the contract
+    // (runAt feeds the |-delimited d preimage).
+    for (const sloppy of ['2026', 'March 7, 2026', '2026-06-11', 'Jun 11 2026 (x|y)']) {
+        await assert.rejects(buildModuleResultEvent({
+            articleHash: HASH, module: 'internal_coherence', runAt: sloppy,
+            findings: COHERENCE_FINDINGS, auditor: MODEL
+        }), /runAt must be an ISO-8601/, `must reject: ${sloppy}`);
+    }
+});
+
+test('30056: beats are validated — module-name collisions, empties, dupes never reach the wire', async () => {
+    const base = {
+        articleHash: HASH, module: 'omission', runAt: RUN_AT, auditor: MODEL,
+        findings: {
+            module: 'omission', version: '1.0', score: 70, confidence: 0.8,
+            auditor_caveats: ['x'],
+            topic_summary: 't', voices_directly_quoted: [], voices_paraphrased_only: [],
+            voices_referenced_but_silent: [], natural_stakeholder_set: [],
+            voices_expected_but_absent: [], speaks_for_instances: []
+        }
+    };
+    await assert.rejects(buildModuleResultEvent({ ...base, beats: ['source_quality'] }),
+        /collides with a module name/,
+        'a beat equal to a module name would poison the indexed module filter');
+    await assert.rejects(buildModuleResultEvent({ ...base, beats: [''] }),
+        /nonempty strings/);
+    await assert.rejects(buildModuleResultEvent({ ...base, beats: [{ a: 1 }] }),
+        /nonempty strings/);
+
+    const { event } = await buildModuleResultEvent({ ...base, beats: ['ai', 'ai', 'banking'] });
+    assert.deepEqual(tagsNamed(event, 't'), [['t', 'omission'], ['t', 'ai'], ['t', 'banking']],
+        'deduped, module t first');
+});
+
+test('30056: score 0 / confidence 0 ride the wire and round-trip (falsy-safe)', async () => {
+    const zeroed = structuredClone(COHERENCE_FINDINGS);
+    zeroed.score = 0;
+    zeroed.confidence = 0;
+    const { event } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: zeroed, auditor: MODEL
+    });
+    assert.deepEqual(firstTag(event, 'score'), ['score', '0']);
+    assert.deepEqual(firstTag(event, 'confidence'), ['confidence', '0']);
+    const parsed = parseModuleResultEvent({ ...event, pubkey: 'e'.repeat(64), id: '9'.repeat(64) });
+    assert.equal(parsed.score, 0, 'a zero score is a maximally failing dimension, not a missing one');
+    assert.equal(parsed.confidence, 0);
+});
+
+test('30056: findings carrying their own evidence_quotes are overwritten by the collected index', async () => {
+    const withStale = structuredClone(COHERENCE_FINDINGS);
+    withStale.evidence_quotes = [{ quote: 'stale from a prior parse' }];
+    const { body } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: withStale, auditor: MODEL
+    });
+    const content = JSON.parse(body);
+    assert.deepEqual(content.evidence_quotes,
+        [{ quote: 'rose 12 percent' }, { quote: 'nearly doubled' }],
+        'rebuild-from-parsed must not freeze a stale index');
+
+    // The explicit override branch.
+    const { body: overridden } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL,
+        evidenceQuotes: [{ quote: 'caller-supplied', source_span: { start: 1, end: 9 } }]
+    });
+    assert.deepEqual(JSON.parse(overridden).evidence_quotes,
+        [{ quote: 'caller-supplied', source_span: { start: 1, end: 9 } }]);
+});
+
+test('30056: no articleUrl → no r/i/k on the wire, parsed.url null', async () => {
+    const { event } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL
+    });
+    for (const name of ['r', 'i', 'k']) {
+        assert.equal(firstTag(event, name), undefined, `${name} absent without a URL`);
+    }
+    const parsed = parseModuleResultEvent({ ...event, pubkey: 'e'.repeat(64), id: '8'.repeat(64) });
+    assert.equal(parsed.url, null);
+    assert.equal(parsed.manifestHash, null, 'no manifest → null, not empty string');
+});
+
+test('30056 parser: findings.module is authoritative; t-tag order cannot mis-bucket (foreign events)', async () => {
+    const { event } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL, beats: ['banking']
+    });
+    // Foreign serialization: beat t BEFORE module t — must still parse
+    // as internal_coherence with the beat intact.
+    const reordered = {
+        ...event,
+        pubkey: 'e'.repeat(64), id: '7'.repeat(64),
+        tags: [...event.tags.filter((t) => t[0] !== 't'),
+            ['t', 'banking'], ['t', 'internal_coherence']]
+    };
+    const parsed = parseModuleResultEvent(reordered);
+    assert.equal(parsed.module, 'internal_coherence');
+    assert.deepEqual(parsed.beats, ['banking']);
+
+    // No t tag at all: content envelope still identifies the module.
+    const noT = { ...event, pubkey: 'e'.repeat(64), id: '6'.repeat(64),
+        tags: event.tags.filter((t) => t[0] !== 't') };
+    assert.equal(parseModuleResultEvent(noT).module, 'internal_coherence');
+
+    // Content/t disagreement: structurally untrustworthy → null.
+    const lying = { ...event, pubkey: 'e'.repeat(64), id: '5'.repeat(64),
+        tags: [...event.tags.filter((t) => t[0] !== 't'), ['t', 'omission']] };
+    assert.equal(parseModuleResultEvent(lying), null,
+        'a mis-tagged audit is rejected, not soft-bucketed');
+
+    // Array content is not a findings object.
+    assert.equal(parseModuleResultEvent({ ...event, content: '[1,2]' }), null);
+});
+
+test('30056: prediction_extraction events carry NO score/confidence tags', async () => {
+    const { event } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'prediction_extraction', runAt: RUN_AT,
+        findings: PREDICTION_FINDINGS, auditor: MODEL
+    });
+    assert.equal(firstTag(event, 'score'), undefined);
+    assert.equal(firstTag(event, 'confidence'), undefined);
+});
+
+test('30056: human auditor gets the indexed p tag; round-trips identically (RQ3)', async () => {
+    const { event, dTag } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: HUMAN
+    });
+    assert.deepEqual(firstTag(event, 'p'), ['p', HUMAN.id, '', 'auditor']);
+
+    const parsed = parseModuleResultEvent({ ...event, pubkey: HUMAN.id, id: 'f'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.id, dTag);
+    assert.deepEqual(parsed.auditor, HUMAN);
+    assert.equal(parsed.score, 62, 'a human-scored module result carries scores like any other');
+});
+
+test('30056: deterministic d — same inputs, same d; new run, new d', async () => {
+    const args = {
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL
+    };
+    const a = await buildModuleResultEvent(args);
+    const b = await buildModuleResultEvent(args);
+    assert.equal(a.dTag, b.dTag, 'idempotent republish of the same run only');
+    const c = await buildModuleResultEvent({ ...args, runAt: '2026-06-12T08:00:00Z' });
+    assert.notEqual(a.dTag, c.dTag, 're-runs accumulate — never overwrite (the RQ5 constraint)');
+
+    const v2 = structuredClone(COHERENCE_FINDINGS);
+    v2.version = '1.1';
+    const d = await buildModuleResultEvent({ ...args, findings: v2 });
+    assert.notEqual(a.dTag, d.dTag, 'a methodology bump is a new d — prior audits persist');
+});
+
+test('30056: parser round-trips builder output; pipeline constituents survive', async () => {
+    const { event, dTag } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, articleUrl: URL,
+        auditor: PIPELINE, constituents: [MODEL], manifestHash: 'd'.repeat(64)
+    });
+    const parsed = parseModuleResultEvent({ ...event, pubkey: 'e'.repeat(64), id: '1'.repeat(64) });
+    assert.ok(parsed, 'parser must accept its own builder output');
+    assert.equal(parsed.id, dTag);
+    assert.equal(parsed.articleHash, HASH);
+    assert.equal(parsed.module, 'internal_coherence');
+    assert.equal(parsed.moduleVersion, '1.0');
+    assert.equal(parsed.runAt, RUN_AT);
+    assert.equal(parsed.confidence, 0.78);
+    assert.deepEqual(parsed.auditor, PIPELINE);
+    assert.deepEqual(parsed.constituents, [MODEL]);
+    assert.equal(parsed.manifestHash, 'd'.repeat(64));
+    assert.equal(parsed.findings.contradictions.length, 1);
+    assert.equal(parsed.evidenceQuotes.length, 2);
+    assert.equal(parsed.url, URL);
+
+    // d is verifiable from the parsed event's own tags.
+    assert.equal(await deriveModuleResultDTag(parsed.articleHash, parsed.module, parsed.moduleVersion, parsed.runAt),
+        parsed.id);
+});
+
+test('30056 parser: null on wrong kind, missing anchors, or unparseable content', async () => {
+    const { event } = await buildModuleResultEvent({
+        articleHash: HASH, module: 'internal_coherence', runAt: RUN_AT,
+        findings: COHERENCE_FINDINGS, auditor: MODEL
+    });
+    assert.equal(parseModuleResultEvent(null), null);
+    assert.equal(parseModuleResultEvent({ ...event, kind: 30054 }), null);
+    assert.equal(parseModuleResultEvent({ ...event, content: 'not json {' }), null);
+    for (const name of ['d', 'x', 'module-version', 'run-at', 'auditor']) {
+        const stripped = { ...event, tags: event.tags.filter((t) => t[0] !== name) };
+        assert.equal(parseModuleResultEvent(stripped), null, `must be null without ${name}`);
+    }
+    // Stripping 't' alone does NOT null — the content envelope still
+    // carries the authoritative module (see the foreign-events test).
+    const noT = { ...event, tags: event.tags.filter((t) => t[0] !== 't') };
+    assert.ok(parseModuleResultEvent(noT));
+});
+
+function aggregateArgs(overrides = {}) {
+    return {
+        articleHash: HASH, runAt: '2026-06-11T20:14:05Z',
+        finalScore: 64.5, rawScore: 71.2, ceiling: 80,
+        ceilingSource: 'heuristic:source-quality/1.0', confidence: 0.71,
+        knowabilityNotes: 'Ceiling derived from sourcing pattern: 50% named.',
+        moduleContributions: [
+            { module: 'internal_coherence', coord: `30056:${'e'.repeat(64)}:mod:1111111111111111`, eventId: '2'.repeat(64), score: 62, confidence: 0.78, weight: 0.10 },
+            { module: 'source_quality', coord: `30056:${'e'.repeat(64)}:mod:2222222222222222`, score: 58, confidence: 0.8, weight: 0.20 }
+        ],
+        topStrengths: ['headline_body_fidelity: 88'],
+        topConcerns: ['source_quality: 58'],
+        articleUrl: URL, beats: ['monetary-policy'],
+        auditor: PIPELINE, constituents: [MODEL],
+        ...overrides
+    };
+}
+
+test('30057: full tag shape, ceiling-binding only when binding', async () => {
+    const { event, body, dTag } = await buildAggregateAuditEvent(aggregateArgs());
+
+    assert.equal(event.kind, 30057);
+    assert.equal(dTag, 'agg:' + sha16(`${HASH}|${PIPELINE.id}|2026-06-11T20:14:05Z`),
+        'd recomputable from hash|auditor-id|runAt');
+    assert.deepEqual(firstTag(event, 'score'), ['score', '64.5']);
+    assert.deepEqual(firstTag(event, 'raw-score'), ['raw-score', '71.2']);
+    assert.deepEqual(firstTag(event, 'ceiling'), ['ceiling', '80']);
+    assert.equal(firstTag(event, 'ceiling-binding'), undefined,
+        'raw 71.2 < ceiling 80 — not binding, tag absent (presence IS the signal)');
+    assert.deepEqual(firstTag(event, 'ceiling-source'), ['ceiling-source', 'heuristic:source-quality/1.0']);
+    assert.deepEqual(firstTag(event, 'confidence'), ['confidence', '0.71']);
+
+    // Module refs: a coordinates first (durable), role-marked; e optional.
+    const moduleAs = tagsNamed(event, 'a').filter((t) => t[1].startsWith('30056:'));
+    assert.equal(moduleAs.length, 2);
+    assert.equal(moduleAs[0][3], 'internal_coherence');
+    const moduleEs = tagsNamed(event, 'e').filter((t) => t[3] === 'internal_coherence');
+    assert.deepEqual(moduleEs, [['e', '2'.repeat(64), '', 'internal_coherence']]);
+
+    const content = JSON.parse(body);
+    assert.equal(content.module_contributions.length, 2);
+    assert.equal(content.module_contributions[0].ref, `30056:${'e'.repeat(64)}:mod:1111111111111111`);
+    assert.equal(content.model_estimated_ceiling, null, 'advisory field present, null by default (RQ2)');
+    assert.deepEqual(content.top_concerns, ['source_quality: 58']);
+
+    for (const name of ['stance', 'rating-value', 'L', 'l', 'p']) {
+        assert.equal(firstTag(event, name), undefined, `this event must not carry ${name}`);
+    }
+    assert.deepEqual(tagsNamed(event, 't'), [['t', 'monetary-policy']], 'beat rides 30057 too');
+});
+
+test('30057: ceiling-binding present iff raw > ceiling — and it parses back', async () => {
+    const binding = await buildAggregateAuditEvent(aggregateArgs({ rawScore: 85, finalScore: 80 }));
+    assert.deepEqual(firstTag(binding.event, 'ceiling-binding'), ['ceiling-binding', 'true']);
+    const parsedBinding = parseAggregateAuditEvent({ ...binding.event, pubkey: 'e'.repeat(64), id: 'a'.repeat(64) });
+    assert.equal(parsedBinding.ceilingBinding, true);
+    assert.equal(parsedBinding.rawScore, 85);
+
+    const notBinding = await buildAggregateAuditEvent(aggregateArgs({ rawScore: 71.2, finalScore: 71.2 }));
+    assert.equal(firstTag(notBinding.event, 'ceiling-binding'), undefined,
+        'absent when the ceiling does not bind — presence IS the signal');
+});
+
+test('30057: an internally contradictory score never builds — score = min(raw, ceiling) is wire semantics', async () => {
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ finalScore: 90, rawScore: 85, ceiling: 80 })),
+        /finalScore must not exceed min/);
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ finalScore: 75, rawScore: 70 })),
+        /finalScore must not exceed min/, 'final above raw is incoherent even under a high ceiling');
+    // Pipeline degradation below min is allowed (≤, not ==).
+    const ok = await buildAggregateAuditEvent(aggregateArgs({ finalScore: 64.5, rawScore: 71.2, ceiling: 80 }));
+    assert.ok(ok.dTag);
+});
+
+test('30057: ceiling-source closed grammar enforced (RQ2)', async () => {
+    for (const bad of ['banana', 'heuristic:', 'heuristic:source-quality', 'module:not-a-coord', '']) {
+        await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ ceilingSource: bad })),
+            /ceilingSource must be/, `must reject: ${bad}`);
+    }
+    for (const good of ['model', 'human', 'heuristic:source-quality/1.0',
+        `module:30062:${'f'.repeat(64)}:know:abc`]) {
+        const { event } = await buildAggregateAuditEvent(aggregateArgs({ ceilingSource: good }));
+        assert.deepEqual(firstTag(event, 'ceiling-source'), ['ceiling-source', good]);
+    }
+});
+
+test('30057: contribution confidence is validated; wrong-kind coords rejected', async () => {
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({
+        moduleContributions: [{ module: 'omission', coord: `30056:${'e'.repeat(64)}:mod:x`, score: 70, weight: 0.2 }]
+    })), /contribution confidence/);
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({
+        moduleContributions: [{ module: 'omission', coord: `30023:${'e'.repeat(64)}:abcd`, score: 70, confidence: 0.8, weight: 0.2 }]
+    })), /must be a 30056 coordinate/, 'a 30023 coord is not a module result');
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({
+        articleCoord: `30040:${'e'.repeat(64)}:claim_x`
+    })), /must be a 30023/, 'the article pointer must be an article');
+});
+
+test('30057: supersession/dispute-resolution are forward e-roles on the NEW event — and parse back', async () => {
+    const { event } = await buildAggregateAuditEvent(aggregateArgs({
+        supersedesEventId: '3'.repeat(64),
+        resolvesDisputeEventId: '4'.repeat(64)
+    }));
+    assert.deepEqual(tagsNamed(event, 'e').filter((t) => t[3] === 'supersedes'),
+        [['e', '3'.repeat(64), '', 'supersedes']]);
+    assert.deepEqual(tagsNamed(event, 'e').filter((t) => t[3] === 'resolves-dispute'),
+        [['e', '4'.repeat(64), '', 'resolves-dispute']]);
+
+    const parsed = parseAggregateAuditEvent({ ...event, pubkey: 'e'.repeat(64), id: 'b'.repeat(64) });
+    assert.equal(parsed.supersedesEventId, '3'.repeat(64), 'P9 lineage is consumer-facing');
+    assert.equal(parsed.resolvesDisputeEventId, '4'.repeat(64));
+
+    const plain = await buildAggregateAuditEvent(aggregateArgs());
+    const parsedPlain = parseAggregateAuditEvent({ ...plain.event, pubkey: 'e'.repeat(64), id: 'c'.repeat(64) });
+    assert.equal(parsedPlain.supersedesEventId, null);
+    assert.equal(parsedPlain.resolvesDisputeEventId, null);
+});
+
+test('30057: validation — no ceiling without provenance, ranges enforced', async () => {
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ ceilingSource: '' })),
+        /ceilingSource must be/);
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ finalScore: 101 })),
+        /finalScore must be a number in \[0, 100\]/);
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ confidence: 1.2 })),
+        /confidence must be a number in \[0, 1\]/);
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({
+        moduleContributions: [{ module: 'internal_coherence', coord: 'not-a-coord', score: 62, confidence: 0.78, weight: 0.1 }]
+    })), /contribution coord/);
+    await assert.rejects(buildAggregateAuditEvent(aggregateArgs({ auditor: { kind: 'robot', id: 'x' } })),
+        /auditor must be/);
+});
+
+test('30057: parser round-trips builder output, incl. human auditor (RQ3)', async () => {
+    const { event, dTag } = await buildAggregateAuditEvent(aggregateArgs({
+        auditor: HUMAN, constituents: []
+    }));
+    const parsed = parseAggregateAuditEvent({ ...event, pubkey: HUMAN.id, id: '5'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.id, dTag);
+    assert.equal(parsed.finalScore, 64.5);
+    assert.equal(parsed.rawScore, 71.2);
+    assert.equal(parsed.ceiling, 80);
+    assert.equal(parsed.ceilingBinding, false);
+    assert.equal(parsed.ceilingSource, 'heuristic:source-quality/1.0');
+    assert.deepEqual(parsed.auditor, HUMAN);
+    assert.equal(parsed.moduleRefs.length, 2);
+    assert.equal(parsed.moduleRefs[1].module, 'source_quality');
+    assert.equal(parsed.moduleContributions.length, 2);
+    assert.equal(parsed.modelEstimatedCeiling, null);
+    assert.equal(parsed.url, URL);
+    assert.deepEqual(parsed.beats, ['monetary-policy'], '30057 beats round-trip — dossiers read them');
+
+    assert.equal(await deriveAggregateAuditDTag(parsed.articleHash, parsed.auditor.id, parsed.runAt),
+        parsed.id, 'd verifiable from the event\'s own tags');
+});
+
+test('30057 parser: null without d/x/score/ceiling/ceiling-source/auditor', async () => {
+    const { event } = await buildAggregateAuditEvent(aggregateArgs());
+    for (const name of ['d', 'x', 'run-at', 'score', 'ceiling', 'ceiling-source', 'auditor']) {
+        const stripped = { ...event, tags: event.tags.filter((t) => t[0] !== name) };
+        assert.equal(parseAggregateAuditEvent(stripped), null, `must be null without ${name}`);
+    }
+    assert.equal(parseAggregateAuditEvent({ ...event, kind: 30051 }), null);
+});
+
+test('collectEvidenceQuotes: every array element walked, dedup, nesting, non-strings skipped', () => {
+    const quotes = collectEvidenceQuotes({
+        a: [{ evidence_quote: 'one' }, { evidence_quote: 'two' }, { evidence_quote: 'one' }],
+        b: { nested: { evidence_quote_a: 'three', evidence_quote_b: 'four' } },
+        c: [[{ evidence_quote: 'deep' }]],
+        d: { evidence_quote: '' },
+        e: { evidence_quote: 42 }
+    });
+    assert.deepEqual(quotes, [
+        { quote: 'one' }, { quote: 'two' }, { quote: 'three' },
+        { quote: 'four' }, { quote: 'deep' }
+    ]);
+});
+
+test('30057: finalScore 0 parses as 0, never as missing', async () => {
+    const { event } = await buildAggregateAuditEvent(aggregateArgs({
+        finalScore: 0, rawScore: 0, ceiling: 40, confidence: 0.6,
+        moduleContributions: []
+    }));
+    assert.deepEqual(firstTag(event, 'score'), ['score', '0']);
+    const parsed = parseAggregateAuditEvent({ ...event, pubkey: 'e'.repeat(64), id: 'd'.repeat(64) });
+    assert.ok(parsed, 'a zero score is a valid event');
+    assert.equal(parsed.finalScore, 0);
+});


### PR DESCRIPTION
Slice **13.2** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — the wire core. **Stacked on #62** (base = the 13.1 branch). ⚠️ Wire-format change: two new event kinds (CHANGELOG callout included).

## What's in it

- **`buildModuleResultEvent` (30056) + `buildAggregateAuditEvent` (30057)** — the Phase-11 `{event, body, dTag}` contract. Findings are **schema-validated before building** (RQ1's never-sign-unverified at the earliest possible point); score/confidence/version are read from the validated findings so tags can never disagree with content; a `prediction_extraction` event structurally cannot carry score tags. The audit/assessment **firewall holds by construction** — closed tag vocabulary, pinned by tests (`stance`/`rating-value`/`L`/`l` never emitted).
- **Builder invariants** (all throw-on-invalid, greppable): `finalScore ≤ min(rawScore, ceiling)`; `ceiling-source` closed grammar (`heuristic:<name>/<ver>` | `model` | `module:<coord>` | `human`, RQ2); strict ISO-8601 `runAt` (bare `Date.parse` accepts pipe-bearing strings that would corrupt the `|`-delimited `d` preimage); beats validated — a beat colliding with a module name would poison the relay-indexed module filter; kind-pinned coordinates.
- **Pure null-on-invalid parsers** — `findings.module` (const-checked in the envelope) is the authoritative module discriminator since NIP-01 doesn't specify t-tag order; tag/content disagreement rejects the event; supersession/dispute lineage roles round-trip; human auditors round-trip identically (RQ3).
- **`epistemicAuditing` flag** (default off) — publish paths only, the Phase 11 split.
- **NIP_DRAFT §30056/§30057** — canonical `x`-tag hash spec, the normative RQ5 time-series `d` constraint, ceiling provenance grammar, forward-reference supersession, MUST-NOT-merge firewall, disagreement-is-data. Found + fixed: the illustrative 30057 example was internally inconsistent (`ceiling-binding` with raw < ceiling) in both the NIP and the design note.

## Verification

- 23 new tests; full suite **749 pass / 0 fail**; build + lint clean.
- Three-lens adversarial review (wire-fidelity / correctness / test-adequacy), every finding adversarially verified: **19 confirmed, 0 refuted, all fixed pre-PR** — including nine mutation-verified test holes (zero-score falsy drops, unparsed lineage, first-array-element walker masking). Details in the JOURNAL entry.

Next: 13.3 — the ledger + governance kinds (30058–30061) and dossier math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)