### PR TITLE
feat(audit): Phase 13.3 — ledger + governance kinds 30058–30061, dossier math

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,25 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
-- **Phase 13.1/13.2 — epistemic-audit foundation** (flag-gated,
+- **Phase 13.1–13.3 — epistemic-audit foundation** (flag-gated,
   default off; `docs/EPISTEMIC_AUDIT_DESIGN.md`). The audit model
   layer (`src/shared/audit/`): canonical article hash (byte-parity
   with the vendored scorer's normalization), eight derived
   findings-schema validators, the `xray-audits` IndexedDB ledger,
-  beats-v1 vocabulary, calibration-v1 math (logged, not activated) —
-  and the wire core: builders + parsers for **two new event kinds**,
-  30056 AuditModuleResult and 30057 AggregateAudit, specified in
-  `docs/NIP_DRAFT.md`. **Wire-format note for event consumers:** the
-  new kinds carry the indexed `x` tag (SHA-256 of normalized article
-  markdown, NIP-94 precedent) as their article anchor; audit events
-  never carry assessment vocabulary (`stance`, `L`/`l` labels) and
-  MUST NOT be merged with 30051 fact-checks or 30054 assessments.
-  Nothing publishes until the `epistemicAuditing` flag (default
-  `false`) is enabled; no UI ships in these slices.
+  beats-v1 vocabulary, calibration-v1 math (logged, not activated),
+  dossier rollup math (published shrinkage) — and the wire layer:
+  builders + parsers for **six new event kinds** specified in
+  `docs/NIP_DRAFT.md`: 30056 AuditModuleResult, 30057 AggregateAudit,
+  30058 PredictionEntry, 30059 PredictionResolution, 30060
+  DossierSnapshot, 30061 AuditDispute (wire-format-only — no filing
+  UI or adjudication runtime). **Wire-format note for event
+  consumers:** the audit kinds carry the indexed `x` tag (SHA-256 of
+  normalized article markdown, NIP-94 precedent) as their article
+  anchor; audit events never carry assessment vocabulary (`stance`,
+  `L`/`l` labels) and MUST NOT be merged with 30051 fact-checks or
+  30054 assessments; 30059 resolutions and 30061 disputes require
+  typed evidence. Nothing publishes until the `epistemicAuditing`
+  flag (default `false`) is enabled; no UI ships in these slices.
 
 ### Fixed
 

--- a/docs/EPISTEMIC_AUDIT_DESIGN.md
+++ b/docs/EPISTEMIC_AUDIT_DESIGN.md
@@ -559,7 +559,7 @@ event; the superseded audit is never edited.
     //  (the 30040 claim-id discipline, exactly) — so re-extraction of the
     //  same restated text converges on one record
     ["x", "<article_hash>"],
-    ["a", "30023:<capturer-pubkey>:<article-d>", "<relay-hint>"],
+    ["a", "30023:<capturer-pubkey>:<article-d>", "<relay-hint>"],   // optional article pointer
     ["a", "30040:<pubkey>:<claim-d>", "<relay-hint>", "claim"],   // optional — the atomized claim
     ["r", "<article-r-verbatim>"],
     ["i", "<normalized-url>"], ["k", "web"],
@@ -598,14 +598,14 @@ resolution criteria ride the `criteria` tag, not the content.
   "kind": 30059,
   "tags": [
     ["d", "res:<sha16(prediction_coordinate)>"],   // one per (resolver, prediction); edits replace
-    ["a", "30058:<extractor-pubkey>:<pred-d>", "<relay-hint>"],
-    ["e", "<30058-event-id>", "<relay-hint>"],     // optional
+    ["a", "30058:<extractor-pubkey>:<pred-d>", "<relay-hint>", "prediction"],
+    ["e", "<30058-event-id>", "<relay-hint>", "prediction"],   // optional
     ["x", "<article_hash>"],                        // the predicting article
     ["outcome", "false"],                           // true|false|partial|unresolvable
     ["confidence", "0.9"],
     ["resolved-at", "2027-01-15T00:00:00Z"],
     ["evidence", "url", "<url>", "<description>"],            // ×N — TYPED:
-    ["evidence", "nostr_event", "<naddr-or-nevent>", "<description>"],
+    ["evidence", "nostr_event", "<coordinate-or-event-id>", "<description>"],
     ["evidence", "document_hash", "<sha256>", "<description>"],
     ["evidence", "quote", "<verbatim text>", "<description>"],
     //  ^ all four framework evidence kinds carried (kind, value, description) —
@@ -668,8 +668,8 @@ keys; the aggregation phase owns this.
   "kind": 30061,
   "tags": [
     ["d", "dispute:<sha16(target_coordinate)>"],   // one per (filer, target)
-    ["a", "<target coordinate>", "<relay-hint>"],
-    ["e", "<target-event-id>", "<relay-hint>"],    // optional
+    ["a", "<target coordinate>", "<relay-hint>", "target"],
+    ["e", "<target-event-id>", "<relay-hint>", "target"],   // optional
     ["target-kind", "aggregate_audit"],   // module_result|aggregate_audit|prediction_resolution|claim
     ["x", "<article_hash>"],              // when the target anchors to an article
     ["status", "open"],                   // filer-asserted: open|withdrawn

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,57 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.3: the ledger kinds, and what a resolution must carry
+
+**Tags:** design
+
+Kinds 30058–30061 + `dossier.js` (slice 13.3). The calls worth a
+paper trail:
+
+- **30058 content is the prediction text and nothing else.** The
+  resolution criteria, horizon, and attribution all ride tags — so
+  the convergent `d` (`pred:<sha16(hash|norm(text))>`) is mechanically
+  recomputable from the event alone, and a re-extraction converges
+  instead of duplicating. Tempting as it was to put a richer JSON in
+  the content, every added byte would have broken `d`-recomputability.
+- **Resolutions and disputes require evidence at build time.** P3
+  applies recursively ("dispute filings, adjudications, and prediction
+  resolutions are equally evidence-bound") — so `evidence: []` throws,
+  in the builder, before anything could be signed. Likewise 30061's
+  `status` enum is just open/withdrawn: upheld/rejected are other
+  pubkeys' judgments and structurally cannot be filer-asserted.
+- **30060 enforces canonical beat slugs at build time** (RQ8):
+  `buildDossierSnapshotEvent` rejects aliases (`fed`) and unmapped
+  strings rather than normalizing silently — the caller should have
+  normalized deliberately, and a dossier minted from a typo would be
+  a permanent subject identity.
+- **Dossier math is a pure module** (`dossier.js`): same inputs, same
+  rollup, auditor-kind-blind (RQ3 pinned by test). The shrinkage
+  factor is returned with every rollup because it must be *published*,
+  not just applied (§4).
+- **The adversarial review (14 confirmed, 1 refuted-by-mutation)
+  earned its keep again.** The bug class from 13.2 recurred in a new
+  costume: typed `nostr_event` evidence emits plain `a`/`e` indexing
+  tags that are name-indistinguishable from the prediction/target
+  *reference* tags — a foreign 30061 with evidence tags serialized
+  first parsed the evidence article as the dispute target (reproduced
+  live), and the same id-confusion hit `predictionEventId`. Fix: the
+  reference `a`/`e` tags are now role-marked (`prediction`/`target`,
+  the 30055 house idiom) with evidence-excluding fallbacks for
+  foreign events. Also: the parser's attribution fallback to
+  `article_voice` would have silently booked a named source's
+  prediction against the *author's* dossier — attribution now rejects
+  like hedge does; `x` became required on 30059 (the prediction `d`
+  is a one-way hash, so an x-less resolution is invisible to article
+  queries); the nostr_event evidence value grammar is pinned to raw
+  coordinate/event-id (the three sources disagreed: naddr-or-nevent
+  vs coordinate-or-event-id vs unvalidated); and zero-article
+  dossiers went from allowed-but-unconstructible (articleCount 0
+  passed, the null median it implies threw) to explicitly never
+  published.
+
+---
+
 ## 2026-06-11 — 13.2: the wire core enforces what the design promises
 
 **Tags:** design

--- a/docs/NIP_DRAFT.md
+++ b/docs/NIP_DRAFT.md
@@ -6,7 +6,7 @@ Web Content Annotations, Fact-Checks, and Topic Trust
 
 `draft` `optional`
 
-This NIP defines ten event kinds and one tag extension that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, and epistemic-audit records (per-module surface-scan results and aggregate article audits, content-addressed to the exact text scored) — and lets readers query, rank, and surface that metadata in context.
+This NIP defines fourteen event kinds and one tag extension that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, and epistemic-audit records (per-module surface-scan results, aggregate article audits, a prediction ledger with resolutions, dossier rollup snapshots, and audit disputes — content-addressed to the exact text scored) — and lets readers query, rank, and surface that metadata in context.
 
 It composes with rather than replaces:
 
@@ -411,6 +411,133 @@ Addressable. The combined article audit: per-module contributions under document
 - A score SHOULD never render without its confidence, and an aggregate never without its ceiling context — the wire carries both precisely so displays have no excuse.
 - The 30056 firewall clause applies identically: consumers MUST NOT merge aggregate audit scores with 30051 verdicts or 30054 stances.
 
+## Kind 30058 — PredictionEntry
+
+Addressable. One testable prediction extracted from an article — the write side of the prediction ledger, the audit system's compounding long-game asset. Extracted at audit time, resolved later (possibly years later, possibly by a different auditor) via kind 30059.
+
+```jsonc
+{
+  "kind": 30058,
+  "tags": [
+    ["d", "pred:<sha256(article_hash + '|' + norm(prediction_text)).slice(0,16)>"],
+    ["x", "<article-hash>"],
+    ["a", "30023:<capturer-pubkey>:<article-d>", "<relay-hint>"],   // optional
+    ["a", "30040:<pubkey>:<claim-d>", "<relay-hint>", "claim"],     // optional — the atomized claim
+    ["r", "<article-url-verbatim>"], ["i", "<normalized-url>"], ["k", "web"],
+    ["prediction-type", "explicit"],     // explicit|implicit|conditional|negative|counterfactual
+    ["hedge", "confident"],              // confident|hedged|speculative — the calibration input
+    ["attribution", "named_source"],     // article_voice|named_source|vague_attribution
+    ["attributed-name", "<who, when named>"],          // optional
+    ["p", "<author-entity-pubkey>", "", "predicts"],   // optional, when tracked
+    ["condition", "<antecedent>"],                     // REQUIRED for conditional predictions
+    ["horizon", "by the end of the year"],
+    ["horizon-iso", "2026-12-31"],                     // optional, when computable
+    ["tractability", "publicly_resolvable"],           // publicly_resolvable|requires_private_info|ambiguous
+    ["quote", "<exact evidence quote from the article>"],
+    ["anchor", "<selector-json>"],                     // optional — W3C selector, the 30040 idiom
+    ["criteria", "<concrete, observable resolution criteria>"],
+    ["module-version", "1.0"],                         // prediction_extraction's version
+    ["auditor", "model", "anthropic/claude-sonnet-4-6"],
+    ["client", "<client>"]
+  ],
+  "content": "<the prediction text, restated clear and testable — NOTHING else>"
+}
+```
+
+- The `content` carries the prediction text and nothing else, precisely so the `d` is mechanically recomputable from the event: `pred:` + the first 16 hex of SHA-256 over `<x> | norm(content)`, where `norm` trims, collapses whitespace runs to single spaces, and lowercases (the kind-30040 claim-id discipline, exactly).
+- **The convergent `d` is deliberate**: re-extraction of the same restated text converges on one ledger record, so a resolution's `a` coordinate never retargets. Differently-phrased re-extractions mint sibling records (consumers group near-duplicates for display). The `d` includes the article hash, so a stealth-edited article's predictions are that text version's ledger.
+- `resolution_status` and any latest-resolution pointer are NOT wire fields — they derive client-side from kind-30059 events (mutable state does not belong on signed immutable records).
+- Predictions are NOT scored at extraction (no `score`/`confidence` tags, ever) — the ledger is graded by reality, via resolutions.
+- When a prediction is promoted to a kind-30040 claim, the entry carries the claim's `a` coordinate (role `claim`) and the claim SHOULD carry an `a` back-reference to this entry (role `prediction`) — lineage runs both directions.
+
+## Kind 30059 — PredictionResolution
+
+Addressable. The outcome of one prediction, judged against reality with evidence. One per (resolver, prediction): the `d` derives from the prediction coordinate alone, so a resolver revising their resolution replaces it (latest wins); different resolvers are different pubkeys and coexist.
+
+```jsonc
+{
+  "kind": 30059,
+  "tags": [
+    ["d", "res:<sha256(prediction_coordinate).slice(0,16)>"],
+    ["a", "30058:<extractor-pubkey>:<pred-d>", "<relay-hint>", "prediction"],
+    ["e", "<30058-event-id>", "<relay-hint>", "prediction"],   // optional
+    ["x", "<article-hash>"],                        // the predicting article
+    ["outcome", "false"],                           // true|false|partial|unresolvable
+    ["confidence", "0.9"],
+    ["resolved-at", "2027-01-15T00:00:00Z"],
+    ["evidence", "url", "<url>", "<description>"],                 // ×N — typed:
+    ["evidence", "nostr_event", "<coordinate-or-event-id>", "<description>"],
+    ["evidence", "document_hash", "<sha256>", "<description>"],
+    ["evidence", "quote", "<verbatim text>", "<description>"],
+    ["auditor", "human", "<resolver-pubkey>"],
+    ["p", "<resolver-pubkey>", "", "auditor"],
+    ["client", "<client>"]
+  ],
+  "content": "<markdown notes: what happened, why this outcome>"
+}
+```
+
+- **Resolutions are evidence-bound**: at least one typed `evidence` tag is REQUIRED — a resolution without verifiable references is returned, not published. Each entry carries kind, value, and description; `nostr_event` evidence values MUST be a raw `kind:pubkey:d` coordinate or a 64-hex event id (never bech32), and additionally emit a plain `a` (coordinate) or `e` (event id) tag for relay indexing.
+- The `d` MUST be recomputable: `res:` + the first 16 hex of SHA-256 over the role-marked `prediction` `a` tag's value, verbatim. The role markers on the reference `a`/`e` tags exist because typed `nostr_event` evidence also emits plain `a`/`e` indexing tags — consumers MUST prefer role-marked references and MUST NOT treat evidence-derived tags as the prediction reference.
+- Resolutions feed exactly one consumer: the calibration ledger (per-hedge resolution rates, and the published Brier-based calibration spec). A 30059 `outcome` judges whether a *specific prediction resolved against reality* — it is NOT a fact-check of any claim the prediction was atomized into. Consumers MUST NOT merge 30059 outcomes with 30051 ClaimReview verdicts or 30054 stances on a linked 30040.
+
+## Kind 30060 — DossierSnapshot
+
+Addressable. A materialized rollup of a subject's audit record — author, publication, beat, or publication×beat. **A cache, latest-wins by design**: the canonical truth is always the underlying audit events, and the snapshot carries every parameter (window, shrinkage constant, population mean) needed for any third party to re-derive it from scratch. Consumers MUST prefer re-derivation when they hold the underlying events.
+
+```jsonc
+{
+  "kind": 30060,
+  "tags": [
+    ["d", "dossier:<sha256(subject_kind + '|' + subject_id).slice(0,16)>"],
+    ["subject-kind", "publication_x_beat"],   // author|publication|beat|publication_x_beat
+    ["p", "<entity-pubkey>"],                 // author/publication(/×beat) subjects
+    ["t", "monetary-policy"],                 // beat(/×beat) subjects — a canonical vocabulary slug
+    ["window-start", "2026-01-01T00:00:00Z"],
+    ["window-end", "2026-06-11T00:00:00Z"],
+    ["article-count", "14"],
+    ["score-mean", "73.5"], ["score-median", "75"], ["score-stdev", "8.1"],
+    ["shrinkage-k", "10"], ["population-mean", "77"], ["shrinkage-factor", "0.42"],
+    ["auditor", "pipeline", "xray-auditor/0.1.0/anthropic/claude-sonnet-4-6"],
+    ["client", "<client>"]
+  ],
+  "content": "{ \"per_module_means\": {…}, \"predictions\": { \"total\":…, \"resolved\":…, \"calibration\": {…}, \"calibration_v1\": { \"mean_brier\":…, \"resolved_count\":…, \"multiplier\": null } }, \"top_named_sources\": […], \"corrections\": null }"
+}
+```
+
+- `subject_id` per kind: author/publication → the entity pubkey (the `p` tag); beat → the beat slug (the `t` tag); publication×beat → `<entity-pubkey>|<beat-slug>`. The `d` MUST be recomputable from the `subject-kind` tag plus those values.
+- **Beat subjects MUST be canonical slugs from the publisher's versioned beat vocabulary** — free-form topic tags ride audit events but never mint dossier subjects (fragmented beats silently shrink sample sizes and distort the shrinkage math on reputation-bearing rollups). Beat semantics derive from matching `t` values against that published vocabulary.
+- **Shrinkage is published, always**: rolled-up means are pulled toward the population mean (`shrunk = (n/(n+k))·raw + (k/(n+k))·population`), and the applied factor rides the wire — a raw three-article mean is never presented as a stable reputation.
+- `calibration_v1` in the content is informational: the published Brier-based calibration spec, logged so the wire shape is stable; the `multiplier` field stays `null` until an explicit activation decision, and is never applied retroactively to article scores.
+
+## Kind 30061 — AuditDispute
+
+Addressable. A challenge to an audit record — module result, aggregate audit, prediction resolution, or claim. Anyone may file, **with evidence**: challenges without evidence quotes or verifiable references are returned, not adjudicated.
+
+```jsonc
+{
+  "kind": 30061,
+  "tags": [
+    ["d", "dispute:<sha256(target_coordinate).slice(0,16)>"],
+    ["a", "<target coordinate>", "<relay-hint>", "target"],
+    ["e", "<target-event-id>", "<relay-hint>", "target"],   // optional
+    ["target-kind", "aggregate_audit"],   // module_result|aggregate_audit|prediction_resolution|claim
+    ["x", "<article-hash>"],              // when the target anchors to an article
+    ["status", "open"],                   // filer-asserted: open|withdrawn
+    ["contested", "<finding pointer: an evidence_quote or JSON path>"],   // ×N
+    ["evidence", "<kind>", "<value>", "<description>"],   // ×N — typed, as on 30059
+    ["auditor", "human", "<filer-pubkey>"],
+    ["p", "<filer-pubkey>", "", "auditor"],
+    ["client", "<client>"]
+  ],
+  "content": "<markdown dispute summary>"
+}
+```
+
+- One dispute per (filer, target): the `d` derives from the target coordinate verbatim (the role-marked `target` `a` tag — evidence-derived `a`/`e` tags are never the target reference), so the filer may amend pre-adjudication or withdraw (`status: withdrawn`); the filed record is otherwise stable.
+- **`status` is filer-asserted only** (`open`/`withdrawn`). Upheld/rejected outcomes are NOT wire fields here — they derive from adjudication events (a separate, future kind authored by other pubkeys) and from superseding audits that `e`-tag this dispute with role `resolves-dispute`. A dispute never edits its target; an upheld dispute produces a NEW audit that supersedes the original, and both remain visible.
+- A rejected dispute remains visible too — the record of what was challenged and survived is part of a score's credibility.
+
 ## Kind 30023 — `responds-to` tag (extension)
 
 A long-form article (kind 30023) MAY declare that it responds to one or more other pieces of content. Each response is a separate `responds-to` tag:
@@ -442,7 +569,7 @@ A client wishing to display all metadata for a URL SHOULD issue these filters in
 ```jsonc
 [
   { "kinds": [30040, 30050, 30051, 30052, 30054, 30055], "#r": ["<url>"], "limit": 200 },
-  { "kinds": [30056, 30057], "#r": ["<url>"], "limit": 100 },
+  { "kinds": [30056, 30057, 30058], "#r": ["<url>"], "limit": 100 },
   { "kinds": [9802], "#r": ["<url>"], "limit": 100 },
   { "kinds": [1111], "#i": ["<url>"], "limit": 200 },
   { "kinds": [1985], "#r": ["<url>"], "limit": 100 },
@@ -460,8 +587,10 @@ Other standard queries:
 { "kinds": [30040, 30054], "#p": ["<entity-pubkey>"], "limit": 200 }   // claims about an entity + their assessments
 { "kinds": [30054, 30055], "#a": ["30040:<pubkey>:<d>"], "limit": 100 } // judgments + links targeting one claim
 { "kinds": [30054], "#l": ["misleading"], "limit": 100 }                // everything labeled `misleading`
-{ "kinds": [30056, 30057], "#x": ["<article-hash>"], "limit": 100 }     // every audit of this exact text
+{ "kinds": [30056, 30057, 30058], "#x": ["<article-hash>"], "limit": 100 } // every audit of this exact text
 { "kinds": [30057], "#t": ["monetary-policy"], "limit": 100 }           // aggregate audits on a beat
+{ "kinds": [30059], "#a": ["30058:<pubkey>:<d>"], "limit": 50 }         // resolutions of one prediction
+{ "kinds": [30061], "#a": ["30057:<pubkey>:<d>"], "limit": 50 }         // disputes targeting one audit
 ```
 
 A client wishing to display helpfulness aggregates for a set of metadata events SHOULD then issue a follow-up `#a` query against kind 9803 keyed by the addressable coordinates of those events.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -986,6 +986,17 @@ Implementation slices 13.1+ are in progress.
   (default off), NIP_DRAFT §30056/§30057 incl. the canonical-hash
   `x` tag and the RQ5 time-series `d` constraint, CHANGELOG
   wire-change callout. — #63
+- ✅ **13.3** Wire ledger + governance kinds — builders + parsers for
+  30058 PredictionEntry (convergent text-hash `d`; content =
+  prediction text only, so `d` recomputes from the event), 30059
+  PredictionResolution (typed four-kind evidence tags, evidence-bound
+  — no evidence, no resolution), 30060 DossierSnapshot (cache
+  semantics; beat subjects MUST be canonical `beats-v1` slugs), 30061
+  AuditDispute (wire-format-only; filer-asserted status open/withdrawn
+  only); dossier rollup math (`dossier.js`: §4 shrinkage published
+  per rollup, per-module means, rate table + logged-not-activated
+  `calibration_v1`); NIP_DRAFT §30058–§30061 + the beat-vocabulary
+  clause. — #64
 
 ---
 

--- a/src/shared/audit/builders.js
+++ b/src/shared/audit/builders.js
@@ -22,6 +22,7 @@
 
 import { normalize } from '../metadata/url-normalizer.js';
 import { MODULE_NAMES, validateFindings } from './findings-schemas.js';
+import { normalizeBeat } from './beats.js';
 
 const KIND_MODULE_RESULT = 30056;
 const KIND_AGGREGATE_AUDIT = 30057;
@@ -511,6 +512,614 @@ export function parseAggregateAuditEvent(event) {
         modelEstimatedCeiling: typeof content.model_estimated_ceiling === 'number' ? content.model_estimated_ceiling : null,
         topStrengths: Array.isArray(content.top_strengths) ? content.top_strengths : [],
         topConcerns: Array.isArray(content.top_concerns) ? content.top_concerns : [],
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        eventId: event.id || null
+    };
+}
+
+// =============================================================================
+// Ledger + governance kinds: 30058 PredictionEntry, 30059
+// PredictionResolution, 30060 DossierSnapshot, 30061 AuditDispute
+// (Phase 13, slice 13.3). 30061 is WIRE-FORMAT-ONLY in v1 — the kind
+// is defined and buildable, no filing UI or adjudication runtime
+// exists (explicit non-goal).
+// =============================================================================
+
+const KIND_PREDICTION_ENTRY = 30058;
+const KIND_PREDICTION_RESOLUTION = 30059;
+const KIND_DOSSIER_SNAPSHOT = 30060;
+const KIND_AUDIT_DISPUTE = 30061;
+
+export const PREDICTION_TYPES = Object.freeze(['explicit', 'implicit', 'conditional', 'negative', 'counterfactual']);
+export const HEDGE_LEVELS = Object.freeze(['confident', 'hedged', 'speculative']);
+export const ATTRIBUTION_KINDS = Object.freeze(['article_voice', 'named_source', 'vague_attribution']);
+export const TRACTABILITIES = Object.freeze(['publicly_resolvable', 'requires_private_info', 'ambiguous']);
+export const RESOLUTION_OUTCOMES_WIRE = Object.freeze(['true', 'false', 'partial', 'unresolvable']);
+export const EVIDENCE_KINDS = Object.freeze(['url', 'nostr_event', 'document_hash', 'quote']);
+export const DOSSIER_SUBJECT_KINDS = Object.freeze(['author', 'publication', 'beat', 'publication_x_beat']);
+export const DISPUTE_TARGET_KINDS = Object.freeze(['module_result', 'aggregate_audit', 'prediction_resolution', 'claim']);
+export const DISPUTE_STATUSES = Object.freeze(['open', 'withdrawn']);   // filer-asserted only
+
+function assertEnum(value, allowed, name, fn) {
+    if (!allowed.includes(value)) {
+        throw new Error(`${fn}: ${name} must be one of ${allowed.join(', ')} (got ${value})`);
+    }
+}
+
+// The claim-id discipline, exactly (claim-model.js / audit-model.js):
+// trim, collapse whitespace runs to single spaces, lowercase — so
+// re-extraction of the same restated text converges on one record.
+function normalizePredictionTextWire(text) {
+    return String(text || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
+ * Typed evidence tags (30059/30061): each entry
+ * {kind, value, description} becomes ["evidence", kind, value,
+ * description] — a flagged extension of the dormant 30051 builder's
+ * bare-string idiom, which could not express document_hash or quote
+ * evidence. nostr_event evidence additionally gets a plain `a` or `e`
+ * tag for relay indexing.
+ */
+function evidenceTags(evidence, fn) {
+    if (!Array.isArray(evidence)) {
+        throw new Error(`${fn}: evidence must be an array of {kind, value, description}`);
+    }
+    const tags = [];
+    for (const ev of evidence) {
+        if (!ev || typeof ev.value !== 'string' || !ev.value) {
+            throw new Error(`${fn}: evidence entries need a nonempty string value (got ${JSON.stringify(ev)})`);
+        }
+        assertEnum(ev.kind, EVIDENCE_KINDS, 'evidence kind', fn);
+        if (ev.kind === 'nostr_event') {
+            // Value grammar enforced: a raw kind:pubkey:d coordinate or
+            // a 64-hex event id — never bech32 — so the SHOULD-level
+            // indexing companion tag below is always emittable.
+            if (!COORD_RE.test(ev.value) && !HASH64_RE.test(ev.value)) {
+                throw new Error(`${fn}: nostr_event evidence value must be a raw coordinate or 64-hex event id (got ${ev.value})`);
+            }
+        }
+        tags.push(tag('evidence', ev.kind, ev.value, ev.description || ''));
+        if (ev.kind === 'nostr_event') {
+            if (COORD_RE.test(ev.value)) tags.push(tag('a', ev.value));
+            else tags.push(tag('e', ev.value));
+        }
+    }
+    return tags;
+}
+
+// Evidence-derived a/e tags are indistinguishable from reference tags
+// by name alone — parsers exclude any value that appears in an
+// evidence tag before falling back to positional matching.
+function evidenceValues(tags) {
+    return new Set(tags.filter((x) => x[0] === 'evidence' && x[1] === 'nostr_event').map((x) => x[2]));
+}
+
+function parseEvidenceTags(tags) {
+    return tags.filter((x) => x[0] === 'evidence' && EVIDENCE_KINDS.includes(x[1]) && x[2])
+        .map((x) => ({ kind: x[1], value: x[2], description: x[3] || '' }));
+}
+
+/** `d` for a 30058: pred:<sha16(articleHash|norm(predictionText))>. */
+export async function derivePredictionEntryDTag(articleHash, predictionText) {
+    return 'pred:' + (await sha16(`${articleHash}|${normalizePredictionTextWire(predictionText)}`));
+}
+
+/** `d` for a 30059: res:<sha16(predictionCoord verbatim)>. */
+export async function derivePredictionResolutionDTag(predictionCoord) {
+    return 'res:' + (await sha16(String(predictionCoord || '').trim()));
+}
+
+/** `d` for a 30060: dossier:<sha16(subjectKind|subjectId)>. */
+export async function deriveDossierSnapshotDTag(subjectKind, subjectId) {
+    return 'dossier:' + (await sha16(`${subjectKind}|${subjectId}`));
+}
+
+/** `d` for a 30061: dispute:<sha16(targetCoord verbatim)>. */
+export async function deriveAuditDisputeDTag(targetCoord) {
+    return 'dispute:' + (await sha16(String(targetCoord || '').trim()));
+}
+
+/**
+ * Build a kind-30058 PredictionEntry. The ledger's write side: the
+ * stable text-hash `d` makes re-extraction CONVERGE (same article
+ * hash + same restated text → one record), so resolutions never
+ * retarget. The content carries the prediction text and NOTHING else,
+ * precisely so the `d` is mechanically recomputable from the event.
+ *
+ * `resolution_status`/`latest_resolution_id` are NOT wire fields —
+ * they derive client-side from 30059s (the local model owns them).
+ *
+ * @returns {Promise<{event: object, body: string, dTag: string}>}
+ */
+export async function buildPredictionEntryEvent({
+    articleHash,
+    predictionText,
+    predictionType,
+    hedgeLevel,
+    attribution,
+    attributedName = null,
+    condition = null,
+    horizon,
+    horizonIso = null,
+    criteria,
+    tractability,
+    evidenceQuote,
+    anchor = null,
+    moduleVersion,
+    claimCoord = null,
+    authorEntityPubkey = null,
+    articleCoord = null,
+    relayHint = '',
+    articleUrl = '',
+    auditor,
+    constituents = [],
+    manifestHash = null,
+    createdAt = nowSeconds()
+} = {}) {
+    const FN = 'buildPredictionEntryEvent';
+    assertArticleHash(articleHash, FN);
+    if (typeof predictionText !== 'string' || !predictionText.trim()) {
+        throw new Error(`${FN}: predictionText required — the prediction is the record`);
+    }
+    assertEnum(predictionType, PREDICTION_TYPES, 'predictionType', FN);
+    assertEnum(hedgeLevel, HEDGE_LEVELS, 'hedgeLevel', FN);
+    assertEnum(attribution, ATTRIBUTION_KINDS, 'attribution', FN);
+    assertEnum(tractability, TRACTABILITIES, 'tractability', FN);
+    if (typeof horizon !== 'string' || !horizon) {
+        throw new Error(`${FN}: horizon required (descriptive or ISO date)`);
+    }
+    if (typeof criteria !== 'string' || !criteria) {
+        throw new Error(`${FN}: criteria required — an unresolvable-by-construction prediction is not a ledger entry`);
+    }
+    if (typeof evidenceQuote !== 'string' || !evidenceQuote) {
+        throw new Error(`${FN}: evidenceQuote required — evidence-bound, no exceptions`);
+    }
+    if (predictionType === 'conditional' && (typeof condition !== 'string' || !condition)) {
+        throw new Error(`${FN}: conditional predictions require the condition (the antecedent)`);
+    }
+    if (typeof moduleVersion !== 'string' || !moduleVersion) {
+        throw new Error(`${FN}: moduleVersion required (prediction_extraction's version)`);
+    }
+    if (claimCoord && (!COORD_RE.test(claimCoord) || !claimCoord.startsWith('30040:'))) {
+        throw new Error(`${FN}: claimCoord must be a 30040 coordinate (got ${claimCoord})`);
+    }
+    if (authorEntityPubkey && !HASH64_RE.test(authorEntityPubkey)) {
+        throw new Error(`${FN}: authorEntityPubkey must be 64-hex (got ${authorEntityPubkey})`);
+    }
+    if (horizonIso !== null && !/^\d{4}-\d{2}-\d{2}$/.test(horizonIso)) {
+        throw new Error(`${FN}: horizonIso must be YYYY-MM-DD or null (got ${horizonIso})`);
+    }
+
+    const body = predictionText.trim();
+    const dTag = await derivePredictionEntryDTag(articleHash, body);
+
+    const tags = [tag('d', dTag)];
+    tags.push(...articleTags({ articleHash, articleCoord, relayHint, articleUrl }, FN));
+    if (claimCoord) tags.push(tag('a', claimCoord, relayHint, 'claim'));   // the atomized claim (RQ6)
+    tags.push(tag('prediction-type', predictionType));
+    tags.push(tag('hedge', hedgeLevel));
+    tags.push(tag('attribution', attribution));
+    if (attributedName) tags.push(tag('attributed-name', attributedName));
+    if (authorEntityPubkey) tags.push(tag('p', authorEntityPubkey, '', 'predicts'));
+    if (condition) tags.push(tag('condition', condition));
+    tags.push(tag('horizon', horizon));
+    if (horizonIso) tags.push(tag('horizon-iso', horizonIso));
+    tags.push(tag('tractability', tractability));
+    tags.push(tag('quote', evidenceQuote));
+    if (anchor) tags.push(tag('anchor', JSON.stringify(anchor)));   // source_span as W3C selector
+    tags.push(tag('criteria', criteria));
+    tags.push(tag('module-version', moduleVersion));
+    tags.push(...auditorTags({ auditor, constituents, manifestHash }, FN));
+    tags.push(tag('client', 'xray'));
+
+    return {
+        event: { kind: KIND_PREDICTION_ENTRY, created_at: createdAt, tags, content: body },
+        body,
+        dTag
+    };
+}
+
+/**
+ * Parse a kind-30058 event. Null when structurally unusable (no
+ * d/x/content text, bad enums, or missing auditor).
+ */
+export function parsePredictionEntryEvent(event) {
+    if (!event || event.kind !== KIND_PREDICTION_ENTRY) return null;
+    const tags = event.tags || [];
+    const id = firstTag(tags, 'd');
+    const articleHash = firstTag(tags, 'x');
+    const text = (event.content || '').trim();
+    const predictionType = firstTag(tags, 'prediction-type');
+    const hedgeLevel = firstTag(tags, 'hedge');
+    const auditorBlock = parseAuditorBlock(tags);
+    if (!id || !articleHash || !text || !auditorBlock) return null;
+    if (!PREDICTION_TYPES.includes(predictionType) || !HEDGE_LEVELS.includes(hedgeLevel)) return null;
+
+    let anchor = null;
+    const anchorRaw = firstTag(tags, 'anchor');
+    if (anchorRaw) { try { anchor = JSON.parse(anchorRaw); } catch (_) { /* stays null */ } }
+
+    // Attribution rejects like hedge/type — it books the prediction
+    // against someone's track record, and defaulting a missing tag to
+    // article_voice would silently misattribute a named source's
+    // prediction to the article author's dossier.
+    const attribution = firstTag(tags, 'attribution');
+    if (!ATTRIBUTION_KINDS.includes(attribution)) return null;
+
+    const claimA = tags.find((x) => x[0] === 'a' && x[3] === 'claim');
+    const articleA = tags.find((x) => x[0] === 'a' && String(x[1]).startsWith('30023:'));
+    const predictsP = tags.find((x) => x[0] === 'p' && x[3] === 'predicts');
+    const tractability = firstTag(tags, 'tractability');
+    return {
+        id,
+        articleHash,
+        text,
+        predictionType,
+        hedgeLevel,
+        attribution,
+        attributedName: firstTag(tags, 'attributed-name') || null,
+        condition: firstTag(tags, 'condition') || null,
+        horizon: firstTag(tags, 'horizon') || '',
+        horizonIso: firstTag(tags, 'horizon-iso') || null,
+        tractability: TRACTABILITIES.includes(tractability) ? tractability : 'ambiguous',
+        evidenceQuote: firstTag(tags, 'quote') || '',
+        anchor,
+        criteria: firstTag(tags, 'criteria') || '',
+        moduleVersion: firstTag(tags, 'module-version') || '',
+        claimCoord: (claimA && claimA[1]) || null,
+        authorEntityPubkey: (predictsP && predictsP[1]) || null,
+        ...auditorBlock,
+        articleCoord: (articleA && articleA[1]) || null,
+        url: firstTag(tags, 'r') || null,
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        eventId: event.id || null
+    };
+}
+
+/**
+ * Build a kind-30059 PredictionResolution. One per (resolver,
+ * prediction) — the same resolver revising replaces (the framework
+ * type's own latest-wins; the accepted RQ5 P9 tension, documented).
+ * Evidence-bound (P3): at least one typed evidence entry is required —
+ * challenges without evidence are returned, and so are resolutions.
+ *
+ * @returns {Promise<{event: object, body: string, dTag: string}>}
+ */
+export async function buildPredictionResolutionEvent({
+    predictionCoord,
+    predictionEventId = null,
+    articleHash = null,
+    outcome,
+    confidence,
+    resolvedAt,
+    evidence,
+    notes = '',
+    relayHint = '',
+    auditor,
+    constituents = [],
+    manifestHash = null,
+    createdAt = nowSeconds()
+} = {}) {
+    const FN = 'buildPredictionResolutionEvent';
+    if (!predictionCoord || !COORD_RE.test(predictionCoord) || !predictionCoord.startsWith(`${KIND_PREDICTION_ENTRY}:`)) {
+        throw new Error(`${FN}: predictionCoord must be a 30058 coordinate (got ${predictionCoord})`);
+    }
+    assertEnum(outcome, RESOLUTION_OUTCOMES_WIRE, 'outcome', FN);
+    assertRange(confidence, 0, 1, 'confidence', FN);
+    assertRunAt(resolvedAt, FN);
+    const evTags = evidenceTags(evidence, FN);
+    if (!evidence || evidence.length === 0) {
+        throw new Error(`${FN}: at least one evidence entry required — resolutions are evidence-bound (P3)`);
+    }
+    // Required: the prediction d is a one-way hash of (article hash |
+    // text), so without `x` a resolution is invisible to #x article
+    // queries — and the resolver always has the hash (it rides the
+    // prediction record).
+    assertArticleHash(articleHash, FN);
+    if (predictionEventId !== null && !HASH64_RE.test(predictionEventId)) {
+        throw new Error(`${FN}: predictionEventId must be a 64-hex event id (got ${predictionEventId})`);
+    }
+
+    const coord = predictionCoord.trim();
+    const dTag = await derivePredictionResolutionDTag(coord);
+
+    const tags = [tag('d', dTag)];
+    tags.push(tag('a', coord, relayHint, 'prediction'));
+    if (predictionEventId) tags.push(tag('e', predictionEventId, relayHint, 'prediction'));
+    tags.push(tag('x', articleHash));     // the predicting article
+    tags.push(tag('outcome', outcome));
+    tags.push(tag('confidence', confidence));
+    tags.push(tag('resolved-at', resolvedAt));
+    tags.push(...evTags);
+    tags.push(...auditorTags({ auditor, constituents, manifestHash }, FN));
+    tags.push(tag('client', 'xray'));
+
+    const body = String(notes || '');
+    return {
+        event: { kind: KIND_PREDICTION_RESOLUTION, created_at: createdAt, tags, content: body },
+        body,
+        dTag
+    };
+}
+
+/** Parse a kind-30059 event. Null when structurally unusable. */
+export function parsePredictionResolutionEvent(event) {
+    if (!event || event.kind !== KIND_PREDICTION_RESOLUTION) return null;
+    const tags = event.tags || [];
+    const id = firstTag(tags, 'd');
+    const evValues = evidenceValues(tags);
+    // Role-marked reference first; fall back to prefix-match for
+    // foreign events, excluding evidence-derived a tags (an evidence
+    // entry can itself cite another 30058).
+    const predictionA = tags.find((x) => x[0] === 'a' && x[3] === 'prediction'
+            && String(x[1]).startsWith(`${KIND_PREDICTION_ENTRY}:`))
+        || tags.find((x) => x[0] === 'a' && String(x[1]).startsWith(`${KIND_PREDICTION_ENTRY}:`)
+            && !evValues.has(x[1]));
+    const outcome = firstTag(tags, 'outcome');
+    const auditorBlock = parseAuditorBlock(tags);
+    if (!id || !predictionA || !RESOLUTION_OUTCOMES_WIRE.includes(outcome) || !auditorBlock) return null;
+
+    const predictionE = tags.find((x) => x[0] === 'e' && x[3] === 'prediction' && HASH64_RE.test(x[1]))
+        || tags.find((x) => x[0] === 'e' && HASH64_RE.test(x[1]) && !evValues.has(x[1]));
+    return {
+        id,
+        predictionCoord: predictionA[1],
+        predictionEventId: (predictionE && predictionE[1]) || null,
+        articleHash: firstTag(tags, 'x') || null,
+        outcome,
+        confidence: numberOrNull(firstTag(tags, 'confidence')),
+        resolvedAt: firstTag(tags, 'resolved-at') || null,
+        evidence: parseEvidenceTags(tags),
+        notes: event.content || '',
+        ...auditorBlock,
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        eventId: event.id || null
+    };
+}
+
+/**
+ * Build a kind-30060 DossierSnapshot. A CACHE: latest-wins per
+ * (pubkey, subject) by design — the only audit kind where relay
+ * replacement is the right semantics, because the record is wholly
+ * re-derivable from published audit events given the window +
+ * parameters it carries. Consumers MUST prefer re-derivation when
+ * they hold the underlying events.
+ *
+ * Beat subjects MUST be canonical beats-v1 slugs (RQ8) — free-form
+ * tags never mint dossier subjects.
+ *
+ * @returns {Promise<{event: object, body: string, dTag: string}>}
+ */
+export async function buildDossierSnapshotEvent({
+    subjectKind,
+    entityPubkey = null,
+    beat = null,
+    windowStart,
+    windowEnd,
+    articleCount,
+    scoreMean,
+    scoreMedian,
+    scoreStdev,
+    shrinkageK,
+    populationMean,
+    shrinkageFactor,
+    perModuleMeans = {},
+    predictions = null,
+    topNamedSources = null,
+    corrections = null,
+    auditor,
+    constituents = [],
+    manifestHash = null,
+    createdAt = nowSeconds()
+} = {}) {
+    const FN = 'buildDossierSnapshotEvent';
+    assertEnum(subjectKind, DOSSIER_SUBJECT_KINDS, 'subjectKind', FN);
+    const needsEntity = subjectKind === 'author' || subjectKind === 'publication' || subjectKind === 'publication_x_beat';
+    const needsBeat = subjectKind === 'beat' || subjectKind === 'publication_x_beat';
+    if (needsEntity && !HASH64_RE.test(entityPubkey || '')) {
+        throw new Error(`${FN}: ${subjectKind} subjects need entityPubkey (64-hex)`);
+    }
+    if (needsBeat) {
+        const slug = normalizeBeat(beat);
+        if (!slug || slug !== beat) {
+            throw new Error(`${FN}: beat subjects MUST be canonical beats-v1 slugs (got ${beat}) — free-form tags never mint dossiers (RQ8)`);
+        }
+    }
+    assertRunAt(windowStart, FN);
+    assertRunAt(windowEnd, FN);
+    if (!Number.isInteger(articleCount) || articleCount < 1) {
+        throw new Error(`${FN}: articleCount must be a positive integer (got ${articleCount}) — empty dossiers are never published; a zero-article rollup is just the population prior`);
+    }
+    assertRange(scoreMean, 0, 100, 'scoreMean', FN);
+    assertRange(scoreMedian, 0, 100, 'scoreMedian', FN);
+    if (typeof scoreStdev !== 'number' || !Number.isFinite(scoreStdev) || scoreStdev < 0) {
+        throw new Error(`${FN}: scoreStdev must be a non-negative number (got ${scoreStdev})`);
+    }
+    if (!Number.isFinite(shrinkageK) || shrinkageK <= 0) {
+        throw new Error(`${FN}: shrinkageK must be positive (got ${shrinkageK})`);
+    }
+    assertRange(populationMean, 0, 100, 'populationMean', FN);
+    assertRange(shrinkageFactor, 0, 1, 'shrinkageFactor', FN);
+
+    const subjectId = subjectKind === 'beat' ? beat
+        : subjectKind === 'publication_x_beat' ? `${entityPubkey}|${beat}`
+            : entityPubkey;
+    const dTag = await deriveDossierSnapshotDTag(subjectKind, subjectId);
+
+    const tags = [tag('d', dTag)];
+    tags.push(tag('subject-kind', subjectKind));
+    if (needsEntity) tags.push(tag('p', entityPubkey));
+    if (needsBeat) tags.push(tag('t', beat));
+    tags.push(tag('window-start', windowStart));
+    tags.push(tag('window-end', windowEnd));
+    tags.push(tag('article-count', articleCount));
+    tags.push(tag('score-mean', scoreMean));
+    tags.push(tag('score-median', scoreMedian));
+    tags.push(tag('score-stdev', scoreStdev));
+    tags.push(tag('shrinkage-k', shrinkageK));
+    tags.push(tag('population-mean', populationMean));
+    tags.push(tag('shrinkage-factor', shrinkageFactor));
+    tags.push(...auditorTags({ auditor, constituents, manifestHash }, FN));
+    tags.push(tag('client', 'xray'));
+
+    const body = JSON.stringify({
+        per_module_means: perModuleMeans,
+        predictions,
+        top_named_sources: topNamedSources,
+        corrections
+    });
+
+    return {
+        event: { kind: KIND_DOSSIER_SNAPSHOT, created_at: createdAt, tags, content: body },
+        body,
+        dTag
+    };
+}
+
+/** Parse a kind-30060 event. Null when structurally unusable. */
+export function parseDossierSnapshotEvent(event) {
+    if (!event || event.kind !== KIND_DOSSIER_SNAPSHOT) return null;
+    const tags = event.tags || [];
+    const id = firstTag(tags, 'd');
+    const subjectKind = firstTag(tags, 'subject-kind');
+    const auditorBlock = parseAuditorBlock(tags);
+    if (!id || !DOSSIER_SUBJECT_KINDS.includes(subjectKind) || !auditorBlock) return null;
+    const entityPubkey = firstTag(tags, 'p') || null;
+    const beat = firstTag(tags, 't') || null;
+    if ((subjectKind === 'author' || subjectKind === 'publication' || subjectKind === 'publication_x_beat') && !entityPubkey) return null;
+    if ((subjectKind === 'beat' || subjectKind === 'publication_x_beat') && !beat) return null;
+
+    let content = {};
+    try { content = JSON.parse(event.content) || {}; } catch (_) { /* tags carry the rollup */ }
+    if (Array.isArray(content) || typeof content !== 'object' || content === null) content = {};
+
+    return {
+        id,
+        subjectKind,
+        entityPubkey,
+        beat,
+        windowStart: firstTag(tags, 'window-start') || null,
+        windowEnd: firstTag(tags, 'window-end') || null,
+        articleCount: numberOrNull(firstTag(tags, 'article-count')),
+        scoreMean: numberOrNull(firstTag(tags, 'score-mean')),
+        scoreMedian: numberOrNull(firstTag(tags, 'score-median')),
+        scoreStdev: numberOrNull(firstTag(tags, 'score-stdev')),
+        shrinkageK: numberOrNull(firstTag(tags, 'shrinkage-k')),
+        populationMean: numberOrNull(firstTag(tags, 'population-mean')),
+        shrinkageFactor: numberOrNull(firstTag(tags, 'shrinkage-factor')),
+        perModuleMeans: content.per_module_means || {},
+        predictions: content.predictions || null,
+        topNamedSources: content.top_named_sources || null,
+        corrections: content.corrections || null,
+        ...auditorBlock,
+        pubkey: event.pubkey || '',
+        created_at: event.created_at || 0,
+        eventId: event.id || null
+    };
+}
+
+/**
+ * Build a kind-30061 AuditDispute — WIRE-FORMAT-ONLY in v1 (no filing
+ * UI, no adjudication runtime). One dispute per (filer, target); the
+ * filer may amend pre-adjudication or withdraw (`status`). Status on
+ * the wire is FILER-ASSERTED only (open|withdrawn) — upheld/rejected
+ * derive from future adjudication events and superseding audits,
+ * which are other pubkeys' records. Evidence-bound: challenges
+ * without evidence are returned, not adjudicated (P3, §7).
+ *
+ * @returns {Promise<{event: object, body: string, dTag: string}>}
+ */
+export async function buildAuditDisputeEvent({
+    targetCoord,
+    targetEventId = null,
+    targetKind,
+    articleHash = null,
+    status = 'open',
+    contested,
+    evidence,
+    disputeSummary,
+    relayHint = '',
+    auditor,
+    constituents = [],
+    manifestHash = null,
+    createdAt = nowSeconds()
+} = {}) {
+    const FN = 'buildAuditDisputeEvent';
+    if (!targetCoord || !COORD_RE.test(targetCoord)) {
+        throw new Error(`${FN}: targetCoord must be a kind:pubkey:d coordinate (got ${targetCoord})`);
+    }
+    assertEnum(targetKind, DISPUTE_TARGET_KINDS, 'targetKind', FN);
+    assertEnum(status, DISPUTE_STATUSES, 'status', FN);
+    if (!Array.isArray(contested) || contested.length === 0 || contested.some((c) => typeof c !== 'string' || !c)) {
+        throw new Error(`${FN}: contested must be a nonempty array of finding pointers (evidence_quote or JSON path)`);
+    }
+    const evTags = evidenceTags(evidence, FN);
+    if (!evidence || evidence.length === 0) {
+        throw new Error(`${FN}: at least one evidence entry required — challenges without evidence are returned, not adjudicated`);
+    }
+    if (typeof disputeSummary !== 'string' || !disputeSummary.trim()) {
+        throw new Error(`${FN}: disputeSummary required`);
+    }
+    if (articleHash !== null) assertArticleHash(articleHash, FN);
+    if (targetEventId !== null && !HASH64_RE.test(targetEventId)) {
+        throw new Error(`${FN}: targetEventId must be a 64-hex event id (got ${targetEventId})`);
+    }
+
+    const coord = targetCoord.trim();
+    const dTag = await deriveAuditDisputeDTag(coord);
+
+    const tags = [tag('d', dTag)];
+    tags.push(tag('a', coord, relayHint, 'target'));
+    if (targetEventId) tags.push(tag('e', targetEventId, relayHint, 'target'));
+    tags.push(tag('target-kind', targetKind));
+    if (articleHash) tags.push(tag('x', articleHash));
+    tags.push(tag('status', status));
+    for (const c of contested) tags.push(tag('contested', c));
+    tags.push(...evTags);
+    tags.push(...auditorTags({ auditor, constituents, manifestHash }, FN));
+    tags.push(tag('client', 'xray'));
+
+    const body = disputeSummary.trim();
+    return {
+        event: { kind: KIND_AUDIT_DISPUTE, created_at: createdAt, tags, content: body },
+        body,
+        dTag
+    };
+}
+
+/** Parse a kind-30061 event. Null when structurally unusable. */
+export function parseAuditDisputeEvent(event) {
+    if (!event || event.kind !== KIND_AUDIT_DISPUTE) return null;
+    const tags = event.tags || [];
+    const id = firstTag(tags, 'd');
+    const evValues = evidenceValues(tags);
+    // Role-marked target first. The fallback for foreign events
+    // cannot prefix-filter (disputes target four kinds), so it
+    // excludes evidence-derived a tags instead.
+    const targetA = tags.find((x) => x[0] === 'a' && x[3] === 'target' && COORD_RE.test(x[1]))
+        || tags.find((x) => x[0] === 'a' && COORD_RE.test(x[1]) && !evValues.has(x[1]));
+    const targetKind = firstTag(tags, 'target-kind');
+    const status = firstTag(tags, 'status');
+    const auditorBlock = parseAuditorBlock(tags);
+    if (!id || !targetA || !targetA[1] || !DISPUTE_TARGET_KINDS.includes(targetKind) || !auditorBlock) return null;
+
+    const targetE = tags.find((x) => x[0] === 'e' && x[3] === 'target' && HASH64_RE.test(x[1]))
+        || tags.find((x) => x[0] === 'e' && HASH64_RE.test(x[1]) && !evValues.has(x[1]));
+    return {
+        id,
+        targetCoord: targetA[1],
+        targetEventId: (targetE && targetE[1]) || null,
+        targetKind,
+        articleHash: firstTag(tags, 'x') || null,
+        status: DISPUTE_STATUSES.includes(status) ? status : 'open',
+        contested: tags.filter((x) => x[0] === 'contested' && x[1]).map((x) => x[1]),
+        evidence: parseEvidenceTags(tags),
+        disputeSummary: event.content || '',
+        ...auditorBlock,
         pubkey: event.pubkey || '',
         created_at: event.created_at || 0,
         eventId: event.id || null

--- a/src/shared/audit/dossier.js
+++ b/src/shared/audit/dossier.js
@@ -1,0 +1,141 @@
+// X-Ray — dossier rollup math (Phase 13, slice 13.3).
+//
+// Dossiers are DERIVED, REPRODUCIBLE views over published audit
+// events (the canonical form is computed-on-open in the portal; the
+// 30060 snapshot is a cache). This module is the pure math: anyone
+// with the same events and the same parameters derives the same
+// numbers — PHILOSOPHY §9 "reproducible rollups".
+//
+// Shrinkage (§4): rolled-up scores for low-volume subjects are pulled
+// toward the population mean —
+//   shrunk = (n/(n+k))·raw_mean + (k/(n+k))·population_mean
+// with k ≈ 10 as the starting constant. The applied factor is
+// published with every rollup; a raw three-article mean is never
+// presented as a stable reputation.
+
+import { normalizeBeat } from './beats.js';
+import { calibrationRateTable, calibrationV1 } from './calibration.js';
+
+export const DEFAULT_SHRINKAGE_K = 10;
+
+/**
+ * Bayesian shrinkage toward the population mean. Returns
+ * {shrunk, factor} where factor = k/(n+k) — 0 means no shrinkage,
+ * 1 fully shrunk (n = 0).
+ */
+export function shrink(rawMean, n, k, populationMean) {
+    if (!Number.isFinite(rawMean) || !Number.isFinite(populationMean)) {
+        throw new Error('shrink: rawMean and populationMean must be finite numbers');
+    }
+    if (!Number.isInteger(n) || n < 0) throw new Error(`shrink: n must be a non-negative integer (got ${n})`);
+    if (!Number.isFinite(k) || k <= 0) throw new Error(`shrink: k must be positive (got ${k})`);
+    const factor = k / (n + k);
+    const shrunk = (n / (n + k)) * rawMean + factor * populationMean;
+    return { shrunk: Number(shrunk.toFixed(2)), factor: Number(factor.toFixed(4)) };
+}
+
+function median(values) {
+    if (values.length === 0) return null;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function stdev(values, mean) {
+    if (values.length === 0) return null;
+    const variance = values.reduce((acc, v) => acc + (v - mean) * (v - mean), 0) / values.length;
+    return Math.sqrt(variance);
+}
+
+/**
+ * Normalize an event's beat tags against beats-v1: canonical slugs
+ * aggregate, unmapped tags go to the review list — they NEVER mint
+ * dossier subjects (RQ8).
+ *
+ * @param {string[]} beats - raw t-tag values
+ * @returns {{canonical: string[], unmapped: string[]}}
+ */
+export function normalizeEventBeats(beats) {
+    const canonical = [];
+    const unmapped = [];
+    for (const b of beats || []) {
+        const slug = normalizeBeat(b);
+        if (slug) {
+            if (!canonical.includes(slug)) canonical.push(slug);
+        } else if (typeof b === 'string' && b && !unmapped.includes(b)) {
+            unmapped.push(b);
+        }
+    }
+    return { canonical, unmapped };
+}
+
+/**
+ * Compute a dossier rollup from parsed aggregate audits (30057s, or
+ * local equivalents carrying finalScore + moduleContributions) and
+ * the subject's resolved predictions.
+ *
+ * The caller has already scoped the inputs to one subject and one
+ * window — this function only does the math, so the same inputs
+ * always produce the same rollup (reproducibility is the point).
+ * Auditor-kind-agnostic by construction: nothing here reads auditor
+ * identity (RQ3).
+ *
+ * @param {object} params
+ * @param {Array<{finalScore: number, moduleContributions?: Array<{module: string, score: number|null}>}>} params.aggregates
+ * @param {Array<{hedge_level: string, outcome: string}>} [params.resolvedPredictions]
+ * @param {number} [params.totalPredictions] - open + resolved count for the summary
+ * @param {number} [params.k] - shrinkage constant
+ * @param {number} params.populationMean
+ * @returns {object} the rollup, 30060-content-shaped where it overlaps
+ */
+export function computeDossier({
+    aggregates,
+    resolvedPredictions = [],
+    totalPredictions = null,
+    k = DEFAULT_SHRINKAGE_K,
+    populationMean
+}) {
+    if (!Array.isArray(aggregates)) throw new Error('computeDossier: aggregates must be an array');
+    const scores = aggregates
+        .map((a) => a && a.finalScore)
+        .filter((s) => typeof s === 'number' && Number.isFinite(s));
+    const n = scores.length;
+    const rawMean = n > 0 ? scores.reduce((a, b) => a + b, 0) / n : null;
+    const { shrunk, factor } = n > 0
+        ? shrink(rawMean, n, k, populationMean)
+        : { shrunk: Number(populationMean.toFixed(2)), factor: 1 };
+
+    // Per-module means over every contribution that carried a score.
+    const byModule = {};
+    for (const a of aggregates) {
+        for (const c of (a && a.moduleContributions) || []) {
+            if (typeof c.score !== 'number' || !Number.isFinite(c.score)) continue;
+            (byModule[c.module] = byModule[c.module] || []).push(c.score);
+        }
+    }
+    const perModuleMeans = {};
+    for (const [mod, vals] of Object.entries(byModule)) {
+        perModuleMeans[mod] = Number((vals.reduce((a, b) => a + b, 0) / vals.length).toFixed(1));
+    }
+
+    const calibration = calibrationRateTable(resolvedPredictions);
+    const resolvedCount = Object.values(calibration).reduce((acc, row) => acc + row.resolved, 0);
+
+    return {
+        articleCount: n,
+        scoreMeanRaw: rawMean === null ? null : Number(rawMean.toFixed(2)),
+        scoreMean: shrunk,                     // the shrunk mean — what displays
+        scoreMedian: median(scores) === null ? null : Number(median(scores).toFixed(1)),
+        scoreStdev: rawMean === null ? null : Number(stdev(scores, rawMean).toFixed(2)),
+        shrinkageK: k,
+        populationMean,
+        shrinkageFactor: factor,
+        perModuleMeans,
+        predictions: {
+            total: totalPredictions === null ? resolvedCount : totalPredictions,
+            resolved: resolvedCount,
+            calibration,
+            calibration_v1: calibrationV1(resolvedPredictions)   // multiplier: null — logged, not activated (RQ4)
+        }
+    };
+}

--- a/tests/audit-dossier.test.mjs
+++ b/tests/audit-dossier.test.mjs
@@ -1,0 +1,118 @@
+// Phase 13.3 — dossier rollup math: shrinkage, per-module means,
+// the calibration rate table, and the logged-not-activated
+// calibration_v1 block. Reproducibility is the contract: same inputs,
+// same numbers, always.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    DEFAULT_SHRINKAGE_K, shrink, normalizeEventBeats, computeDossier
+} from '../src/shared/audit/dossier.js';
+
+function close(actual, expected, label) {
+    assert.ok(Math.abs(actual - expected) < 1e-9, `${label}: ${actual} !== ~${expected}`);
+}
+
+test('shrink: the §4 formula exactly — n=0 fully shrunk, n=k halfway, n→∞ raw', () => {
+    assert.equal(DEFAULT_SHRINKAGE_K, 10, 'the schema\'s recommended starting constant');
+    assert.deepEqual(shrink(50, 0, 10, 77), { shrunk: 77, factor: 1 });
+    const halfway = shrink(60, 10, 10, 80);
+    close(halfway.shrunk, 70, 'n = k pulls exactly halfway');
+    close(halfway.factor, 0.5, 'factor at n = k');
+    const heavy = shrink(60, 1000, 10, 80);
+    assert.ok(Math.abs(heavy.shrunk - 60) < 0.5, 'volume overwhelms the prior');
+    assert.throws(() => shrink(60, -1, 10, 80), /non-negative integer/);
+    assert.throws(() => shrink(60, 5, 0, 80), /k must be positive/);
+});
+
+test('normalizeEventBeats: canonical aggregates, aliases map, unmapped go to review — never mint (RQ8)', () => {
+    const { canonical, unmapped } = normalizeEventBeats(
+        ['monetary-policy', 'fed', 'crypto', 'novel-topic', 'monetary-policy']);
+    assert.deepEqual(canonical, ['monetary-policy'], 'alias folded in, duplicate dropped');
+    assert.deepEqual(unmapped, ['crypto', 'novel-topic'],
+        'crypto is deliberately unmapped — review list, not bitcoin');
+});
+
+test('computeDossier: a worked rollup — every number recomputable by hand', () => {
+    const rollup = computeDossier({
+        aggregates: [
+            { finalScore: 80, moduleContributions: [{ module: 'omission', score: 75 }, { module: 'source_quality', score: 60 }] },
+            { finalScore: 70, moduleContributions: [{ module: 'omission', score: 65 }, { module: 'source_quality', score: null }] },
+            { finalScore: 90, moduleContributions: [] }
+        ],
+        resolvedPredictions: [
+            { hedge_level: 'confident', outcome: 'true' },    // brier 0.01
+            { hedge_level: 'confident', outcome: 'false' },   // brier 0.81
+            { hedge_level: 'hedged', outcome: 'unresolvable' } // excluded
+        ],
+        totalPredictions: 5,
+        k: 10,
+        populationMean: 77
+    });
+
+    assert.equal(rollup.articleCount, 3);
+    close(rollup.scoreMeanRaw, 80, 'raw mean of 80/70/90');
+    // shrunk = (3/13)·80 + (10/13)·77 = 77.69…
+    close(rollup.scoreMean, 77.69, 'shrunk toward population 77 at n=3, k=10');
+    close(rollup.shrinkageFactor, 0.7692, 'factor published with every rollup');
+    assert.equal(rollup.scoreMedian, 80);
+    close(rollup.scoreStdev, 8.16, 'population stdev of 80/70/90');
+    assert.deepEqual(rollup.perModuleMeans, { omission: 70, source_quality: 60 },
+        'null module scores excluded, not zeroed');
+    assert.equal(rollup.predictions.total, 5);
+    assert.equal(rollup.predictions.resolved, 2, 'unresolvable excluded everywhere');
+    assert.equal(rollup.predictions.calibration.confident.rate, 0.5);
+    close(rollup.predictions.calibration_v1.mean_brier, 0.41, 'mean of 0.01 and 0.81');
+    assert.equal(rollup.predictions.calibration_v1.multiplier, null,
+        'logged, NOT activated — no rollup ever applies it in v1 (RQ4)');
+});
+
+test('computeDossier: zero articles = the population prior, honestly labeled', () => {
+    const rollup = computeDossier({ aggregates: [], populationMean: 77 });
+    assert.equal(rollup.articleCount, 0);
+    assert.equal(rollup.scoreMeanRaw, null);
+    assert.equal(rollup.scoreMean, 77, 'no data → the prior, factor 1');
+    assert.equal(rollup.shrinkageFactor, 1);
+    assert.equal(rollup.scoreMedian, null);
+    assert.equal(rollup.predictions.resolved, 0);
+});
+
+test('computeDossier: default total is the RESOLVED count — unresolvables need an explicit total', () => {
+    // When the caller doesn't supply totalPredictions, total defaults
+    // to the resolved count (total ≥ resolved stays consistent);
+    // unresolvable entries are excluded from both. A caller tracking
+    // open + unresolvable predictions passes totalPredictions
+    // explicitly.
+    const rollup = computeDossier({
+        aggregates: [],
+        resolvedPredictions: [
+            { hedge_level: 'confident', outcome: 'true' },
+            { hedge_level: 'hedged', outcome: 'unresolvable' }
+        ],
+        populationMean: 77
+    });
+    assert.equal(rollup.predictions.resolved, 1);
+    assert.equal(rollup.predictions.total, 1, 'default total = resolved count, never raw array length');
+});
+
+test('computeDossier: deterministic — same inputs, same rollup (reproducibility, P12)', () => {
+    const inputs = {
+        aggregates: [{ finalScore: 73.4 }, { finalScore: 81.2 }],
+        resolvedPredictions: [{ hedge_level: 'speculative', outcome: 'partial' }],
+        populationMean: 77
+    };
+    assert.deepEqual(computeDossier(inputs), computeDossier(inputs));
+});
+
+test('computeDossier: auditor-kind-agnostic — identity never enters the math (RQ3)', () => {
+    const a = computeDossier({
+        aggregates: [{ finalScore: 70, auditor: { kind: 'human', id: 'h'.repeat(64) } }],
+        populationMean: 77
+    });
+    const b = computeDossier({
+        aggregates: [{ finalScore: 70, auditor: { kind: 'pipeline', id: 'xray-auditor/0.1.0' } }],
+        populationMean: 77
+    });
+    assert.deepEqual(a, b, 'a human-scored 70 rolls up exactly like a pipeline-scored 70');
+});

--- a/tests/audit-ledger-builders.test.mjs
+++ b/tests/audit-ledger-builders.test.mjs
@@ -1,0 +1,495 @@
+// Phase 13.3 — wire builders + parsers for kinds 30058–30061.
+// Pinned-tag-vocabulary tests, the Phase-11 idiom.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+import {
+    buildPredictionEntryEvent, parsePredictionEntryEvent,
+    buildPredictionResolutionEvent, parsePredictionResolutionEvent,
+    buildDossierSnapshotEvent, parseDossierSnapshotEvent,
+    buildAuditDisputeEvent, parseAuditDisputeEvent,
+    derivePredictionEntryDTag, derivePredictionResolutionDTag,
+    deriveDossierSnapshotDTag, deriveAuditDisputeDTag
+} from '../src/shared/audit/builders.js';
+
+const HASH = 'a'.repeat(64);
+const MODEL = { kind: 'model', id: 'anthropic/claude-sonnet-4-6' };
+const HUMAN = { kind: 'human', id: 'b'.repeat(64) };
+const PIPELINE = { kind: 'pipeline', id: 'xray-auditor/0.1.0/anthropic/claude-sonnet-4-6' };
+const URL = 'https://example.com/story?utm_source=feed';
+
+function sha16(s) {
+    return createHash('sha256').update(s, 'utf8').digest('hex').slice(0, 16);
+}
+function firstTag(event, name) { return event.tags.find((t) => t[0] === name); }
+function tagsNamed(event, name) { return event.tags.filter((t) => t[0] === name); }
+
+function predictionArgs(overrides = {}) {
+    return {
+        articleHash: HASH,
+        predictionText: 'Rates will fall by December.',
+        predictionType: 'explicit',
+        hedgeLevel: 'confident',
+        attribution: 'named_source',
+        attributedName: 'Chair Powell',
+        horizon: 'by the end of the year',
+        horizonIso: '2026-12-31',
+        criteria: 'Fed funds target below current on Dec 31',
+        tractability: 'publicly_resolvable',
+        evidenceQuote: 'rates will come down before December',
+        moduleVersion: '1.0',
+        articleUrl: URL,
+        auditor: MODEL,
+        ...overrides
+    };
+}
+
+test('30058: full tag shape; content is the prediction text and NOTHING else', async () => {
+    const { event, body, dTag } = await buildPredictionEntryEvent(predictionArgs({
+        claimCoord: `30040:${'c'.repeat(64)}:claim_1234567890abcdef`,
+        authorEntityPubkey: 'd'.repeat(64),
+        anchor: [{ type: 'TextQuoteSelector', exact: 'rates will come down' }]
+    }));
+
+    assert.equal(event.kind, 30058);
+    assert.equal(body, 'Rates will fall by December.');
+    assert.equal(event.content, body, 'content = prediction text — the d is recomputable from the event');
+    assert.equal(dTag, 'pred:' + sha16(`${HASH}|rates will fall by december.`),
+        'd over hash|norm(text), the claim-id discipline');
+
+    assert.deepEqual(firstTag(event, 'x'), ['x', HASH]);
+    assert.deepEqual(tagsNamed(event, 'a').find((t) => t[3] === 'claim'),
+        ['a', `30040:${'c'.repeat(64)}:claim_1234567890abcdef`, '', 'claim']);
+    assert.deepEqual(firstTag(event, 'prediction-type'), ['prediction-type', 'explicit']);
+    assert.deepEqual(firstTag(event, 'hedge'), ['hedge', 'confident']);
+    assert.deepEqual(firstTag(event, 'attribution'), ['attribution', 'named_source']);
+    assert.deepEqual(firstTag(event, 'attributed-name'), ['attributed-name', 'Chair Powell']);
+    assert.deepEqual(firstTag(event, 'p'), ['p', 'd'.repeat(64), '', 'predicts']);
+    assert.deepEqual(firstTag(event, 'horizon'), ['horizon', 'by the end of the year']);
+    assert.deepEqual(firstTag(event, 'horizon-iso'), ['horizon-iso', '2026-12-31']);
+    assert.deepEqual(firstTag(event, 'tractability'), ['tractability', 'publicly_resolvable']);
+    assert.deepEqual(firstTag(event, 'quote'), ['quote', 'rates will come down before December']);
+    assert.deepEqual(firstTag(event, 'criteria'), ['criteria', 'Fed funds target below current on Dec 31']);
+    assert.deepEqual(firstTag(event, 'module-version'), ['module-version', '1.0']);
+    assert.deepEqual(JSON.parse(firstTag(event, 'anchor')[1]),
+        [{ type: 'TextQuoteSelector', exact: 'rates will come down' }]);
+    assert.deepEqual(firstTag(event, 'r'), ['r', URL]);
+    assert.deepEqual(firstTag(event, 'i'), ['i', 'https://example.com/story']);
+    assert.deepEqual(firstTag(event, 'client'), ['client', 'xray']);
+    for (const name of ['stance', 'rating-value', 'L', 'l', 'score', 'confidence']) {
+        assert.equal(firstTag(event, name), undefined, `30058 never carries ${name}`);
+    }
+});
+
+test('30058: d converges across phrasing noise — the ledger survives re-extraction', async () => {
+    const a = await buildPredictionEntryEvent(predictionArgs());
+    const b = await buildPredictionEntryEvent(predictionArgs({
+        predictionText: '  rates  WILL fall   by december. '
+    }));
+    assert.equal(a.dTag, b.dTag, 'same normalized text, one ledger identity');
+    assert.equal(await derivePredictionEntryDTag(HASH, 'Rates will fall by December.'), a.dTag);
+
+    const otherHash = await buildPredictionEntryEvent(predictionArgs({ articleHash: 'e'.repeat(64) }));
+    assert.notEqual(a.dTag, otherHash.dTag, 'stealth edits fork the ledger per text version');
+});
+
+test('30058: validation — enums, conditional antecedent, evidence-bound, claim kind', async () => {
+    await assert.rejects(buildPredictionEntryEvent(predictionArgs({ hedgeLevel: 'certain' })),
+        /hedgeLevel must be one of/);
+    await assert.rejects(buildPredictionEntryEvent(predictionArgs({ predictionType: 'conditional', condition: null })),
+        /conditional predictions require the condition/);
+    await assert.rejects(buildPredictionEntryEvent(predictionArgs({ evidenceQuote: '' })),
+        /evidenceQuote required/);
+    await assert.rejects(buildPredictionEntryEvent(predictionArgs({ criteria: '' })),
+        /criteria required/);
+    await assert.rejects(buildPredictionEntryEvent(predictionArgs({ claimCoord: `30054:${'c'.repeat(64)}:assess_x` })),
+        /claimCoord must be a 30040/);
+    await assert.rejects(buildPredictionEntryEvent(predictionArgs({ horizonIso: 'December' })),
+        /horizonIso must be YYYY-MM-DD/);
+});
+
+test('30058: round-trip incl. human auditor (RQ3); descriptive-horizon entries carry no horizon-iso', async () => {
+    const { event, dTag } = await buildPredictionEntryEvent(predictionArgs({
+        auditor: HUMAN, horizonIso: null, attribution: 'article_voice', attributedName: null
+    }));
+    assert.deepEqual(tagsNamed(event, 'p').find((t) => t[3] === 'auditor'),
+        ['p', HUMAN.id, '', 'auditor']);
+    assert.equal(firstTag(event, 'horizon-iso'), undefined, 'unscheduled — lists under "unscheduled"');
+
+    const parsed = parsePredictionEntryEvent({ ...event, pubkey: HUMAN.id, id: '1'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.id, dTag);
+    assert.equal(parsed.text, 'Rates will fall by December.');
+    assert.equal(parsed.predictionType, 'explicit');
+    assert.equal(parsed.hedgeLevel, 'confident');
+    assert.equal(parsed.horizonIso, null);
+    assert.deepEqual(parsed.auditor, HUMAN);
+    assert.equal(parsed.evidenceQuote, 'rates will come down before December');
+    assert.equal(await derivePredictionEntryDTag(parsed.articleHash, parsed.text), parsed.id,
+        'd verifiable from the event itself');
+});
+
+test('30058 parser: null without d/x/auditor, empty content, or bad enums', async () => {
+    const { event } = await buildPredictionEntryEvent(predictionArgs());
+    for (const name of ['d', 'x', 'auditor']) {
+        assert.equal(parsePredictionEntryEvent({ ...event, tags: event.tags.filter((t) => t[0] !== name) }),
+            null, `must be null without ${name}`);
+    }
+    assert.equal(parsePredictionEntryEvent({ ...event, content: '   ' }), null);
+    const badHedge = { ...event, tags: event.tags.map((t) => (t[0] === 'hedge' ? ['hedge', 'certain'] : t)) };
+    assert.equal(parsePredictionEntryEvent(badHedge), null,
+        'an unparseable hedge level would corrupt calibration — reject, never default');
+    const badType = { ...event, tags: event.tags.map((t) => (t[0] === 'prediction-type' ? ['prediction-type', 'guess'] : t)) };
+    assert.equal(parsePredictionEntryEvent(badType), null);
+    assert.equal(parsePredictionEntryEvent({ ...event, tags: event.tags.filter((t) => t[0] !== 'attribution') }), null,
+        'a missing attribution would silently book a named source\'s prediction against the author — reject');
+    assert.equal(parsePredictionEntryEvent({ ...event, kind: 30057 }), null);
+});
+
+test('30058: maximal round-trip — every optional field survives parse, claim-a before article-a', async () => {
+    const { event } = await buildPredictionEntryEvent(predictionArgs({
+        predictionType: 'conditional',
+        condition: 'if the Fed holds in November',
+        claimCoord: `30040:${'c'.repeat(64)}:claim_1234567890abcdef`,
+        articleCoord: `30023:${'d'.repeat(64)}:1234567890abcdef`,
+        authorEntityPubkey: 'e'.repeat(64),
+        anchor: [{ type: 'TextQuoteSelector', exact: 'rates will come down' }]
+    }));
+    // Foreign serialization: claim a-tag before article a-tag.
+    const aTags = event.tags.filter((t) => t[0] === 'a');
+    const reordered = {
+        ...event, pubkey: MODEL.id, id: '8'.repeat(64),
+        tags: [...event.tags.filter((t) => t[0] !== 'a'), ...aTags.reverse()]
+    };
+    const parsed = parsePredictionEntryEvent(reordered);
+    assert.equal(parsed.claimCoord, `30040:${'c'.repeat(64)}:claim_1234567890abcdef`, 'role-marked claim ref');
+    assert.equal(parsed.articleCoord, `30023:${'d'.repeat(64)}:1234567890abcdef`, 'prefix-matched article ref');
+    assert.equal(parsed.authorEntityPubkey, 'e'.repeat(64));
+    assert.equal(parsed.condition, 'if the Fed holds in November');
+    assert.equal(parsed.attributedName, 'Chair Powell');
+    assert.deepEqual(parsed.anchor, [{ type: 'TextQuoteSelector', exact: 'rates will come down' }]);
+});
+
+function resolutionArgs(overrides = {}) {
+    return {
+        predictionCoord: `30058:${'c'.repeat(64)}:pred:1111111111111111`,
+        articleHash: HASH,
+        outcome: 'false',
+        confidence: 0.9,
+        resolvedAt: '2027-01-15T00:00:00Z',
+        evidence: [
+            { kind: 'url', value: 'https://fred.example/data', description: 'the December print' },
+            { kind: 'nostr_event', value: `30023:${'d'.repeat(64)}:abcd1234abcd1234`, description: 'captured follow-up' },
+            { kind: 'quote', value: 'rates ended the year higher', description: 'from the follow-up' }
+        ],
+        notes: 'Rates rose; the prediction failed on its own criteria.',
+        auditor: HUMAN,
+        ...overrides
+    };
+}
+
+test('30059: full tag shape — typed evidence, nostr_event gets an indexing a tag', async () => {
+    const { event, body, dTag } = await buildPredictionResolutionEvent(resolutionArgs());
+
+    assert.equal(event.kind, 30059);
+    assert.equal(body, 'Rates rose; the prediction failed on its own criteria.');
+    assert.equal(dTag, 'res:' + sha16(`30058:${'c'.repeat(64)}:pred:1111111111111111`),
+        'd over the prediction coordinate verbatim');
+    assert.deepEqual(firstTag(event, 'a'),
+        ['a', `30058:${'c'.repeat(64)}:pred:1111111111111111`, '', 'prediction'],
+        'role-marked — evidence also emits plain a tags');
+    assert.deepEqual(firstTag(event, 'x'), ['x', HASH],
+        'x is REQUIRED: pred-d is a one-way hash, so an x-less resolution is invisible to article queries');
+    assert.deepEqual(firstTag(event, 'outcome'), ['outcome', 'false']);
+    assert.deepEqual(firstTag(event, 'resolved-at'), ['resolved-at', '2027-01-15T00:00:00Z']);
+    assert.deepEqual(tagsNamed(event, 'evidence'), [
+        ['evidence', 'url', 'https://fred.example/data', 'the December print'],
+        ['evidence', 'nostr_event', `30023:${'d'.repeat(64)}:abcd1234abcd1234`, 'captured follow-up'],
+        ['evidence', 'quote', 'rates ended the year higher', 'from the follow-up']
+    ], 'all three framework fields per entry — kind, value, description');
+    assert.deepEqual(tagsNamed(event, 'a')[1], ['a', `30023:${'d'.repeat(64)}:abcd1234abcd1234`],
+        'nostr_event evidence also gets a plain a tag for relay indexing');
+    assert.deepEqual(tagsNamed(event, 'p').find((t) => t[3] === 'auditor'),
+        ['p', HUMAN.id, '', 'auditor'], 'human resolver indexed');
+});
+
+test('30059: evidence-bound — no evidence, no resolution (P3)', async () => {
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({ evidence: [] })),
+        /at least one evidence entry required/);
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({
+        evidence: [{ kind: 'hearsay', value: 'trust me', description: '' }]
+    })), /evidence kind must be one of/);
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({ outcome: 'True' })),
+        /outcome must be one of/);
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({
+        predictionCoord: `30040:${'c'.repeat(64)}:claim_x`
+    })), /must be a 30058 coordinate/);
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({ articleHash: null })),
+        /articleHash must be 64 lowercase hex/, 'x is required on resolutions');
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({ confidence: 1.5 })),
+        /confidence must be a number/);
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({ resolvedAt: 'last week' })),
+        /must be an ISO-8601/);
+    await assert.rejects(buildPredictionResolutionEvent(resolutionArgs({
+        evidence: [{ kind: 'nostr_event', value: 'naddr1qqxyz', description: 'bech32 is not the wire grammar' }]
+    })), /raw coordinate or 64-hex event id/);
+});
+
+test('30059: confidence 0 rides the wire and round-trips (falsy-safe)', async () => {
+    const { event } = await buildPredictionResolutionEvent(resolutionArgs({ confidence: 0 }));
+    assert.deepEqual(firstTag(event, 'confidence'), ['confidence', '0']);
+    const parsed = parsePredictionResolutionEvent({ ...event, pubkey: HUMAN.id, id: '6'.repeat(64) });
+    assert.equal(parsed.confidence, 0);
+});
+
+test('30059 parser: evidence-derived a/e tags are never the prediction reference (foreign order)', async () => {
+    const { event } = await buildPredictionResolutionEvent(resolutionArgs({
+        evidence: [
+            { kind: 'nostr_event', value: `30058:${'f'.repeat(64)}:pred:9999999999999999`, description: 'cites another prediction' },
+            { kind: 'nostr_event', value: '9'.repeat(64), description: 'an event id as evidence' }
+        ]
+    }));
+    // Foreign serialization: evidence tags first.
+    const reordered = {
+        ...event, pubkey: HUMAN.id, id: '7'.repeat(64),
+        tags: [...event.tags.filter((t) => t[0] === 'evidence' || (t[0] === 'a' && t.length === 2) || (t[0] === 'e' && t.length === 2)),
+            ...event.tags.filter((t) => !(t[0] === 'evidence' || (t[0] === 'a' && t.length === 2) || (t[0] === 'e' && t.length === 2)))]
+    };
+    const parsed = parsePredictionResolutionEvent(reordered);
+    assert.equal(parsed.predictionCoord, `30058:${'c'.repeat(64)}:pred:1111111111111111`,
+        'the role-marked reference wins even when an evidence 30058 coordinate precedes it');
+    assert.equal(parsed.predictionEventId, null,
+        'an evidence event id is not the prediction event id');
+});
+
+test('30059: round-trip; same resolver + same prediction = same d (latest-wins by design)', async () => {
+    const a = await buildPredictionResolutionEvent(resolutionArgs());
+    const b = await buildPredictionResolutionEvent(resolutionArgs({ outcome: 'partial' }));
+    assert.equal(a.dTag, b.dTag,
+        'the resolver revising their resolution replaces — the accepted RQ5 P9 tension');
+
+    const parsed = parsePredictionResolutionEvent({ ...a.event, pubkey: HUMAN.id, id: '2'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.outcome, 'false');
+    assert.equal(parsed.confidence, 0.9);
+    assert.equal(parsed.evidence.length, 3);
+    assert.deepEqual(parsed.evidence[1],
+        { kind: 'nostr_event', value: `30023:${'d'.repeat(64)}:abcd1234abcd1234`, description: 'captured follow-up' });
+    assert.equal(await derivePredictionResolutionDTag(parsed.predictionCoord), parsed.id);
+    assert.deepEqual(parsed.auditor, HUMAN);
+});
+
+test('30059 parser: null without d, the prediction a-coord, valid outcome, or auditor', async () => {
+    const { event } = await buildPredictionResolutionEvent(resolutionArgs());
+    for (const name of ['d', 'a', 'auditor']) {
+        assert.equal(parsePredictionResolutionEvent({ ...event, tags: event.tags.filter((t) => t[0] !== name) }),
+            null, `must be null without ${name}`);
+    }
+    const badOutcome = { ...event, tags: event.tags.map((t) => (t[0] === 'outcome' ? ['outcome', 'maybe'] : t)) };
+    assert.equal(parsePredictionResolutionEvent(badOutcome), null);
+    assert.equal(parsePredictionResolutionEvent({ ...event, kind: 30058 }), null);
+});
+
+function dossierArgs(overrides = {}) {
+    return {
+        subjectKind: 'publication_x_beat',
+        entityPubkey: 'e'.repeat(64),
+        beat: 'monetary-policy',
+        windowStart: '2026-01-01T00:00:00Z',
+        windowEnd: '2026-06-11T00:00:00Z',
+        articleCount: 14,
+        scoreMean: 73.5,
+        scoreMedian: 75,
+        scoreStdev: 8.1,
+        shrinkageK: 10,
+        populationMean: 77,
+        shrinkageFactor: 0.42,
+        perModuleMeans: { source_quality: 68.2, omission: 71.5 },
+        predictions: {
+            total: 9, resolved: 4,
+            calibration: { confident: { resolved: 2, true_count: 1, rate: 0.5 }, hedged: { resolved: 2, true_count: 2, rate: 1 }, speculative: { resolved: 0, true_count: 0, rate: null } },
+            calibration_v1: { version: 'calibration-v1', mean_brier: 0.305, resolved_count: 4, multiplier: null }
+        },
+        auditor: PIPELINE,
+        ...overrides
+    };
+}
+
+test('30060: full tag shape — latest-wins cache, parameters on the wire for re-derivation', async () => {
+    const { event, body, dTag } = await buildDossierSnapshotEvent(dossierArgs());
+
+    assert.equal(event.kind, 30060);
+    assert.equal(dTag, 'dossier:' + sha16(`publication_x_beat|${'e'.repeat(64)}|monetary-policy`),
+        'd over subjectKind|subjectId; pub×beat id = pubkey|slug');
+    assert.deepEqual(firstTag(event, 'subject-kind'), ['subject-kind', 'publication_x_beat']);
+    assert.deepEqual(firstTag(event, 'p'), ['p', 'e'.repeat(64)]);
+    assert.deepEqual(firstTag(event, 't'), ['t', 'monetary-policy']);
+    assert.deepEqual(firstTag(event, 'shrinkage-k'), ['shrinkage-k', '10']);
+    assert.deepEqual(firstTag(event, 'population-mean'), ['population-mean', '77']);
+    assert.deepEqual(firstTag(event, 'shrinkage-factor'), ['shrinkage-factor', '0.42']);
+    const content = JSON.parse(body);
+    assert.equal(content.predictions.calibration_v1.multiplier, null,
+        'logged, not activated — the wire never carries an applied multiplier in v1');
+    assert.equal(content.per_module_means.source_quality, 68.2);
+});
+
+test('30060: beat subjects MUST be canonical beats-v1 slugs — free-form never mints dossiers (RQ8)', async () => {
+    await assert.rejects(buildDossierSnapshotEvent(dossierArgs({ subjectKind: 'beat', entityPubkey: null, beat: 'fed' })),
+        /MUST be canonical beats-v1 slugs/, 'an alias is not a subject id — normalize first');
+    await assert.rejects(buildDossierSnapshotEvent(dossierArgs({ subjectKind: 'beat', entityPubkey: null, beat: 'monetarypolicy' })),
+        /MUST be canonical beats-v1 slugs/);
+    const ok = await buildDossierSnapshotEvent(dossierArgs({ subjectKind: 'beat', entityPubkey: null, beat: 'monetary-policy' }));
+    assert.equal(ok.dTag, 'dossier:' + sha16('beat|monetary-policy'));
+    assert.equal(firstTag(ok.event, 'p'), undefined, 'a beat is a bare tag — no entity pubkey assumed');
+
+    // Beat-only subjects parse and d-recompute like entity subjects.
+    const parsed = parseDossierSnapshotEvent({ ...ok.event, pubkey: 'e'.repeat(64), id: '9'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.beat, 'monetary-policy');
+    assert.equal(parsed.entityPubkey, null);
+    assert.equal(await deriveDossierSnapshotDTag('beat', parsed.beat), parsed.id);
+});
+
+test('30060: empty dossiers are never published — articleCount 0 rejects', async () => {
+    await assert.rejects(buildDossierSnapshotEvent(dossierArgs({ articleCount: 0 })),
+        /empty dossiers are never published/,
+        'a zero-article rollup is just the population prior — noise dressed as judgment');
+});
+
+test('30060: subject-kind requirements enforced; round-trips', async () => {
+    await assert.rejects(buildDossierSnapshotEvent(dossierArgs({ subjectKind: 'author', entityPubkey: null })),
+        /subjects need entityPubkey/);
+    const { event, dTag } = await buildDossierSnapshotEvent(dossierArgs({
+        subjectKind: 'author', entityPubkey: 'f'.repeat(64), beat: null
+    }));
+    const parsed = parseDossierSnapshotEvent({ ...event, pubkey: 'e'.repeat(64), id: '3'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.id, dTag);
+    assert.equal(parsed.subjectKind, 'author');
+    assert.equal(parsed.entityPubkey, 'f'.repeat(64));
+    assert.equal(parsed.scoreMean, 73.5);
+    assert.equal(parsed.shrinkageFactor, 0.42);
+    assert.equal(parsed.predictions.calibration_v1.multiplier, null);
+    assert.equal(await deriveDossierSnapshotDTag('author', 'f'.repeat(64)), parsed.id);
+});
+
+test('30060 parser: null when the subject anchors are missing', async () => {
+    const { event } = await buildDossierSnapshotEvent(dossierArgs());
+    for (const name of ['d', 'p', 't', 'subject-kind', 'auditor']) {
+        assert.equal(parseDossierSnapshotEvent({ ...event, tags: event.tags.filter((t) => t[0] !== name) }),
+            null, `pub×beat must be null without ${name}`);
+    }
+    assert.equal(parseDossierSnapshotEvent({ ...event, kind: 30054 }), null);
+});
+
+function disputeArgs(overrides = {}) {
+    return {
+        targetCoord: `30057:${'c'.repeat(64)}:agg:2222222222222222`,
+        targetKind: 'aggregate_audit',
+        articleHash: HASH,
+        contested: ['the omission finding quoting "no parent was reached"'],
+        evidence: [
+            { kind: 'url', value: 'https://example.com/parents-statement', description: 'parents were quoted here' },
+            { kind: 'quote', value: 'we spoke to the reporter on Tuesday', description: 'from the statement' }
+        ],
+        disputeSummary: 'The omission module missed a published stakeholder response.',
+        auditor: HUMAN,
+        ...overrides
+    };
+}
+
+test('30061: full tag shape — wire-format-only kind, filer-asserted status', async () => {
+    const { event, body, dTag } = await buildAuditDisputeEvent(disputeArgs());
+
+    assert.equal(event.kind, 30061);
+    assert.equal(body, 'The omission module missed a published stakeholder response.');
+    assert.equal(dTag, 'dispute:' + sha16(`30057:${'c'.repeat(64)}:agg:2222222222222222`),
+        'd over the target coordinate — one dispute per (filer, target)');
+    assert.deepEqual(firstTag(event, 'a'),
+        ['a', `30057:${'c'.repeat(64)}:agg:2222222222222222`, '', 'target'],
+        'role-marked — evidence also emits plain a tags');
+    assert.deepEqual(firstTag(event, 'target-kind'), ['target-kind', 'aggregate_audit']);
+    assert.deepEqual(firstTag(event, 'status'), ['status', 'open']);
+    assert.deepEqual(tagsNamed(event, 'contested'),
+        [['contested', 'the omission finding quoting "no parent was reached"']]);
+    assert.equal(tagsNamed(event, 'evidence').length, 2);
+    assert.deepEqual(tagsNamed(event, 'p').find((t) => t[3] === 'auditor'),
+        ['p', HUMAN.id, '', 'auditor'], 'the filer, indexed');
+});
+
+test('30061: challenges without evidence are returned, not adjudicated (§7)', async () => {
+    await assert.rejects(buildAuditDisputeEvent(disputeArgs({ evidence: [] })),
+        /at least one evidence entry required/);
+    await assert.rejects(buildAuditDisputeEvent(disputeArgs({ contested: [] })),
+        /contested must be a nonempty array/);
+    await assert.rejects(buildAuditDisputeEvent(disputeArgs({ status: 'upheld' })),
+        /status must be one of/,
+        'upheld\\/rejected derive from adjudication events — the filer cannot self-assert them');
+    await assert.rejects(buildAuditDisputeEvent(disputeArgs({ targetKind: 'assessment' })),
+        /targetKind must be one of/);
+});
+
+test('30061: round-trip; withdrawal replaces (filer amendment pre-adjudication)', async () => {
+    const open = await buildAuditDisputeEvent(disputeArgs());
+    const withdrawn = await buildAuditDisputeEvent(disputeArgs({ status: 'withdrawn' }));
+    assert.equal(open.dTag, withdrawn.dTag, 'same (filer, target) — amendment, not a new dispute');
+
+    const parsed = parseAuditDisputeEvent({ ...open.event, pubkey: HUMAN.id, id: '4'.repeat(64) });
+    assert.ok(parsed);
+    assert.equal(parsed.targetKind, 'aggregate_audit');
+    assert.equal(parsed.status, 'open');
+    assert.equal(parsed.contested.length, 1);
+    assert.equal(parsed.evidence.length, 2);
+    assert.deepEqual(parsed.auditor, HUMAN);
+    assert.equal(await deriveAuditDisputeDTag(parsed.targetCoord), parsed.id);
+
+    // A withdrawn dispute must not re-present as live.
+    const parsedWithdrawn = parseAuditDisputeEvent({ ...withdrawn.event, pubkey: HUMAN.id, id: '5'.repeat(64) });
+    assert.equal(parsedWithdrawn.status, 'withdrawn');
+    // Unknown/missing status defaults to open — a dispute of unknown
+    // state is treated as live, the conservative pole.
+    const noStatus = { ...open.event, pubkey: HUMAN.id, id: '6'.repeat(64),
+        tags: open.event.tags.filter((t) => t[0] !== 'status') };
+    assert.equal(parseAuditDisputeEvent(noStatus).status, 'open');
+});
+
+test('30061 parser: evidence a-tags are never the target — foreign tag order cannot misroute', async () => {
+    const { event } = await buildAuditDisputeEvent(disputeArgs({
+        evidence: [
+            { kind: 'nostr_event', value: `30023:${'d'.repeat(64)}:abcd1234abcd1234`, description: 'a captured article as evidence' },
+            { kind: 'url', value: 'https://example.com/x', description: 'context' }
+        ]
+    }));
+    // Foreign serialization: evidence-derived plain a tag FIRST.
+    const reordered = {
+        ...event, pubkey: HUMAN.id, id: '7'.repeat(64),
+        tags: [...event.tags.filter((t) => t[0] === 'evidence' || (t[0] === 'a' && t.length === 2)),
+            ...event.tags.filter((t) => !(t[0] === 'evidence' || (t[0] === 'a' && t.length === 2)))]
+    };
+    const parsed = parseAuditDisputeEvent(reordered);
+    assert.equal(parsed.targetCoord, `30057:${'c'.repeat(64)}:agg:2222222222222222`,
+        'the role-marked target wins; the d-recompute discipline depends on it');
+    assert.equal(await deriveAuditDisputeDTag(parsed.targetCoord), parsed.id);
+});
+
+test('30061 parser: null without d, target coord, valid target-kind, or auditor', async () => {
+    const { event } = await buildAuditDisputeEvent(disputeArgs());
+    for (const name of ['d', 'a', 'target-kind', 'auditor']) {
+        assert.equal(parseAuditDisputeEvent({ ...event, tags: event.tags.filter((t) => t[0] !== name) }),
+            null, `must be null without ${name}`);
+    }
+    assert.equal(parseAuditDisputeEvent({ ...event, kind: 30055 }), null);
+});
+
+test('cross-kind: every d derivation is deterministic and distinct per prefix', async () => {
+    const pred = await derivePredictionEntryDTag(HASH, 'X will happen');
+    const res = await derivePredictionResolutionDTag(`30058:${'c'.repeat(64)}:${pred}`);
+    const dossier = await deriveDossierSnapshotDTag('beat', 'bitcoin');
+    const dispute = await deriveAuditDisputeDTag(`30057:${'c'.repeat(64)}:agg:x`);
+    assert.match(pred, /^pred:[0-9a-f]{16}$/);
+    assert.match(res, /^res:[0-9a-f]{16}$/);
+    assert.match(dossier, /^dossier:[0-9a-f]{16}$/);
+    assert.match(dispute, /^dispute:[0-9a-f]{16}$/);
+});


### PR DESCRIPTION
Slice **13.3** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — completes the wire layer: **all six audit kinds now build, parse, and are specified in the NIP draft.** Stacked on #63. ⚠️ Wire-format change: four new event kinds (CHANGELOG callout).

## What's in it

| Kind | The contract it pins |
| --- | --- |
| **30058 PredictionEntry** | Convergent text-hash `d` (the claim-id discipline) — re-extraction converges, resolutions never retarget. Content = the prediction text and *nothing else*, so the `d` recomputes from the event alone. Conditional predictions require their antecedent; no score tags, ever. |
| **30059 PredictionResolution** | Evidence-bound (P3): at least one typed evidence entry required — *no evidence, no resolution*. `x` required (the prediction `d` is a one-way hash; an x-less resolution is invisible to article queries). One per (resolver, prediction); self-revision replaces — the accepted RQ5 tension, documented. |
| **30060 DossierSnapshot** | Cache semantics — the one latest-wins kind, wholly re-derivable from the parameters it carries. Beat subjects MUST be canonical `beats-v1` slugs (aliases reject: a dossier minted from a typo is a permanent subject identity). Empty dossiers are never published. |
| **30061 AuditDispute** | Wire-format-only (no filing UI, no adjudication runtime — explicit non-goal). Filer-asserted status is `open`/`withdrawn` only; upheld/rejected derive from other pubkeys' records. Challenges without evidence are returned, not adjudicated. |
| **`dossier.js`** | Pure reproducible rollup math: published shrinkage (§4 — the factor rides every rollup), per-module means, the canonical rate table, and the logged-not-activated `calibration_v1` block. Auditor-kind-blind (RQ3, pinned). |

## Review

Three-lens adversarial review with per-finding verification: **14 confirmed, 1 refuted by mutation testing, all fixed pre-PR.** The headline find: typed `nostr_event` evidence emits plain `a`/`e` indexing tags that were name-indistinguishable from the prediction/target *reference* tags — a wire-conformant foreign 30061 with evidence serialized first parsed the evidence article as the dispute target (reproduced live). References are now **role-marked** (`prediction`/`target`, the 30055 house idiom) with evidence-excluding fallbacks, and both docs were aligned. Also fixed: the parser's `article_voice` attribution fallback (would have silently booked a named source's prediction against the author's dossier — now rejects like hedge), the three-way nostr_event value-grammar disagreement, and the allowed-but-unconstructible zero-article dossier.

## Verification

30 new tests; full suite **779 pass / 0 fail**; build + lint clean.

This closes the wire layer (13.1–13.3). Next per the slice plan: 13.4 (capture-time hashing — the `x` tag on 30023s) and 13.5 (the import-then-sign execution path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)