### PR TITLE
feat(audit): Phase 13.4 — capture-time canonical hashing, the x tag on 30023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 13.4 — capture-time canonical hashing.** ⚠️ **Wire-format
+  change to kind 30023 (additive)**: new articles carry the canonical
+  article hash as an indexed `x` tag — SHA-256 of the normalized body
+  markdown (the content after the metadata header), the anchor every
+  audit kind joins on (`docs/NIP_DRAFT.md` §30023 `x` extension).
+  Pre-13.4 events are unaffected (no `x`; consumers fall back to
+  `r`/`d`). Interpolated metadata-header fields (title/byline/site
+  name) are newline-flattened at build time so a hostile value cannot
+  forge the header terminator and skew third-party hash
+  recomputation — a no-op for every real capture seen so far. Archive
+  records gain an `articleHash` field; the reader shows the hash under
+  the article meta and a warning banner when a re-capture of the same
+  URL hashes differently (the stealth-edit surface). Displaced
+  versions are retained on the archive row (`priorVersions`, bounded
+  at 3) so the text prior audits anchor to genuinely survives a
+  re-capture — "capturing both versions is its own diagnostic."
+
 - **Phase 13.1–13.3 — epistemic-audit foundation** (flag-gated,
   default off; `docs/EPISTEMIC_AUDIT_DESIGN.md`). The audit model
   layer (`src/shared/audit/`): canonical article hash (byte-parity

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,66 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.4: the hash reaches the capture pipeline
+
+**Tags:** design
+
+Slice 13.4 puts the canonical article hash on shipping surfaces. The
+second-guessable calls:
+
+- **The hash input is the assembled publish-path body, not raw
+  `article.content`.** `assembleArticleBody` was extracted from
+  `buildArticleEvent` so the capture path (archive record), the
+  publish path (the `x` tag), and any future import path hash
+  identical bytes. Consequence, stated in the design and now true in
+  code: the video transcript-chunking loop is part of the content
+  address — a formatting tweak there changes video hashes and gets
+  the wire-change treatment.
+- **Header fields are newline-flattened, not rejected.** A title
+  smuggling `\n---\n` would forge the header terminator and leak the
+  Archived date into a third party's hash recomputation. Flattening
+  to spaces is a no-op for every real capture seen so far and keeps
+  capture unbreakable by hostile page titles. Pinned by a hostile-
+  title test asserting the strip invariant byte-for-byte:
+  `stripMetadataHeader(event.content) === assembleArticleBody(article)`.
+- **Relay reconstructions carry the published hash (`_articleHash`),
+  never recompute.** A markdown→HTML→markdown round trip does not
+  byte-match the original body; recomputing would mint a divergent
+  hash for the same published text.
+- **The reader's stealth-edit check is sequenced, not racing.** The
+  load path previously fire-and-forgot the archive save; the hash
+  comparison must read the PRIOR row, so hash → compare → save now
+  run in order inside one async block (still non-blocking for
+  render).
+- **Dependency note:** `archive-cache.js` now imports
+  `event-builder.js` (for the body assembly) — which transitively
+  probes `chrome.storage.local` at module load, so archive-cache
+  tests gained the event-builder tests' minimal chrome stub.
+- **The adversarial review caught the slice contradicting itself —
+  8 confirmed findings, one BLOCKING.** The banner told the user
+  "your previous capture stays in the archive" while the very next
+  line's `saveArticle` overwrote the single per-URL row — destroying
+  the only local copy of the text prior audits anchor to,
+  milliseconds after promising to keep it (and the design note had
+  explicitly committed to local survival, so softening the copy was
+  not an option). Fix: **bounded stealth-edit retention** — when a
+  re-capture's hash differs, the displaced `{article, articleHash,
+  cachedAt, displacedAt}` snapshots onto the row's `priorVersions`
+  (cap 3; the row still LRU-evicts as a unit). Also from the review:
+  the hash line went stale after "Load archive" (now refreshed from
+  the archive's carried hash, or recomputed) and after body edits
+  (now flagged "edited, recomputed at publish" — honest display over
+  live recomputation against a half-synced draft); republishing a
+  relay-loaded archive would have stamped the OLD carried hash into
+  the archive row beside a new event whose x tag differs (publish now
+  stamps the just-built event's x); a failed hash no longer inherits
+  the prior row's (a hash labels THIS body — inheriting mislabels);
+  and three mutation-verified test holes (per-call-site header
+  sanitization, the legacy fenced-transcript body — the only shape
+  that pins the strip regex's laziness — and the hash-failure path).
+
+---
+
 ## 2026-06-11 — 13.3: the ledger kinds, and what a resolution must carry
 
 **Tags:** design

--- a/docs/NIP_DRAFT.md
+++ b/docs/NIP_DRAFT.md
@@ -6,7 +6,7 @@ Web Content Annotations, Fact-Checks, and Topic Trust
 
 `draft` `optional`
 
-This NIP defines fourteen event kinds and one tag extension that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, and epistemic-audit records (per-module surface-scan results, aggregate article audits, a prediction ledger with resolutions, dossier rollup snapshots, and audit disputes — content-addressed to the exact text scored) — and lets readers query, rank, and surface that metadata in context.
+This NIP defines fourteen event kinds and two tag extensions that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, and epistemic-audit records (per-module surface-scan results, aggregate article audits, a prediction ledger with resolutions, dossier rollup snapshots, and audit disputes — content-addressed to the exact text scored) — and lets readers query, rank, and surface that metadata in context.
 
 It composes with rather than replaces:
 
@@ -561,6 +561,16 @@ Consumers visiting a URL or NOSTR event that is the target of a `responds-to` SH
 ```
 
 Filtered client-side to events that carry a matching `responds-to` tag.
