### PR TITLE
feat(audit): Phase 13.5 — CLI-audit import, the v1 execution path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 13.5 — audit import (the v1 execution path).** Run the
+  vendored scorer CLI out-of-band, then import its JSON from the
+  Reader ("Import audit JSON…" under the open capture) or Settings →
+  Advanced → Epistemic audits (matched against the archive, including
+  retained prior versions). Imports enforce the never-sign-unverified
+  gate at the door: the article body is re-hashed against the claimed
+  hash, the audit must match a locally captured text, and every
+  module payload is schema-validated (failed modules are stored as
+  failed runs and excluded from aggregation). Importing is local-only
+  and ungated; publishing audit events remains a separate
+  `epistemicAuditing`-flagged step (slice 13.8).
+
 - **Phase 13.4 — capture-time canonical hashing.** ⚠️ **Wire-format
   change to kind 30023 (additive)**: new articles carry the canonical
   article hash as an indexed `x` tag — SHA-256 of the normalized body

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,56 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.5: the import gate, and what rejects vs what degrades
+
+**Tags:** design
+
+Slice 13.5 (`audit/import.js` + reader/options affordances). The
+calls worth a paper trail:
+
+- **Reject vs degrade is drawn at the badge.** A corrupt file
+  (claimed hash ≠ body), a capture mismatch (audit about text the
+  user never captured), or a contradictory aggregate (final >
+  min(raw, ceiling)) rejects the whole import — those poison the
+  badge record. A single module failing schema validation (or a
+  scorer-reported `_error`) degrades instead: stored as a failed run,
+  score null, the validation errors recorded as a caveat — the
+  scorer's own failure posture, because one flaky module shouldn't
+  discard seven paid ones. A file where EVERY module fails rejects.
+- **The options importer matches against retained prior versions
+  too** — an audit of last week's text is still an audit of text the
+  user captured; 13.4's `priorVersions` retention is what makes that
+  honest.
+- **The reader's status line obeys the display rules from day one**:
+  no naked numbers (score renders with confidence), and
+  confidence < 0.6 renders as "needs human review" — even in this
+  pre-panel stub, so 13.6 inherits a surface that never violated the
+  rule.
+- **`ceiling_source` defaults to `heuristic:source-quality/1.0` on
+  import** when the export predates the field — RQ2's canonical
+  pipeline source, which is what the vendored scorer actually does.
+  A *present-but-invalid* value rejects (the closed RQ2 grammar,
+  enforced at the door rather than at publish).
+- **The adversarial review confirmed the slice's one real gate
+  hole**: the reader passed `state.articleHash || null`, and the
+  hash is never computed for read-only portal opens — so on those
+  views ANY internally-consistent audit imported ungated while the
+  status line simultaneously said "no audit imported." The reader
+  now refuses without a capture hash (pointing at the
+  archive-matched options importer); the half-checked state was
+  worse than either honest extreme. Mutation testing also showed
+  module- and prediction-level auditor attribution was unasserted
+  (a silent fallback-to-pipeline would have flattened RQ3's
+  identity layer into the published events) — now pinned. Review
+  process note: seven verifier agents hit the session usage limit
+  mid-run; their finder-lens findings (prediction enums unvalidated,
+  never-publishable predictions, ceiling_source grammar, the
+  vacuous `.every`-on-empty rejection) were adjudicated by direct
+  code reading and all fixed — predictions now validate enums +
+  publishability at import and skip with counted reasons.
+
+---
+
 ## 2026-06-11 — 13.4: the hash reaches the capture pipeline
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1005,6 +1005,15 @@ Implementation slices 13.1+ are in progress.
   `articleHash` on archive records; reader hash line + stealth-edit
   mismatch banner (sequenced before the archive save so the
   comparison reads the prior row). — #65
+- ✅ **13.5** Audit execution, v1 path — `audit/import.js` enforces
+  the RQ1 gate at the door: re-hash `body_markdown` vs the claimed
+  hash, match against the local capture, schema-validate every module
+  payload (failed/`_error` modules stored as failed runs — one bad
+  module never rejects the file; a contradictory aggregate does);
+  reader import bar (keyed to the open capture's hash, display-rule-
+  honest status line) + options Advanced importer (archive-matched,
+  incl. retained prior versions); scorer README import note. Imports
+  are local-only and ungated; publishing is 13.8. — #66
 
 ---
 

--- a/docs/auditor-prototype/scorer/README.md
+++ b/docs/auditor-prototype/scorer/README.md
@@ -113,3 +113,7 @@ Either path produces results in the same `audit-types.ts` shape, so downstream N
 - **No dispute mechanism.** The schema includes `AuditDispute` but the scorer doesn't yet handle re-scoring on dispute resolution.
 - **Single-auditor.** No multi-model consensus or human-in-the-loop. Production gains a lot from running the same article through Claude + GPT + a human and surfacing the disagreement.
 - **Knowability heuristic is crude.** It uses only source-quality findings. A dedicated knowability module (or beat-specific lookup table) would be more defensible.
+
+---
+
+*[X-Ray integration note, Phase 13.5: `--output audit.json` is X-Ray's import format. Import from the Reader ("Import audit JSON…" under the open capture — matched against that capture's canonical hash) or Settings → Advanced → Epistemic audits (matched against your archive, including retained prior versions). Imports re-hash `article.body_markdown` against `article.hash`, schema-validate every module payload (failed modules are stored as failed runs, excluded from aggregation), and refuse audits whose text you never captured. Importing is local-only; publishing the audit events is a separate, flag-gated step.]*

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -8,6 +8,9 @@ import { Storage } from '../shared/storage.js';
 import { Crypto } from '../shared/crypto.js';
 import { NSecBunkerClient } from '../shared/nsecbunker-client.js';
 import { loadFlags, isEnabled, setOverride, resetOverrides } from '../shared/metadata/feature-flags.js';
+import { importAuditJson } from '../shared/audit/import.js';
+import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
+import { listArticles } from '../shared/archive-cache.js';
 
 const browserApi = (typeof browser !== 'undefined' && browser.runtime) ? browser : chrome;
 
@@ -417,6 +420,36 @@ async function exportKeypairs() {
     flash(document.getElementById('keypairs-status'), 'Exported.');
 }
 
+// Epistemic-audit import (13.5). The options-side gate is the archive
+// match: the audit must be about text the user actually captured
+// (current or a retained prior version). importAuditJson then applies
+// the RQ1 invariant — re-hash, schema-validate — before anything
+// persists. Local-only; publishing is 13.8 behind the flag.
+async function importAuditFromFile(file) {
+    const status = document.getElementById('audit-status');
+    try {
+        const parsed = JSON.parse(await file.text());
+        const body = parsed && parsed.article && parsed.article.body_markdown;
+        if (typeof body !== 'string' || !body) {
+            throw new Error('not a scorer export — article.body_markdown missing');
+        }
+        const claimed = await canonicalArticleHash(body);
+        const records = await listArticles();
+        const match = records.find((r) => r.articleHash === claimed
+            || (Array.isArray(r.priorVersions) && r.priorVersions.some((v) => v.articleHash === claimed)));
+        if (!match) {
+            throw new Error('no local capture matches this audit\'s article hash — capture the article first');
+        }
+        const summary = await importAuditJson(parsed, { localArticleHash: claimed });
+        const bits = [`${summary.modulesValid} modules valid`];
+        if (summary.modulesFailed) bits.push(`${summary.modulesFailed} failed validation`);
+        if (summary.predictionsImported) bits.push(`${summary.predictionsImported} predictions`);
+        flash(status, `Imported — ${bits.join(', ')}.`, summary.modulesFailed === 0);
+    } catch (e) {
+        flash(status, 'Import failed: ' + (e && e.message), false);
+    }
+}
+
 async function importKeypairsFromFile(file) {
     const status = document.getElementById('keypairs-status');
     try {
@@ -558,6 +591,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('keypairs-file').addEventListener('change', (e) => {
         const file = e.target.files && e.target.files[0];
         if (file) importKeypairsFromFile(file);
+        e.target.value = '';
+    });
+
+    document.getElementById('audit-import').addEventListener('click', () => {
+        document.getElementById('audit-file').click();
+    });
+    document.getElementById('audit-file').addEventListener('change', (e) => {
+        const file = e.target.files && e.target.files[0];
+        if (file) importAuditFromFile(file);
         e.target.value = '';
     });
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -234,6 +234,22 @@
       </p>
 
       <hr />
+      <h3 class="xr-opt__subhead">Epistemic audits</h3>
+      <p class="xr-opt__hint">
+        Run the companion scorer CLI (<code>docs/auditor-prototype/scorer/</code>)
+        against a captured article, then import its JSON here. Imports
+        are re-hashed and schema-validated, and must match a local
+        capture — the audit has to be about text you actually captured.
+        Importing stores results locally only; publishing audit events
+        is a separate, experimental-flagged step.
+      </p>
+      <div class="xr-opt__actions">
+        <button class="xr-opt__btn" id="audit-import">Import audit JSON…</button>
+        <span class="xr-opt__status" id="audit-status"></span>
+      </div>
+      <input type="file" id="audit-file" accept="application/json" style="display:none" />
+
+      <hr />
       <h3 class="xr-opt__subhead">Power user</h3>
 
       <label class="xr-opt__field xr-opt__field--inline">

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -1731,6 +1731,39 @@ body {
   flex-shrink: 0;
 }
 
+/* ---------------- Epistemic-audit import bar (13.5) ---------------------- */
+
+.xr-audit {
+  max-width: var(--xr-reader-max-w);
+  margin: 18px auto 0;
+}
+
+.xr-audit__bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  background: var(--xr-surface);
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+}
+
+.xr-audit__label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--xr-text-dim);
+}
+
+.xr-audit__status {
+  flex: 1;
+  min-width: 200px;
+  font-size: 12px;
+  color: var(--xr-text-dim);
+}
+
 /* ---------------- Canonical-hash line + stealth-edit banner (13.4) ------- */
 
 .xr-article__hash {

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -43,6 +43,17 @@
        with edit + delete affordances. -->
   <div id="xr-claims-host"></div>
 
+  <!-- Epistemic audit (Phase 13.5): CLI-audit import affordance. The
+       full audit panel arrives in 13.6; this hosts the import bar. -->
+  <section class="xr-audit" id="xr-audit">
+    <div class="xr-audit__bar">
+      <span class="xr-audit__label">Epistemic audit</span>
+      <span class="xr-audit__status" id="xr-audit-status">No audit imported for this capture.</span>
+      <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-import">Import audit JSON…</button>
+      <input type="file" id="xr-audit-file" accept="application/json,.json" hidden />
+    </div>
+  </section>
+
   <!-- Comments section. Shown only when the article has a postId from
        a platform that supports comment capture (Substack today). The
        inner HTML is populated by reader/index.js. -->

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -27,6 +27,8 @@ import { selectAssessmentsToPublish, selectLinksToPublish, selectMirrors } from 
 import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent } from '../shared/metadata/builders.js';
 import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
 import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