+
+## Kind 30023 — `x` tag (extension)
+
+A long-form article (kind 30023) SHOULD carry the canonical article hash of its own body as an indexed `x` tag (NIP-94 precedent: the SHA-256 of the thing):
+
+```
+["x", "<sha256 of the normalized article body markdown>"]
+```
+
+The hash input is the event `content` after stripping the client metadata header (the leading `---…---` block), normalized exactly as specified in the kind-30056 section — so any consumer can verify the tag from the event alone, and `{"kinds":[30023],"#x":["<hash>"]}` finds the article a set of audit events scored. Additive and optional: events published before this extension carry no `x` tag and join audit queries by `r`/`d` instead; a re-published edit derives a NEW hash, which is the point — the audit kinds anchor to the exact text they scored, and a hash change between captures of one URL is a detected content change, not an error.
 
 ## Querying
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -997,6 +997,14 @@ Implementation slices 13.1+ are in progress.
   per rollup, per-module means, rate table + logged-not-activated
   `calibration_v1`); NIP_DRAFT §30058–§30061 + the beat-vocabulary
   clause. — #64
+- ✅ **13.4** Capture-time hashing — the canonical hash rides new
+  30023s as an indexed `x` tag (additive wire change, CHANGELOG
+  callout; NIP_DRAFT §30023 `x` extension); `assembleArticleBody`
+  extracted so capture and publish hash identical bytes;
+  header-field newline sanitization (terminator-forge defense);
+  `articleHash` on archive records; reader hash line + stealth-edit
+  mismatch banner (sequenced before the archive save so the
+  comparison reads the prior row). — #65
 
 ---
 

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -1731,6 +1731,55 @@ body {
   flex-shrink: 0;
 }
 
+/* ---------------- Canonical-hash line + stealth-edit banner (13.4) ------- */
+
+.xr-article__hash {
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--xr-text-dim);
+  margin-top: 4px;
+  user-select: all;
+}
+
+.xr-hash-banner {
+  max-width: var(--xr-reader-max-w);
+  margin: 14px auto 0;
+  padding: 12px 18px;
+  background: color-mix(in srgb, var(--xr-warning) 10%, var(--xr-surface));
+  border: 1px solid color-mix(in srgb, var(--xr-warning) 50%, transparent);
+  border-left: 3px solid var(--xr-warning);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.xr-hash-banner__body {
+  flex: 1;
+  min-width: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.xr-hash-banner__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--xr-text);
+}
+
+.xr-hash-banner__metric {
+  font-size: 11px;
+  color: var(--xr-text-dim);
+}
+
+.xr-hash-banner__actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
 /* ---------------- "Others' claims" relay-query modal (C5) ---------------- */
 
 .xr-claims__others-btn {

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -26,6 +26,7 @@ import { makeClaimRefCanonicalizer } from '../shared/claim-ref.js';
 import { selectAssessmentsToPublish, selectLinksToPublish, selectMirrors } from '../shared/assessment-publish.js';
 import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent } from '../shared/metadata/builders.js';
 import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
+import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
 
 const browserApi = typeof browser !== 'undefined' && browser.runtime ? browser : chrome;
 