+import { importAuditJson } from '../shared/audit/import.js';
+import { AuditRunModel } from '../shared/audit/audit-model.js';
 
 const browserApi = typeof browser !== 'undefined' && browser.runtime ? browser : chrome;
 
@@ -155,6 +157,10 @@ async function loadArticle() {
                 state.articleHash = await canonicalArticleHash(
                     EventBuilder.assembleArticleBody(state.article));
                 updateHashLine();
+                // The audit bar keys on the hash — refresh it now that
+                // the hash is known (init wired it before this resolved).
+                refreshAuditStatus().catch((err) =>
+                    console.warn('[X-Ray Reader] audit status failed:', err));
             } catch (err) {
                 console.warn('[X-Ray Reader] article hash failed:', err);
             }
@@ -415,6 +421,33 @@ function updateHashLine() {
     }
     el.title = state.articleHash;
     el.textContent = 'content hash ' + state.articleHash.slice(0, 16) + '…';
+}
+
+// Audit-bar status line (13.5): how many imported runs anchor to this
+// capture's hash. The full panel (scores, module rows) is 13.6 — this
+// just keeps the import affordance honest about what's stored.
+async function refreshAuditStatus() {
+    const el = $('#xr-audit-status');
+    if (!el) return;
+    if (!state.articleHash) {
+        el.textContent = 'No audit imported for this capture.';
+        return;
+    }
+    const runs = await AuditRunModel.getByArticleHash(state.articleHash);
+    if (!runs.length) {
+        el.textContent = 'No audit imported for this capture.';
+        return;
+    }
+    const latest = runs.slice().sort((a, b) => String(b.runAt).localeCompare(String(a.runAt)))[0];
+    const score = latest.aggregate && typeof latest.aggregate.final_score === 'number'
+        ? latest.aggregate.final_score : null;
+    const conf = latest.aggregate && typeof latest.aggregate.overall_confidence === 'number'
+        ? latest.aggregate.overall_confidence : null;
+    // Display rule (no naked numbers; <0.6 ⇒ needs human review).
+    const scoreLabel = score === null ? 'no aggregate score'
+        : (conf !== null && conf < 0.6) ? 'needs human review (confidence < 0.6)'
+            : `score ${score}` + (conf !== null ? ` · confidence ${conf}` : '');
+    el.textContent = `${runs.length} audit run${runs.length === 1 ? '' : 's'} stored — latest: ${scoreLabel}. Full panel arrives in 13.6.`;
 }
 
 // Stealth-edit surface: the same URL hashed differently on a prior