@@ -142,9 +143,33 @@ async function loadArticle() {
     // (the portal's relay reconstructions, Phase 12.7): overwriting
     // the archive row here would reset its publishedToRelay marker and
     // break the portal's read-only guarantee.
+    //
+    // Phase 13.4: hash this capture (the canonical article hash — the
+    // `x` tag value) and compare against the prior archived record
+    // BEFORE the save replaces it. A different hash for the same URL
+    // is a detected content change (the stealth-edit surface) —
+    // sequenced, not racing, so the comparison reads the prior row.
     if (state.article && state.article.url && !(stored && stored.readOnly)) {
-        ArchiveCache.saveArticle({ article: state.article, source: 'capture' })
-            .catch((err) => console.warn('[X-Ray Reader] archive cache save failed:', err));
+        (async () => {
+            try {
+                state.articleHash = await canonicalArticleHash(
+                    EventBuilder.assembleArticleBody(state.article));
+                updateHashLine();
+            } catch (err) {
+                console.warn('[X-Ray Reader] article hash failed:', err);
+            }
+            try {
+                const prior = await ArchiveCache.getArticle(state.article.url);
+                if (prior && prior.articleHash && state.articleHash
+                        && prior.articleHash !== state.articleHash) {
+                    renderHashMismatchBanner(prior);
+                }
+            } catch (err) {
+                console.warn('[X-Ray Reader] hash check failed:', err);
+            }
+            ArchiveCache.saveArticle({ article: state.article, source: 'capture' })
+                .catch((err) => console.warn('[X-Ray Reader] archive cache save failed:', err));
+        })();
     }
 
     // Archive-reader affordance — if this capture looks paywalled OR
@@ -346,6 +371,18 @@ function loadArchivedArticle(archived, provenance) {
     state.htmlDraft     = archived.content  || ContentExtractor.markdownToHtml(state.markdownDraft);
     state.dirtySource   = 'reader';
 
+    // The hash line labels the visible body — the swapped-in archive
+    // is different text, so the load-time hash is wrong for it. Relay
+    // archives carry the PUBLISHED hash (carry, don't recompute: the
+    // HTML round trip doesn't byte-match); cache archives recompute.
+    state.articleHash = archived._articleHash || null;
+    state.hashDirty = false;
+    if (!state.articleHash) {
+        canonicalArticleHash(EventBuilder.assembleArticleBody(state.article))
+            .then((h) => { state.articleHash = h; updateHashLine(); })
+            .catch((err) => console.warn('[X-Ray Reader] archive hash failed:', err));
+    }
+
     // Re-render whatever view the user's currently in.
     switch (state.viewMode) {
         case 'reader':   renderReader();   break;
@@ -358,6 +395,53 @@ function loadArchivedArticle(archived, provenance) {
 // ------------------------------------------------------------------
 // Render — READER mode
 // ------------------------------------------------------------------
+
+// ------------------------------------------------------------------
+// Canonical article hash (Phase 13.4)
+// ------------------------------------------------------------------
+
+// Fill (or refresh) the small hash line under the article meta. The
+// hash computes async after first render, and mode switches re-render
+// the template — so this is callable from both paths.
+function updateHashLine() {
+    const el = $('#xr-article-hash');
+    if (!el) return;
+    if (!state.articleHash) { el.hidden = true; return; }
+    el.hidden = false;
+    if (state.hashDirty) {
+        el.title = 'The body was edited — the published hash is computed from the final text at publish time.';
+        el.textContent = 'content hash — edited, recomputed at publish';
+        return;
+    }
+    el.title = state.articleHash;
+    el.textContent = 'content hash ' + state.articleHash.slice(0, 16) + '…';
+}
+
+// Stealth-edit surface: the same URL hashed differently on a prior
+// capture. Informational — the prior text stays in the archive; the
+// re-audit affordance arrives with the audit panel (13.6).
+function renderHashMismatchBanner(prior) {
+    let banner = $('#xr-hash-banner');
+    if (!banner) {
+        banner = document.createElement('aside');
+        banner.id = 'xr-hash-banner';
+        banner.className = 'xr-hash-banner';
+        const main = $('#xr-main');
+        if (!main || !main.parentElement) return;
+        main.parentElement.insertBefore(banner, main);
+    }
+    const ago = prior.cachedAt ? new Date(prior.cachedAt * 1000).toLocaleDateString() : 'earlier';
+    banner.innerHTML = `
+      <div class="xr-hash-banner__body">
+        <div class="xr-hash-banner__label">⚠️ Content changed since your last capture (${escapeHtml(ago)})</div>
+        <div class="xr-hash-banner__metric">The text hashes differently — the page was edited between captures. Your previous capture stays in the archive; audits anchor to the exact text they scored.</div>
+      </div>
+      <div class="xr-hash-banner__actions">
+        <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-hash-dismiss">Dismiss</button>
+      </div>
+    `;
+    $('#xr-hash-dismiss').addEventListener('click', () => banner.remove());
+}
 
 function renderReader() {
     const a = state.article;
@@ -373,6 +457,7 @@ function renderReader() {
             ${field('Published',   'publishedAt', fmtDate(a.publishedAt))}
             ${field('URL',         'url',         a.url)}
           </div>
+          <div class="xr-article__hash" id="xr-article-hash" hidden></div>
         </header>
         ${renderYouTubeHeader(a)}
         ${renderTikTokHeader(a)}
@@ -436,6 +521,10 @@ function renderReader() {
     // Render the claims bar below the article body. Fires in the
     // background — we don't block the main render on it.
     refreshClaimsBar().catch((err) => console.warn('[X-Ray Reader] claims-bar render failed:', err));
+
+    // Re-fill the hash line — the template above recreates it hidden,
+    // and the hash (computed async at load) may already be known.
+    updateHashLine();
 
     // Wire metadata-field edits back to the article object.
     main.querySelectorAll('[contenteditable]').forEach((el) => {
@@ -987,8 +1076,16 @@ function buildCaptureHints(a) {
     return hints;
 }
 
-function onReaderFieldInput() {
+function onReaderFieldInput(ev) {
     state.dirtySource = 'reader';
+    // Body edits change what publish will hash and stamp as the x
+    // tag — the load-time hash no longer labels the visible text.
+    // Honest display beats live recomputation against a half-synced
+    // draft: flag dirty, recompute at publish (13.4).
+    if (ev && ev.target && ev.target.dataset.field === 'content' && !state.hashDirty) {
+        state.hashDirty = true;
+        updateHashLine();
+    }
 }
 
 function onReaderFieldBlur(ev) {
@@ -1518,6 +1615,20 @@ async function publish() {
         } catch (_) { /* identity is enrichment, never a publish gate */ }
 
         const unsignedArticle = await EventBuilder.buildArticleEvent(article, entityRefs, userPubkey, [], authorAccountPubkey);
+
+        // 13.4: the event just built carries the canonical hash of the
+        // FINAL (possibly edited) body as its x tag. Stamp it on the
+        // article so the post-publish archive save records the hash of
+        // what was actually published — a carried stale _articleHash
+        // (relay-loaded archives) would otherwise mislabel the row —
+        // and refresh the hash line, which may have been edit-dirty.
+        const publishedXTag = unsignedArticle.tags.find((t) => t[0] === 'x');
+        if (publishedXTag && publishedXTag[1]) {
+            article._articleHash = publishedXTag[1];
+            state.articleHash = publishedXTag[1];
+            state.hashDirty = false;
+            updateHashLine();
+        }
 
         btn.textContent = totalEvents > 1 ? `Publishing (1/${totalEvents})…` : 'Publishing…';
         const articleResp = await browserApi.runtime.sendMessage({

--- a/src/shared/archive-cache.js
+++ b/src/shared/archive-cache.js
@@ -37,11 +37,19 @@
 // permission means we have headroom to be sloppy about this for now.
 
 import { Utils } from './utils.js';
+import { EventBuilder } from './event-builder.js';
+import { articleHash as canonicalArticleHash } from './audit/article-hash.js';
 
 const DB_NAME        = 'xray-archive';
 const DB_VERSION     = 2;     // v2 (Phase 9a) added metadata stores
 const ARTICLES_STORE = 'articles';
 const MAX_ENTRIES    = 500;  // cheap starting budget; revisit if needed
+
+// Stealth-edit retention bound (13.4): displaced article versions kept
+// per row. Bounded because article bodies are large and the row is
+// LRU-evicted as a unit; three covers the realistic edit-detection
+// window without letting a churn-heavy page balloon its row.
+const MAX_PRIOR_VERSIONS = 3;
 
 // Phase 9a metadata stores (XRAY_METADATA_SPEC.md §6, Implementation Plan §4).
 // All keyed on `eventId` so we can dedupe across relays. `urlHash`
@@ -204,14 +212,56 @@ export async function saveArticle({ article, source = 'capture', publishedToRela
     const hash = await urlHash(url);
     const now = Math.floor(Date.now() / 1000);
 
+    // Phase 13.4 — the canonical article hash (the audit anchor, the
+    // `x` tag value). Relay-reconstructed articles carry the hash the
+    // publisher computed (`_articleHash`; recomputing after a
+    // markdown→HTML→markdown round trip would not byte-match);
+    // captures compute it from the same body assembly the publish
+    // path uses, so local and published hashes agree. Best-effort —
+    // a hash failure must never block archiving, and a failed hash
+    // stays null rather than inheriting the prior row's (the hash
+    // labels THIS article body; inheriting would mislabel new
+    // content with old identity). Computed BEFORE the store
+    // transaction opens (an awaited digest would let an IndexedDB
+    // transaction auto-commit under it).
+    let contentHash = article._articleHash || null;
+    if (!contentHash) {
+        try {
+            contentHash = await canonicalArticleHash(EventBuilder.assembleArticleBody(article));
+        } catch (err) {
+            Utils.error('archive-cache: article hash failed', err);
+        }
+    }
+
     const transaction = db.transaction(ARTICLES_STORE, 'readwrite');
     const store       = transaction.objectStore(ARTICLES_STORE);
     const existing    = await req(store.get(hash));
+
+    // Stealth-edit retention (13.4): this row is the only LOCAL copy
+    // of the text prior audits anchor to, and put() replaces it. When
+    // a re-capture's hash differs from the stored one, snapshot the
+    // displaced version (bounded) so "capturing both versions is its
+    // own diagnostic" stays true locally — the design's promise, and
+    // the reader banner's.
+    let priorVersions = (existing && Array.isArray(existing.priorVersions))
+        ? existing.priorVersions : [];
+    if (existing && existing.articleHash && contentHash
+            && existing.articleHash !== contentHash) {
+        priorVersions = [...priorVersions, {
+            article:     existing.article,
+            articleHash: existing.articleHash,
+            cachedAt:    existing.cachedAt,
+            source:      existing.source,
+            displacedAt: now
+        }].slice(-MAX_PRIOR_VERSIONS);
+    }
 
     const record = {
         urlHash:          hash,
         url,
         article,
+        articleHash:      contentHash,
+        priorVersions,
         cachedAt:         existing ? existing.cachedAt : now,
         lastAccessed:     now,
         source,

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -13,49 +13,27 @@ import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
 import { ContentExtractor } from './content-extractor.js';
 import { buildRespondsToTag, RESPONDS_TO_RELATIONSHIPS } from './metadata/builders.js';
+import { articleHash } from './audit/article-hash.js';
 
 // Re-export the metadata helpers so callers that already import from
 // `event-builder.js` don't need a second import path. See spec §6.4.
 export { buildRespondsToTag, RESPONDS_TO_RELATIONSHIPS } from './metadata/builders.js';
 
 export const EventBuilder = {
-  // Build NIP-23 article event (kind 30023).
-  //
-  // `authorAccountPubkey` (Phase 9 identity) is the deterministic
-  // PlatformAccount pubkey of the POST author — when present, emitted as
-  // a `['p', pubkey, '', 'author']` reference so the post is linked to
-  // the same stable identity used for that author's comments elsewhere.
-  // Additive + optional: existing 4-arg callers are unaffected and emit
-  // no author p-tag, exactly as before.
-  buildArticleEvent: async (article, entities, userPubkey, claims = [], authorAccountPubkey = null) => {
+  // Assemble the publish-path article BODY — the markdown that follows
+  // the metadata header in a published 30023's content. This is the
+  // canonical-article-hash input (Phase 13.4): the audited text is the
+  // published text in full, so video Description/Transcript sections
+  // are INSIDE it, and the transcript chunking below is part of the
+  // content address — a formatting tweak here changes video hashes and
+  // gets the wire-change treatment (docs/EPISTEMIC_AUDIT_DESIGN.md
+  // §"Canonical article hash").
+  assembleArticleBody: (article) => {
     // Convert content to markdown, preserving formatting and images
     let markdownContent = article.content || '';
     if (markdownContent && markdownContent.includes('<')) {
       markdownContent = ContentExtractor.htmlToMarkdown(markdownContent);
     }
-
-    // Build metadata header for published content
-    let metadataHeader = '---\n';
-    metadataHeader += `**Source**: [${article.title}](${article.url})\n`;
-
-    // For video content, use "Channel" instead of "Author"
-    if (article.contentType === 'video' && article.byline) {
-      metadataHeader += `**Channel**: ${article.byline}\n`;
-    } else {
-      const metaParts = [];
-      if (article.siteName) metaParts.push(`**Publisher**: ${article.siteName}`);
-      if (article.byline) metaParts.push(`**Author**: ${article.byline}`);
-      if (metaParts.length) metadataHeader += metaParts.join(' | ') + '\n';
-    }
-
-    const dateParts = [];
-    if (article.publishedAt) {
-      dateParts.push(`**Published**: ${new Date(article.publishedAt * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`);
-    }
-    dateParts.push(`**Archived**: ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`);
-    metadataHeader += dateParts.join(' | ') + '\n';
-
-    metadataHeader += '---\n\n';
 
     // For video content, include description and transcript as separate sections
     if (article.contentType === 'video') {
@@ -91,8 +69,58 @@ export const EventBuilder = {
       }
     }
 
+    return markdownContent;
+  },
+
+  // Build NIP-23 article event (kind 30023).
+  //
+  // `authorAccountPubkey` (Phase 9 identity) is the deterministic
+  // PlatformAccount pubkey of the POST author — when present, emitted as
+  // a `['p', pubkey, '', 'author']` reference so the post is linked to
+  // the same stable identity used for that author's comments elsewhere.
+  // Additive + optional: existing 4-arg callers are unaffected and emit
+  // no author p-tag, exactly as before.
+  buildArticleEvent: async (article, entities, userPubkey, claims = [], authorAccountPubkey = null) => {
+    const markdownContent = EventBuilder.assembleArticleBody(article);
+
+    // Header fields are interpolated raw between the `---` markers; a
+    // value smuggling a newline could forge the header terminator and
+    // leak header residue (the Archived date) into a third party's
+    // hash recomputation (Phase 13.4). Newlines have no business in a
+    // title/byline/site name anyway — flatten them.
+    const headerField = (v) => String(v == null ? '' : v).replace(/[\r\n]+/g, ' ');
+
+    // Build metadata header for published content
+    let metadataHeader = '---\n';
+    metadataHeader += `**Source**: [${headerField(article.title)}](${headerField(article.url)})\n`;
+
+    // For video content, use "Channel" instead of "Author"
+    if (article.contentType === 'video' && article.byline) {
+      metadataHeader += `**Channel**: ${headerField(article.byline)}\n`;
+    } else {
+      const metaParts = [];
+      if (article.siteName) metaParts.push(`**Publisher**: ${headerField(article.siteName)}`);
+      if (article.byline) metaParts.push(`**Author**: ${headerField(article.byline)}`);
+      if (metaParts.length) metadataHeader += metaParts.join(' | ') + '\n';
+    }
+
+    const dateParts = [];
+    if (article.publishedAt) {
+      dateParts.push(`**Published**: ${new Date(article.publishedAt * 1000).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`);
+    }
+    dateParts.push(`**Archived**: ${new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}`);
+    metadataHeader += dateParts.join(' | ') + '\n';
+
+    metadataHeader += '---\n\n';
+
     // Prepend metadata header to content
     const content = metadataHeader + markdownContent;
+
+    // Canonical article hash (Phase 13.4): SHA-256 of the normalized
+    // body — exactly what stripMetadataHeader recovers from this
+    // event's content, so any third party can verify the tag from the
+    // event alone. The anchor every audit kind joins on (`#x`).
+    const articleXHash = await articleHash(markdownContent);
 
     // Note: Images are kept as original URLs to avoid exceeding relay event size limits
     // (base64 embedding can inflate events to megabytes, causing universal relay rejection).
@@ -104,6 +132,7 @@ export const EventBuilder = {
       ['title', article.title || 'Untitled'],
       ['published_at', String(article.publishedAt || Math.floor(Date.now() / 1000))],
       ['r', article.url],
+      ['x', articleXHash],
       ['client', 'xray']
     ];
     
@@ -769,6 +798,11 @@ export const EventBuilder = {
       _nostrEventId: event.id,
       _nostrCreatedAt: event.created_at,
       _nostrPubkey: event.pubkey,
+      // Phase 13.4 — the canonical article hash the publisher computed
+      // at build time (the `x` tag). Carried as published rather than
+      // recomputed: a markdown→HTML→markdown round trip would not
+      // byte-match the original body. Null on pre-13.4 events.
+      _articleHash: tags['x'] || null,
     };
 
     // Reconstruct engagement

--- a/tests/archive-cache.test.mjs
+++ b/tests/archive-cache.test.mjs
@@ -11,6 +11,15 @@ import assert from 'node:assert/strict';
 // module's `globalThis.indexedDB` lookup lands on the fake.
 await import('fake-indexeddb/auto');
 
+// Since 13.4 the cache imports event-builder (for the canonical
+// article-hash body assembly), which transitively imports Storage —
+// and storage.js probes `chrome.storage.local` at module-load time.
+// Stub a minimal chrome global before importing (the
+// event-builder.test.mjs idiom).
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
 const {
     openArchiveDb, urlHash,
     saveArticle, getArticle, hasArticle, deleteArticle,

--- a/tests/audit-capture-hash.test.mjs
+++ b/tests/audit-capture-hash.test.mjs
@@ -1,0 +1,217 @@
+// Phase 13.4 — capture-time canonical hashing: the x tag on 30023s,
+// the header-strip invariant, header-field sanitization, and the
+// archive record's articleHash.
+//
+// THE load-bearing invariant: for every article,
+//   stripMetadataHeader(event.content) === assembleArticleBody(article)
+// byte-for-byte — that equality is what lets any third party verify
+// the x tag from the published event alone.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+await import('fake-indexeddb/auto');
+
+// Storage probes chrome.storage.local at module-load time.
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const { EventBuilder } = await import('../src/shared/event-builder.js');
+const { normalizeForHash, articleHash, stripMetadataHeader } = await import('../src/shared/audit/article-hash.js');
+const ArchiveCache = await import('../src/shared/archive-cache.js');
+
+const PUBKEY = '4ba5145ddce7322c3422096997fdf9d5cf9198312d7567b0dda275e580654a9f';
+
+function expectedHash(body) {
+    return createHash('sha256').update(normalizeForHash(body), 'utf8').digest('hex');
+}
+
+function articleFixture(overrides = {}) {
+    return {
+        url: 'https://example.com/story',
+        title: 'A Perfectly Normal Title',
+        byline: 'Jane Reporter',
+        siteName: 'The Example Times',
+        publishedAt: 1765000000,
+        content: '# Heading\n\nBody paragraph one.\n\nBody paragraph two.',
+        domain: 'example.com',
+        ...overrides
+    };
+}
+
+test('30023 carries the x tag, verifiable from the event alone', async () => {
+    const article = articleFixture();
+    const ev = await EventBuilder.buildArticleEvent(article, [], PUBKEY, []);
+    const xTag = ev.tags.find((t) => t[0] === 'x');
+    assert.ok(xTag, 'x tag present');
+    assert.match(xTag[1], /^[0-9a-f]{64}$/);
+
+    // Verifiable two independent ways: from the assembly, and from the
+    // published content via the header strip.
+    const body = EventBuilder.assembleArticleBody(article);
+    assert.equal(xTag[1], expectedHash(body));
+    assert.equal(stripMetadataHeader(ev.content), body,
+        'strip(content) must recover the exact hash input');
+    assert.equal(xTag[1], await articleHash(stripMetadataHeader(ev.content)),
+        'a third party recomputes the x tag from the event alone');
+});
+
+test('header-field newlines cannot forge the header terminator — every call site', async () => {
+    // A hostile value smuggling "\n---\n" would end the header strip
+    // early and leak header residue (the Archived date) into a third
+    // party's recomputation — the one thing a content address must
+    // never depend on. Every interpolated field is hostile here so a
+    // single unsanitized call site fails the invariant.
+    const hostile = articleFixture({
+        title: 'Evil\n---\n\nInjected body line',
+        byline: 'Line\n---\nBreaker',
+        siteName: 'News\n---\nCorp'
+    });
+    const ev = await EventBuilder.buildArticleEvent(hostile, [], PUBKEY, []);
+    const body = EventBuilder.assembleArticleBody(hostile);
+    assert.equal(stripMetadataHeader(ev.content), body,
+        'sanitized header fields keep the strip exact');
+    assert.equal(ev.tags.find((t) => t[0] === 'x')[1], expectedHash(body));
+    // The header itself flattened the newlines rather than dropping the fields.
+    assert.ok(ev.content.includes('Evil --- Injected body line'),
+        'title survives, flattened to one line');
+
+    // The video Channel line is a SEPARATE call site, and channel
+    // names come from third-party platforms — attacker-influenced.
+    const hostileVideo = articleFixture({
+        contentType: 'video',
+        byline: 'Sneaky\n---\nChannel',
+        title: 'Evil\n---\nVideo'
+    });
+    const evVideo = await EventBuilder.buildArticleEvent(hostileVideo, [], PUBKEY, []);
+    const videoBody = EventBuilder.assembleArticleBody(hostileVideo);
+    assert.equal(stripMetadataHeader(evVideo.content), videoBody);
+    assert.equal(evVideo.tags.find((t) => t[0] === 'x')[1], expectedHash(videoBody));
+});
+
+test('legacy non-video transcript: the fenced block (with its own ---) keeps the strip lazy', async () => {
+    // The only body shape that naturally contains "\n---\n" — a GREEDY
+    // header-strip regex would eat through it and silently fork the
+    // hash recomputation for every article with a markdown hr.
+    const article = articleFixture({
+        transcript: 'Spoken words, raw and unchunked.'
+    });
+    const ev = await EventBuilder.buildArticleEvent(article, [], PUBKEY, []);
+    const body = EventBuilder.assembleArticleBody(article);
+    assert.ok(body.includes('\n---\n'), 'the legacy transcript separator is in the body');
+    assert.ok(body.includes('```\nSpoken words'), 'fenced transcript block assembled');
+    assert.equal(stripMetadataHeader(ev.content), body,
+        'the strip must stop at the FIRST header terminator, never a body hr');
+    assert.equal(ev.tags.find((t) => t[0] === 'x')[1], expectedHash(body));
+});
+
+test('video Description/Transcript sections are INSIDE the hash input', async () => {
+    const plain = articleFixture();
+    const video = articleFixture({
+        contentType: 'video',
+        description: 'A talk about rates.',
+        transcript: 'First sentence. Second sentence. Third sentence. Fourth one here. Fifth too.'
+    });
+    const evPlain = await EventBuilder.buildArticleEvent(plain, [], PUBKEY, []);
+    const evVideo = await EventBuilder.buildArticleEvent(video, [], PUBKEY, []);
+    const xPlain = evPlain.tags.find((t) => t[0] === 'x')[1];
+    const xVideo = evVideo.tags.find((t) => t[0] === 'x')[1];
+    assert.notEqual(xPlain, xVideo, 'the audited text is the published text, in full');
+
+    const videoBody = EventBuilder.assembleArticleBody(video);
+    assert.ok(videoBody.includes('## Transcript'), 'chunked transcript is part of the body');
+    assert.equal(stripMetadataHeader(evVideo.content), videoBody,
+        'strip invariant holds for assembled video bodies too');
+    assert.equal(xVideo, expectedHash(videoBody));
+});
+
+test('reconstructArticleFromEvent carries the published hash as _articleHash', async () => {
+    const article = articleFixture();
+    const ev = await EventBuilder.buildArticleEvent(article, [], PUBKEY, []);
+    const xValue = ev.tags.find((t) => t[0] === 'x')[1];
+    const reconstructed = EventBuilder.reconstructArticleFromEvent({ ...ev, id: 'e'.repeat(64) });
+    assert.equal(reconstructed._articleHash, xValue,
+        'carried as published, never recomputed after the HTML round trip');
+
+    // Pre-13.4 events (no x tag) reconstruct with null, not undefined.
+    const legacy = { ...ev, id: 'f'.repeat(64), tags: ev.tags.filter((t) => t[0] !== 'x') };
+    assert.equal(EventBuilder.reconstructArticleFromEvent(legacy)._articleHash, null);
+});
+
+test('archive records carry articleHash, agreeing with the publish-path x tag', async () => {
+    await ArchiveCache.clear().catch(() => { /* fresh db */ });
+    const article = articleFixture({ url: 'https://example.com/archived-story' });
+    const record = await ArchiveCache.saveArticle({ article, source: 'capture' });
+    assert.equal(record.articleHash, expectedHash(EventBuilder.assembleArticleBody(article)),
+        'local capture and publish path hash the same bytes');
+
+    // Relay-reconstructed articles carry the PUBLISHED hash through
+    // _articleHash rather than recomputing post-round-trip.
+    const reconstructed = articleFixture({
+        url: 'https://example.com/relay-story',
+        _articleHash: 'a'.repeat(64)
+    });
+    const relayRecord = await ArchiveCache.saveArticle({ article: reconstructed, source: 'relay' });
+    assert.equal(relayRecord.articleHash, 'a'.repeat(64));
+});
+
+test('a re-capture with changed content changes the record hash — and RETAINS the displaced text', async () => {
+    const url = 'https://example.com/edited-story';
+    const v1 = await ArchiveCache.saveArticle({
+        article: articleFixture({ url, content: 'The minister said yes.' }), source: 'capture'
+    });
+    assert.deepEqual(v1.priorVersions, [], 'first capture displaces nothing');
+
+    const v2 = await ArchiveCache.saveArticle({
+        article: articleFixture({ url, content: 'The minister said no.' }), source: 'capture'
+    });
+    assert.notEqual(v1.articleHash, v2.articleHash);
+    // The banner promises "your previous capture stays in the archive" —
+    // the displaced version must actually survive (the design's
+    // "capturing both versions is its own diagnostic").
+    assert.equal(v2.priorVersions.length, 1);
+    assert.equal(v2.priorVersions[0].articleHash, v1.articleHash);
+    assert.equal(v2.priorVersions[0].article.content, 'The minister said yes.',
+        'the prior TEXT survives, not just its hash');
+    assert.ok(v2.priorVersions[0].displacedAt > 0);
+
+    // Formatting noise does NOT change the hash — and snapshots nothing.
+    const v3 = await ArchiveCache.saveArticle({
+        article: articleFixture({ url, content: 'The minister said no.   \n\n\n' }), source: 'capture'
+    });
+    assert.equal(v2.articleHash, v3.articleHash);
+    assert.equal(v3.priorVersions.length, 1, 'same hash, no new snapshot');
+
+    // Retention is bounded: distinct versions beyond the cap drop oldest-first.
+    let last = v3;
+    for (const text of ['v4 text.', 'v5 text.', 'v6 text.', 'v7 text.']) {
+        last = await ArchiveCache.saveArticle({
+            article: articleFixture({ url, content: text }), source: 'capture'
+        });
+    }
+    assert.equal(last.priorVersions.length, 3, 'capped');
+    assert.equal(last.priorVersions[2].article.content, 'v6 text.', 'newest displaced kept');
+    assert.ok(!last.priorVersions.some((v) => v.article.content === 'The minister said yes.'),
+        'oldest dropped beyond the cap');
+});
+
+test('hash failure never blocks archiving — and never inherits the prior hash', async () => {
+    const url = 'https://example.com/fragile-story';
+    const good = await ArchiveCache.saveArticle({
+        article: articleFixture({ url, content: 'Good text.' }), source: 'capture'
+    });
+    assert.ok(good.articleHash);
+
+    // A non-string content makes the body assembly throw; the record
+    // must still persist — with articleHash NULL, not the prior row's
+    // (the hash labels THIS body; inheriting would mislabel new
+    // content with old identity).
+    const broken = await ArchiveCache.saveArticle({
+        article: articleFixture({ url, content: 12345 }), source: 'capture'
+    });
+    assert.equal(broken.articleHash, null);
+    const reread = await ArchiveCache.getArticle(url);
+    assert.equal(reread.articleHash, null, 'persisted, unhashed, honest');
+});


### PR DESCRIPTION
Slice **13.4** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — the canonical hash reaches the **shipping capture pipeline**. Stacked on #64. ⚠️ Additive wire-format change to kind 30023 (CHANGELOG callout; NIP_DRAFT §30023 `x` extension).

## What's in it

- **`assembleArticleBody` extracted** from `buildArticleEvent` — capture, publish, and the upcoming import path hash identical bytes. The `x` tag is verifiable from the event alone: `stripMetadataHeader(content)` byte-equals the hash input (pinned, including against hostile header fields smuggling `\n---\n` and the legacy fenced-transcript body — the only shape that pins the strip regex's laziness).
- **Header-forge defense**: interpolated header fields are newline-flattened at build time (a no-op for every real capture; per-call-site mutation-tested).
- **Archive records carry `articleHash`** + **bounded stealth-edit retention**: a re-capture whose hash differs snapshots the displaced version onto `priorVersions` (cap 3) — the text prior audits anchor to genuinely survives. A failed hash stays `null`, never inheriting the prior row's identity.
- **Reader**: sequenced hash → compare-prior → save; content-hash line under the meta; mismatch warning banner; the line refreshes on archive-body swap, flags *edited, recomputed at publish* on body edits, and publish stamps the just-built event's `x` into the archive row.

## Review

Three-lens adversarial review (regression / design-fidelity / test-adequacy) with per-finding verification: **8 confirmed, 0 refuted — including one BLOCKING**: the mismatch banner promised "your previous capture stays in the archive" while `saveArticle` overwrote the single per-URL row three lines later, destroying the only local copy of the audit-anchored text. The accepted design commits to local survival, so the fix is retention, not softer copy. Also caught: the stale hash line after "Load archive"/edits, the relay-carry mislabel on republish, and the hash-inheritance mislabel. Full record in the JOURNAL entry.

## Verification

8 new tests (787 total green); build + lint clean.

Next: 13.5 — the import-then-sign execution path (re-validate before signing, RQ1's invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)