@@ -2469,6 +2502,37 @@ async function init() {
     $('#xr-comments-include').addEventListener('change', (ev) => {
         state.comments.includeInPublish = ev.target.checked;
     });
+
+    // Epistemic-audit import (13.5): button → hidden file input →
+    // importAuditJson with the RQ1 gate (re-hash + schema-validate +
+    // match against THIS capture's hash). Local-only and ungated —
+    // publishing the audit events is 13.8, behind the flag.
+    $('#xr-audit-import').addEventListener('click', () => $('#xr-audit-file').click());
+    $('#xr-audit-file').addEventListener('change', async (ev) => {
+        const file = ev.target.files && ev.target.files[0];
+        ev.target.value = '';
+        if (!file) return;
+        // The capture-match half of the RQ1 gate NEEDS the capture's
+        // hash — without it (read-only portal opens, hash failure) an
+        // import would be silently ungated. Refuse rather than weaken;
+        // the options importer matches against the archive instead.
+        if (!state.articleHash) {
+            toast('This view has no capture hash to verify against — import from Settings → Advanced → Epistemic audits instead.', 'error', 7000);
+            return;
+        }
+        try {
+            const parsed = JSON.parse(await file.text());
+            const summary = await importAuditJson(parsed, { localArticleHash: state.articleHash });
+            const bits = [`${summary.modulesValid} module${summary.modulesValid === 1 ? '' : 's'} valid`];
+            if (summary.modulesFailed) bits.push(`${summary.modulesFailed} failed validation`);
+            if (summary.predictionsImported) bits.push(`${summary.predictionsImported} prediction${summary.predictionsImported === 1 ? '' : 's'}`);
+            toast(`Audit imported — ${bits.join(', ')}`, summary.modulesFailed ? 'warning' : 'success', 5000);
+            await refreshAuditStatus();
+        } catch (err) {
+            toast('Audit import failed: ' + (err && err.message), 'error', 7000);
+        }
+    });
+    refreshAuditStatus().catch((err) => console.warn('[X-Ray Reader] audit status failed:', err));
 
     // Kick off the platform-specific data fetch, if any.
     // Non-blocking — the reader is already interactive.

--- a/src/shared/audit/import.js
+++ b/src/shared/audit/import.js
@@ -1,0 +1,269 @@
+// X-Ray — CLI-audit import (Phase 13, slice 13.5).
+//
+// The v1 execution path (RQ1, confirmed as the keeper architecture):
+// the vendored scorer runs out-of-band (`node scorer.js --input …
+// --output audit.json`), and the extension ingests the JSON here. The
+// CLI never touches NOSTR keys; signing stays in the extension, and
+// the unsigned-JSON intermediate is the human-review checkpoint (P11).
+//
+// THE RQ1 INVARIANT — you never sign what you haven't verified — is
+// enforced at the door, before anything persists:
+//   1. Re-hash the imported `body_markdown` and require it to equal
+//      the JSON's claimed `article.hash`.
+//   2. When a local capture hash is supplied, require it to match too
+//      (this note's addition beyond RQ1's letter): the audit must be
+//      about the text the user actually captured.
+//   3. Schema-validate every module payload. A failed validation (or
+//      a scorer-reported `_error` run) is stored as a FAILED module
+//      result — score null, caveat recorded, excluded from
+//      aggregation — the scorer's own failure posture; one bad module
+//      never rejects the file.
+// The aggregate is different: it is the badge record, so a malformed
+// aggregate rejects the whole import.
+//
+// Import is local-only and ungated (the Phase 11 split) — publishing
+// the resulting events is slice 13.8, behind `epistemicAuditing`.
+
+import { articleHash } from './article-hash.js';
+import { MODULE_NAMES, validateFindings } from './findings-schemas.js';
+import { AuditRunModel, PredictionModel } from './audit-model.js';
+import {
+    AUDITOR_KINDS, isValidCeilingSource,
+    PREDICTION_TYPES, HEDGE_LEVELS, ATTRIBUTION_KINDS, TRACTABILITIES
+} from './builders.js';
+
+const HASH64_RE = /^[0-9a-f]{64}$/;
+
+function fail(message) {
+    const err = new Error(`importAuditJson: ${message}`);
+    err.auditImport = true;
+    return err;
+}
+
+function normalizeAuditor(raw, fallbackId) {
+    if (raw && AUDITOR_KINDS.includes(raw.kind) && typeof raw.id === 'string' && raw.id) {
+        const auditor = { kind: raw.kind, id: raw.id };
+        if (Array.isArray(raw.constituents)) {
+            auditor.constituents = raw.constituents
+                .filter((c) => c && AUDITOR_KINDS.includes(c.kind) && typeof c.id === 'string' && c.id)
+                .map((c) => ({ kind: c.kind, id: c.id }));
+        }
+        return auditor;
+    }
+    return fallbackId ? { kind: 'pipeline', id: fallbackId } : null;
+}
+
+/**
+ * Import one scorer-export JSON (the `scoreArticle` result shape:
+ * `{article, module_results, predictions, aggregate}`) into the local
+ * audit ledger.
+ *
+ * @param {object} json - the parsed scorer output
+ * @param {object} [opts]
+ * @param {string|null} [opts.localArticleHash] - the current capture's
+ *   canonical hash; when present, a mismatch REJECTS the import (the
+ *   audit is about different text than the user captured)
+ * @returns {Promise<object>} summary: {runId, articleHash,
+ *   modulesValid, modulesFailed, failedModules, predictionsImported,
+ *   alreadyImported}
+ */
+export async function importAuditJson(json, { localArticleHash = null } = {}) {
+    if (!json || typeof json !== 'object' || Array.isArray(json)) {
+        throw fail('expected the scorer JSON object (article / module_results / aggregate)');
+    }
+    const { article, module_results: moduleResults, predictions, aggregate } = json;
+
+    // --- 1+2: the hash gate ------------------------------------------------
+    if (!article || typeof article.body_markdown !== 'string' || !article.body_markdown) {
+        throw fail('article.body_markdown missing — the audited text must ride with the audit');
+    }
+    if (typeof article.hash !== 'string' || !HASH64_RE.test(article.hash)) {
+        throw fail('article.hash missing or malformed');
+    }
+    const recomputed = await articleHash(article.body_markdown);
+    if (recomputed !== article.hash) {
+        throw fail(`article.hash does not match its body_markdown — claimed ${article.hash.slice(0, 16)}…, recomputed ${recomputed.slice(0, 16)}… (the file is corrupt or tampered)`);
+    }
+    if (localArticleHash && localArticleHash !== recomputed) {
+        throw fail(`this audit scored different text than your capture — audit ${recomputed.slice(0, 16)}…, capture ${localArticleHash.slice(0, 16)}… (re-run the scorer against the current capture, or open the capture this audit belongs to)`);
+    }
+
+    // --- aggregate: the badge record — malformed rejects -------------------
+    if (!aggregate || typeof aggregate !== 'object') {
+        throw fail('aggregate missing');
+    }
+    const finalScore = aggregate.final_score;
+    const rawScore = aggregate.raw_weighted_score;
+    const ceiling = aggregate.knowability_ceiling;
+    const confidence = aggregate.overall_confidence;
+    for (const [name, v, lo, hi] of [
+        ['final_score', finalScore, 0, 100],
+        ['raw_weighted_score', rawScore, 0, 100],
+        ['knowability_ceiling', ceiling, 0, 100],
+        ['overall_confidence', confidence, 0, 1]
+    ]) {
+        if (typeof v !== 'number' || !Number.isFinite(v) || v < lo || v > hi) {
+            throw fail(`aggregate.${name} must be a number in [${lo}, ${hi}] (got ${v})`);
+        }
+    }
+    if (finalScore > ceiling + 1e-9 || finalScore > rawScore + 1e-9) {
+        throw fail(`aggregate is internally contradictory: final_score ${finalScore} exceeds min(raw ${rawScore}, ceiling ${ceiling})`);
+    }
+    if (typeof aggregate.run_at !== 'string' || Number.isNaN(Date.parse(aggregate.run_at))) {
+        throw fail('aggregate.run_at missing or unparseable');
+    }
+    // A present-but-invalid ceiling provenance means a tampered or
+    // foreign file — the wire's closed grammar (RQ2) would reject it
+    // at publish anyway; reject it at the door instead.
+    if (aggregate.ceiling_source != null && !isValidCeilingSource(aggregate.ceiling_source)) {
+        throw fail(`aggregate.ceiling_source is not a valid provenance (got ${aggregate.ceiling_source})`);
+    }
+    const auditor = normalizeAuditor(aggregate.auditor, 'xray-auditor-import/unknown');
+
+    // --- 3: per-module validation, failure posture per module --------------
+    if (!Array.isArray(moduleResults) || moduleResults.length === 0) {
+        throw fail('module_results missing or empty');
+    }
+    const storedResults = [];
+    const failedModules = [];
+    for (const r of moduleResults) {
+        const module = r && r.module;
+        if (!MODULE_NAMES.includes(module)) {
+            failedModules.push({ module: String(module), reason: 'unknown module' });
+            continue;
+        }
+        const base = {
+            module,
+            module_version: (r && r.module_version) || '1.0',
+            auditor: normalizeAuditor(r && r.auditor, null) || auditor,
+            run_at: (r && r.run_at) || aggregate.run_at,
+            evidence_quotes: Array.isArray(r && r.evidence_quotes) ? r.evidence_quotes : [],
+            auditor_caveats: Array.isArray(r && r.auditor_caveats) ? r.auditor_caveats : []
+        };
+        if (r._error) {
+            storedResults.push({
+                ...base, score: null, confidence: null,
+                findings: r.findings || null, failed: true
+            });
+            failedModules.push({ module, reason: 'scorer-reported error' });
+            continue;
+        }
+        const { valid, errors } = validateFindings(module, r.findings);
+        if (!valid) {
+            storedResults.push({
+                ...base, score: null, confidence: null, findings: r.findings,
+                failed: true,
+                auditor_caveats: [...base.auditor_caveats,
+                    `findings failed schema validation on import: ${errors.slice(0, 3).map((e) => `${e.path}: ${e.message}`).join('; ')}`]
+            });
+            failedModules.push({ module, reason: `schema validation (${errors.length} errors)` });
+            continue;
+        }
+        storedResults.push({
+            ...base,
+            score: typeof r.score === 'number' ? r.score : null,
+            confidence: typeof r.confidence === 'number' ? r.confidence : null,
+            findings: r.findings,
+            failed: false
+        });
+    }
+    // Explicit empty check — .every() on an empty array is vacuously
+    // true, which happens to reject, but the contract should not hang
+    // on a vacuous truth.
+    if (storedResults.length === 0 || storedResults.every((r) => r.failed)) {
+        throw fail('every module result failed validation — nothing importable');
+    }
+
+    // --- persist -------------------------------------------------------------
+    const existing = await AuditRunModel.getByArticleHash(recomputed);
+    const run = await AuditRunModel.create({
+        articleHash: recomputed,
+        auditor,
+        runAt: aggregate.run_at,
+        source: 'cli-import',
+        moduleResults: storedResults,
+        aggregate: {
+            final_score: finalScore,
+            raw_weighted_score: rawScore,
+            knowability_ceiling: ceiling,
+            knowability_notes: aggregate.knowability_notes || '',
+            ceiling_binding: aggregate.ceiling_binding === true,
+            // RQ2: the scorer's heuristic is the canonical pipeline
+            // source; an import carrying its own source wins.
+            ceiling_source: aggregate.ceiling_source || 'heuristic:source-quality/1.0',
+            model_estimated_ceiling: typeof aggregate.model_estimated_ceiling === 'number'
+                ? aggregate.model_estimated_ceiling : null,
+            overall_confidence: confidence,
+            module_contributions: Array.isArray(aggregate.module_contributions)
+                ? aggregate.module_contributions : [],
+            top_strengths: Array.isArray(aggregate.top_strengths) ? aggregate.top_strengths : [],
+            top_concerns: Array.isArray(aggregate.top_concerns) ? aggregate.top_concerns : []
+        }
+    });
+    const alreadyImported = existing.some((r) => r.id === run.id);
+
+    // Predictions are ledger records: enum fields feed calibration and
+    // the 30058 builder requires horizon/criteria/evidence at publish.
+    // An entry that could never publish (or would silently vanish from
+    // calibration) is SKIPPED with a counted reason — extraction is
+    // enrichment, so one malformed prediction never fails the import.
+    let predictionsImported = 0;
+    const skippedPredictions = [];
+    for (const p of (Array.isArray(predictions) ? predictions : [])) {
+        const text = (p && (p.prediction_text || p.prediction)) || '';
+        const candidate = {
+            text: typeof text === 'string' ? text.trim() : '',
+            type: p && (p.prediction_type || p.type),
+            hedge_level: p && p.hedge_level,
+            attributed_to: p && (p.attribution_kind || p.attributed_to),
+            tractability: p && p.tractability,
+            condition: (p && p.condition) || null,
+            horizon: (p && p.resolution_horizon) || '',
+            criteria: (p && p.resolution_criteria) || '',
+            evidence_quote: (p && p.evidence_quote) || ''
+        };
+        const reason = !candidate.text ? 'no prediction text'
+            : !PREDICTION_TYPES.includes(candidate.type) ? `invalid type (${candidate.type})`
+                : !HEDGE_LEVELS.includes(candidate.hedge_level) ? `invalid hedge_level (${candidate.hedge_level})`
+                    : !ATTRIBUTION_KINDS.includes(candidate.attributed_to) ? `invalid attribution (${candidate.attributed_to})`
+                        : !TRACTABILITIES.includes(candidate.tractability) ? `invalid tractability (${candidate.tractability})`
+                            : !candidate.horizon ? 'no resolution horizon'
+                                : !candidate.criteria ? 'no resolution criteria'
+                                    : !candidate.evidence_quote ? 'no evidence quote'
+                                        : (candidate.type === 'conditional' && !candidate.condition) ? 'conditional without its antecedent'
+                                            : null;
+        if (reason) {
+            skippedPredictions.push({ text: candidate.text.slice(0, 60), reason });
+            continue;
+        }
+        await PredictionModel.create({
+            articleHash: recomputed,
+            text: candidate.text,
+            type: candidate.type,
+            hedge_level: candidate.hedge_level,
+            attributed_to: candidate.attributed_to,
+            attributed_source_name: p.attributed_to_named_source || p.attributed_source_name || null,
+            condition: candidate.condition,
+            horizon: candidate.horizon,
+            horizon_iso: p.resolution_horizon_iso || null,
+            criteria: candidate.criteria,
+            tractability: candidate.tractability,
+            evidence_quote: candidate.evidence_quote,
+            auditor: normalizeAuditor(p.extracted_by, null) || auditor,
+            extracted_at: p.extracted_at || aggregate.run_at
+        });
+        predictionsImported += 1;
+    }
+
+    return {
+        runId: run.id,
+        articleHash: recomputed,
+        modulesValid: storedResults.filter((r) => !r.failed).length,
+        modulesFailed: failedModules.length,
+        failedModules,
+        predictionsImported,
+        predictionsSkipped: skippedPredictions.length,
+        skippedPredictions,
+        alreadyImported
+    };
+}

--- a/tests/audit-import.test.mjs
+++ b/tests/audit-import.test.mjs
@@ -1,0 +1,246 @@
+// Phase 13.5 — CLI-audit import: the RQ1 gate (re-hash +
+// local-capture match + schema validation) enforced at the door, the
+// per-module failure posture, and idempotent re-import.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+await import('fake-indexeddb/auto');
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const { importAuditJson } = await import('../src/shared/audit/import.js');
+const { articleHash } = await import('../src/shared/audit/article-hash.js');
+const { AuditRunModel, PredictionModel } = await import('../src/shared/audit/audit-model.js');
+const { clear } = await import('../src/shared/audit/audit-cache.js');
+
+const BODY = '# A Story\n\nThe minister said the program would end by December.';
+const HASH = await articleHash(BODY);
+const RUN_AT = '2026-06-11T20:14:05Z';
+const PIPELINE = {
+    kind: 'pipeline',
+    id: 'xray-auditor-prototype/anthropic/claude-sonnet-4-6',
+    constituents: [{ kind: 'model', id: 'anthropic/claude-sonnet-4-6' }]
+};
+
+function coherenceResult(overrides = {}) {
+    return {
+        article_hash: HASH,
+        module: 'internal_coherence',
+        module_version: '1.0',
+        auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' },
+        run_at: RUN_AT,
+        score: 74,
+        confidence: 0.8,
+        findings: {
+            module: 'internal_coherence', version: '1.0',
+            score: 74, confidence: 0.8, confidence_notes: 'short piece',
+            auditor_caveats: ['Surface scan only.'],
+            contradictions: [], logical_gaps: []
+        },
+        evidence_quotes: [],
+        auditor_caveats: ['Surface scan only.'],
+        ...overrides
+    };
+}
+
+function predictionExtraction() {
+    return {
+        article_hash: HASH,
+        module: 'prediction_extraction',
+        module_version: '1.0',
+        auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' },
+        run_at: RUN_AT,
+        score: null,
+        confidence: null,
+        findings: {
+            module: 'prediction_extraction', version: '1.0',
+            auditor_caveats: ['Horizon approximate.'],
+            predictions: [{
+                prediction: 'The program will end by December.',
+                type: 'explicit', hedge_level: 'confident',
+                attributed_to: 'named_source', attributed_source_name: 'the minister',
+                resolution_horizon: 'by December', resolution_criteria: 'program shut down by Dec 31',
+                tractability: 'publicly_resolvable',
+                evidence_quote: 'would end by December'
+            }],
+            summary: { total_predictions: 1 }
+        },
+        evidence_quotes: [{ quote: 'would end by December' }],
+        auditor_caveats: ['Horizon approximate.']
+    };
+}
+
+function scorerExport(overrides = {}) {
+    return {
+        article: {
+            hash: HASH, source_url: 'https://example.com/story',
+            headline: 'A Story', body_markdown: BODY,
+            captured_at: RUN_AT, capture_method: 'xray_extension'
+        },
+        module_results: [coherenceResult(), predictionExtraction()],
+        predictions: [{
+            prediction: 'The program will end by December.',
+            type: 'explicit', hedge_level: 'confident',
+            attributed_to: 'named_source',
+            resolution_horizon: 'by December', resolution_criteria: 'program shut down by Dec 31',
+            tractability: 'publicly_resolvable', evidence_quote: 'would end by December',
+            article_hash: HASH,
+            prediction_text: 'The program will end by December.',
+            attribution_kind: 'named_source',
+            attributed_to_named_source: 'the minister',
+            extracted_by: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' },
+            extracted_at: RUN_AT,
+            resolution_status: 'open', latest_resolution_id: null
+        }],
+        aggregate: {
+            article_hash: HASH, auditor: PIPELINE, run_at: RUN_AT,
+            module_contributions: [{ module: 'internal_coherence', module_result_id: null, score: 74, confidence: 0.8, weight: 0.1 }],
+            knowability_ceiling: 80, knowability_notes: 'mostly named sourcing',
+            raw_weighted_score: 74, final_score: 74, ceiling_binding: false,
+            overall_confidence: 0.72,
+            top_strengths: [], top_concerns: [], disputes: []
+        },
+        ...overrides
+    };
+}
+
+test.beforeEach(async () => { await clear(); });
+
+test('happy path: imports, stores the run, creates the prediction', async () => {
+    const summary = await importAuditJson(scorerExport(), { localArticleHash: HASH });
+    assert.equal(summary.articleHash, HASH);
+    assert.equal(summary.modulesValid, 2);
+    assert.equal(summary.modulesFailed, 0);
+    assert.equal(summary.predictionsImported, 1);
+    assert.equal(summary.alreadyImported, false);
+
+    const runs = await AuditRunModel.getByArticleHash(HASH);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].source, 'cli-import');
+    assert.deepEqual(runs[0].auditor, { kind: 'pipeline', id: PIPELINE.id, constituents: PIPELINE.constituents });
+    assert.equal(runs[0].aggregate.final_score, 74);
+    assert.equal(runs[0].aggregate.ceiling_source, 'heuristic:source-quality/1.0',
+        'RQ2 default when the export predates the ceiling-source field');
+    assert.equal(runs[0].aggregate.model_estimated_ceiling, null);
+
+    const preds = await PredictionModel.getByArticleHash(HASH);
+    assert.equal(preds.length, 1);
+    assert.equal(preds[0].hedge_level, 'confident');
+    assert.equal(preds[0].attributed_to, 'named_source');
+    assert.equal(preds[0].attributed_source_name, 'the minister');
+    assert.equal(preds[0].horizon, 'by December');
+    assert.equal(preds[0].criteria, 'program shut down by Dec 31');
+    assert.equal(preds[0].evidence_quote, 'would end by December');
+    assert.equal(preds[0].resolution_status, 'open');
+
+    // Attribution survives at every level (RQ3): the module result and
+    // the prediction keep their MODEL auditor; only the run carries
+    // the pipeline. A silent fallback-to-pipeline would flatten the
+    // identity layer the published events depend on.
+    const coherence = runs[0].moduleResults.find((r) => r.module === 'internal_coherence');
+    assert.deepEqual(coherence.auditor, { kind: 'model', id: 'anthropic/claude-sonnet-4-6' });
+    assert.deepEqual(preds[0].auditor, { kind: 'model', id: 'anthropic/claude-sonnet-4-6' });
+});
+
+test('malformed predictions are skipped with reasons, never imported or failed-the-file', async () => {
+    const json = scorerExport();
+    json.predictions = [
+        ...json.predictions,
+        { ...json.predictions[0], prediction_text: 'Hedge chaos.', prediction: 'Hedge chaos.', hedge_level: 'certain' },
+        { ...json.predictions[0], prediction_text: 'No criteria.', prediction: 'No criteria.', resolution_criteria: '' }
+    ];
+    const summary = await importAuditJson(json, { localArticleHash: HASH });
+    assert.equal(summary.predictionsImported, 1);
+    assert.equal(summary.predictionsSkipped, 2);
+    assert.match(summary.skippedPredictions[0].reason, /invalid hedge_level/);
+    assert.match(summary.skippedPredictions[1].reason, /no resolution criteria/,
+        'a prediction the 30058 builder could never publish is not a ledger entry');
+    assert.equal((await PredictionModel.getByArticleHash(HASH)).length, 1);
+});
+
+test('an invalid ceiling_source rejects — provenance has a closed grammar (RQ2)', async () => {
+    const bad = scorerExport();
+    bad.aggregate.ceiling_source = 'banana';
+    await assert.rejects(importAuditJson(bad, { localArticleHash: HASH }),
+        /ceiling_source is not a valid provenance/);
+});
+
+test('the hash gate: corrupt and mismatched files never persist anything', async () => {
+    // Claimed hash disagrees with the body — corrupt or tampered.
+    const corrupt = scorerExport();
+    corrupt.article.hash = 'f'.repeat(64);
+    await assert.rejects(importAuditJson(corrupt), /does not match its body_markdown/);
+
+    // The audit is internally consistent but about DIFFERENT text than
+    // the local capture — refuse: the audit must be about text the
+    // user actually captured.
+    await assert.rejects(importAuditJson(scorerExport(), { localArticleHash: 'e'.repeat(64) }),
+        /scored different text than your capture/);
+
+    // Nothing persisted by either rejection.
+    assert.equal((await AuditRunModel.getByArticleHash(HASH)).length, 0);
+    assert.equal((await PredictionModel.getByArticleHash(HASH)).length, 0);
+});
+
+test('per-module failure posture: one bad module never rejects the file', async () => {
+    const broken = coherenceResult();
+    broken.findings.contradictions = [{ type: 'numerical' }];   // missing required fields
+    const summary = await importAuditJson(scorerExport({
+        module_results: [broken, predictionExtraction()]
+    }), { localArticleHash: HASH });
+    assert.equal(summary.modulesValid, 1);
+    assert.equal(summary.modulesFailed, 1);
+    assert.equal(summary.failedModules[0].module, 'internal_coherence');
+    assert.match(summary.failedModules[0].reason, /schema validation/);
+
+    const run = (await AuditRunModel.getByArticleHash(HASH))[0];
+    const failed = run.moduleResults.find((r) => r.module === 'internal_coherence');
+    assert.equal(failed.failed, true);
+    assert.equal(failed.score, null, 'failed runs carry no score — excluded from aggregation');
+    assert.ok(failed.auditor_caveats.some((c) => c.includes('failed schema validation')),
+        'the failure is recorded as a caveat, never silent');
+});
+
+test('scorer-reported _error modules store as failed runs', async () => {
+    const errored = {
+        module: 'omission', module_version: '1.0',
+        auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' },
+        run_at: RUN_AT, score: null, confidence: null,
+        findings: { error: 'API call failed: 529' },
+        evidence_quotes: [], auditor_caveats: ['API call failed: 529'],
+        _error: true
+    };
+    const summary = await importAuditJson(scorerExport({
+        module_results: [coherenceResult(), errored]
+    }), { localArticleHash: HASH });
+    assert.equal(summary.modulesValid, 1);
+    assert.equal(summary.failedModules[0].reason, 'scorer-reported error');
+});
+
+test('a file where EVERY module fails is rejected — nothing importable', async () => {
+    const broken = coherenceResult();
+    delete broken.findings.auditor_caveats;
+    await assert.rejects(importAuditJson(scorerExport({ module_results: [broken] }),
+        { localArticleHash: HASH }), /every module result failed/);
+});
+
+test('a contradictory aggregate rejects the import — it is the badge record', async () => {
+    const bad = scorerExport();
+    bad.aggregate.final_score = 90;   // > ceiling 80
+    await assert.rejects(importAuditJson(bad, { localArticleHash: HASH }),
+        /internally contradictory/);
+    const noConf = scorerExport();
+    delete noConf.aggregate.overall_confidence;
+    await assert.rejects(importAuditJson(noConf, { localArticleHash: HASH }),
+        /overall_confidence/);
+});
+
+test('re-import is idempotent: same run converges, predictions never duplicate', async () => {
+    await importAuditJson(scorerExport(), { localArticleHash: HASH });
+    const second = await importAuditJson(scorerExport(), { localArticleHash: HASH });
+    assert.equal(second.alreadyImported, true);
+    assert.equal((await AuditRunModel.getByArticleHash(HASH)).length, 1);
+    assert.equal((await PredictionModel.getByArticleHash(HASH)).length, 1);
+});


### PR DESCRIPTION
Slice **13.5** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — the **import half of import-then-sign** (RQ1's keeper architecture). Stacked on #65. Local-only and ungated; publishing audit events is 13.8, behind `epistemicAuditing`.

## What's in it

- **`audit/import.js` — the RQ1 gate at the door**: re-hash `body_markdown` vs the claimed hash (corrupt/tampered files reject); match against the local capture (an audit about text you never captured rejects); schema-validate every module payload. **Reject-vs-degrade is drawn at the badge**: a contradictory aggregate or invalid `ceiling-source` provenance rejects the file, while a single failed/`_error` module degrades to a failed run (score null, caveats recorded, excluded from aggregation — the scorer's own failure posture). Predictions validate enums **and publishability** (horizon/criteria/evidence — an entry the 30058 builder could never publish is not a ledger entry) and skip with counted reasons. Idempotent re-import.
- **Reader**: an Epistemic-audit bar — import keyed to the open capture's hash, **refused when no capture hash exists** (read-only portal opens; a half-checked import is worse than either honest extreme), status line obeying the display rules from day one.
- **Options → Advanced → Epistemic audits**: archive-matched import, including 13.4's retained prior versions.
- **Scorer README**: a clearly-marked X-Ray import note.

## Review

Three-lens adversarial review: **3 findings machine-verified** (the reader-gate hole — on read-only views any internally-consistent audit imported ungated while the status line said "no audit imported"; plus two mutation-verified attribution test gaps that would have let a silent fallback-to-pipeline flatten RQ3's identity layer). Seven verifier agents hit the session usage limit mid-run; their finder-lens findings were **adjudicated by direct code reading** — all real, all fixed (prediction enum validation, never-publishable predictions, the `ceiling_source` closed grammar, the vacuous `.every`-on-empty rejection). Full record in the JOURNAL.

## Verification

9 import tests; full suite **796 pass / 0 fail**; build + lint clean.

With this PR the v1 acceptance walk's left half is real: **capture → hash → CLI audit → import → validated local ledger.** Remaining per the slice plan: 13.6 (reader audit panel), 13.7 (portal surfaces + Resolve… form), 13.8 (flag-gated ordered publish), 13.9 (hardening + SMOKE_TEST).

🤖 Generated with [Claude Code](https://claude.com/claude-code)