### PR TITLE
feat(audit): Phase 13.6 — reader audit panel, atomize-as-claim, RQ6 lineage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 13.6 — reader audit panel.** The imported audit renders
+  under the claims bar: aggregate badge on the framework's rubric
+  bands (a score never renders without its confidence; aggregate
+  confidence below 0.6 renders as "needs human review" with no
+  number; a binding knowability ceiling always shows its context and
+  provenance), expandable per-module rows with auditor caveats and
+  click-to-locate evidence quotes, the prediction ledger with
+  **Atomize as claim** offers, and side-by-side display of multiple
+  runs (never averaged). ⚠️ **Wire-format note (additive, kind
+  30040)**: a claim promoted from a prediction-ledger entry emits an
+  `a` back-reference to its kind-30058 prediction (4th-position role
+  `prediction`) — lineage runs both directions; unpromoted claims are
+  byte-identical to the previous shape.
+
 - **Phase 13.5 — audit import (the v1 execution path).** Run the
   vendored scorer CLI out-of-band, then import its JSON from the
   Reader ("Import audit JSON…" under the open capture) or Settings →

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,56 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.6: the audit panel, and where the promotion link lives
+
+**Tags:** design
+
+Slice 13.6 (reader audit panel, draft PR). The second-guessable calls:
+
+- **The RQ6 promotion link lives on the PREDICTION record, not the
+  claim record.** `ClaimModel` whitelists its fields (id-deriving
+  fields immutable, the rest enumerated) — extending it for one
+  enrichment field would touch shipped Phase-10 storage for no
+  gain. Instead `PredictionModel.setClaimRef` stores
+  `{claim_id, pred_d}` (enrichment, no `updated` bump), and the
+  publish loop builds a claim→prediction map from the predictions
+  side. `pred_d` is stored pre-derived (the wire `d` is the local id
+  with the prefix swapped) so `buildClaimEvent` stays synchronous.
+- **Quote-locate is selection-only.** The article body is
+  contenteditable and syncs `htmlDraft` — wrapping matches in mark
+  elements (the entity-tagger idiom) would pollute the draft with
+  audit chrome. A Range + Selection highlight scrolls and flashes
+  without mutating anything.
+- **A sub-0.6 aggregate renders NO band color.** The review chip IS
+  the badge — score, band, and color all suppressed, because a
+  colored "needs review" still smuggles a verdict.
+- **Audits anchored to retained prior versions surface as a re-audit
+  notice, never as scores** — scores don't transfer across edits;
+  the notice says exactly that and points at the CLI re-run.
+- **The adversarial review confirmed 8 findings (0 refuted), one
+  BLOCKING**: the publish flow restamps `state.articleHash` to the
+  newly built event's hash (13.4) BEFORE the claims loop builds the
+  RQ6 back-ref map (13.6) — on an edited-body publish the prediction
+  lookup ran under the wrong hash and every back-reference silently
+  dropped. Fixed by snapshotting the capture hash before the restamp.
+  Also caught: a score with UNKNOWN confidence rendered as a naked —
+  and therefore more authoritative — number than one at 0.59
+  (unknown now renders the review chip, and import takes
+  score/confidence FROM the validated findings, failing modules whose
+  top-level copies diverge); `ceiling_binding` was trusted from the
+  file though both operands are validated (now derived — a tampered
+  file can neither hide a binding ceiling nor paint a spurious one);
+  quote-locate had a measured 213ms O(n²) stall plus an off-by-N that
+  started selections inside collapsed whitespace (rewritten as one
+  O(n) scan with per-character index mapping, cross-node ranges);
+  atomizing onto an already-published claim never re-emitted (the
+  publish filter skips published-unedited claims — promotion now
+  bumps `updated`, because gaining the back-ref tag IS an edit); and
+  the pred_d string surgery now has a parity test against the wire
+  derivation so the lineage coordinate cannot silently drift.
+
+---
+
 ## 2026-06-11 — 13.5: the import gate, and what rejects vs what degrades
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1014,6 +1014,18 @@ Implementation slices 13.1+ are in progress.
   honest status line) + options Advanced importer (archive-matched,
   incl. retained prior versions); scorer README import note. Imports
   are local-only and ungated; publishing is 13.8. — #66
+- 🔄 **13.6** Reader audit panel (draft PR for smoke-testing) —
+  aggregate badge on the framework rubric bands (no naked numbers;
+  confidence < 0.6 renders "needs human review" with no number and no
+  band color; ceiling context when binding; provenance line), eight
+  expandable module rows (caveats + click-to-locate evidence quotes,
+  selection-only — never mutates the contenteditable body), prediction
+  ledger list with **Atomize as claim** offers (RQ6: the promotion
+  links both ways — prediction `claim_ref` locally, and the promoted
+  claim's 30040 emits an `a` back-reference at publish; additive wire
+  change, CHANGELOG callout), prior-version re-audit notice,
+  staleness chips (`CURRENT_MODULE_VERSIONS` reference), other runs
+  side-by-side (never averaged). — #67
 
 ---
 

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -1764,6 +1764,118 @@ body {
   color: var(--xr-text-dim);
 }
 
+/* Panel body (13.6). Badge bands are the framework rubric — the scale
+   anchors at 70–85 normal, so "acceptable" (60–74) is deliberately NOT
+   green, and nothing below 75 reads as good. */
+
+.xr-audit__body { margin-top: 10px; display: flex; flex-direction: column; gap: 10px; }
+.xr-audit__body:empty { display: none; }
+
+.xr-audit__badge {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  border-radius: 8px;
+  font-size: 26px;
+  font-weight: 700;
+  border: 1px solid var(--xr-border);
+  background: var(--xr-surface);
+}
+.xr-audit__badge-conf { font-size: 13px; font-weight: 500; color: var(--xr-text-dim); }
+.xr-audit__badge-band { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+.xr-audit__badge-sub { flex-basis: 100%; font-size: 12px; font-weight: 500; color: var(--xr-text-dim); }
+
+.xr-audit__badge--exemplary   { border-left: 4px solid var(--xr-success); }
+.xr-audit__badge--solid       { border-left: 4px solid color-mix(in srgb, var(--xr-success) 65%, var(--xr-accent)); }
+.xr-audit__badge--acceptable  { border-left: 4px solid var(--xr-accent); }
+.xr-audit__badge--significant { border-left: 4px solid var(--xr-warning); }
+.xr-audit__badge--severe      { border-left: 4px solid color-mix(in srgb, var(--xr-danger) 70%, var(--xr-warning)); }
+.xr-audit__badge--catastrophic{ border-left: 4px solid var(--xr-danger); }
+.xr-audit__badge--review,
+.xr-audit__badge--none {
+  font-size: 15px;
+  font-weight: 600;
+  border-left: 4px solid var(--xr-text-dim);
+  color: var(--xr-text-dim);
+}
+
+.xr-audit__provenance { font-size: 11px; color: var(--xr-text-dim); }
+
+.xr-audit__chip {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  border: 1px solid var(--xr-border);
+  background: var(--xr-surface-2);
+  color: var(--xr-text-dim);
+}
+.xr-audit__chip--review { border-color: var(--xr-warning); color: var(--xr-warning); }
+.xr-audit__chip--failed { border-color: var(--xr-danger); color: var(--xr-danger); }
+.xr-audit__chip--stale  { border-color: var(--xr-accent); color: var(--xr-accent); }
+.xr-audit__chip--claimed{ border-color: var(--xr-success); color: var(--xr-success); }
+.xr-audit__chip--hedge-confident { border-color: var(--xr-primary); color: var(--xr-primary); }
+
+.xr-audit__score { font-size: 13px; font-weight: 600; }
+
+.xr-audit__modules { display: flex; flex-direction: column; gap: 4px; }
+.xr-audit__module {
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  background: var(--xr-surface);
+}
+.xr-audit__module > summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 8px 12px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 13px;
+}
+.xr-audit__module-name { font-weight: 600; text-transform: capitalize; flex: 1; min-width: 160px; }
+.xr-audit__module-version { font-size: 11px; color: var(--xr-text-dim); }
+.xr-audit__module-body { padding: 0 12px 10px; font-size: 12px; display: flex; flex-direction: column; gap: 8px; }
+.xr-audit__caveats ul, .xr-audit__quotes ul { margin: 4px 0 0 18px; padding: 0; }
+.xr-audit__quote {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--xr-accent);
+  cursor: pointer;
+  text-align: left;
+}
+.xr-audit__quote:hover { text-decoration: underline; }
+
+.xr-audit__h { font-size: 13px; margin: 4px 0 6px; }
+.xr-audit__predictions ul, .xr-audit__others ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.xr-audit__prediction {
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  background: var(--xr-surface);
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.xr-audit__prediction-meta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.xr-audit__prediction-horizon, .xr-audit__prediction-criteria { font-size: 11px; color: var(--xr-text-dim); }
+.xr-audit__others li { font-size: 12px; color: var(--xr-text-dim); }
+.xr-audit__prior-note {
+  font-size: 12px;
+  color: var(--xr-text);
+  padding: 8px 12px;
+  border: 1px solid color-mix(in srgb, var(--xr-warning) 50%, transparent);
+  border-left: 3px solid var(--xr-warning);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--xr-warning) 8%, var(--xr-surface));
+}
+
 /* ---------------- Canonical-hash line + stealth-edit banner (13.4) ------- */
 
 .xr-article__hash {

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -43,8 +43,10 @@
        with edit + delete affordances. -->
   <div id="xr-claims-host"></div>
 
-  <!-- Epistemic audit (Phase 13.5): CLI-audit import affordance. The
-       full audit panel arrives in 13.6; this hosts the import bar. -->
+  <!-- Epistemic audit (Phase 13.5/13.6): import bar + audit panel.
+       Firewall note: this section never visually merges with the
+       claims/assessment UI above it — separate blocks, separate
+       provenance, separate color scales. -->
   <section class="xr-audit" id="xr-audit">
     <div class="xr-audit__bar">
       <span class="xr-audit__label">Epistemic audit</span>
@@ -52,6 +54,7 @@
       <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-import">Import audit JSON…</button>
       <input type="file" id="xr-audit-file" accept="application/json,.json" hidden />
     </div>
+    <div class="xr-audit__body" id="xr-audit-body"></div>
   </section>
 
   <!-- Comments section. Shown only when the article has a postId from

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -28,7 +28,8 @@ import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirro
 import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
 import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
 import { importAuditJson } from '../shared/audit/import.js';
-import { AuditRunModel } from '../shared/audit/audit-model.js';
+import { AuditRunModel, PredictionModel, staleModules } from '../shared/audit/audit-model.js';
+import { CURRENT_MODULE_VERSIONS } from '../shared/audit/findings-schemas.js';
 
 const browserApi = typeof browser !== 'undefined' && browser.runtime ? browser : chrome;
 
@@ -423,31 +424,286 @@ function updateHashLine() {
     el.textContent = 'content hash ' + state.articleHash.slice(0, 16) + '…';
 }
 
-// Audit-bar status line (13.5): how many imported runs anchor to this
-// capture's hash. The full panel (scores, module rows) is 13.6 — this
-// just keeps the import affordance honest about what's stored.
+// ------------------------------------------------------------------
+// Audit panel (13.6)
+// ------------------------------------------------------------------
+//
+// Display rules, every surface (docs/EPISTEMIC_AUDIT_DESIGN.md §"Score
+// display"): no naked numbers (a score renders with its confidence);
+// confidence < 0.6 renders as "needs human review", not a number; the
+// badge bands are the framework's own rubric — never centered on 50;
+// provenance one tap away; disagreement side-by-side, never averaged;
+// audit and assessment UI never visually merge.
+
+// The framework rubric bands (prompts/00; PHILOSOPHY §4).
+function auditBand(score) {
+    if (score >= 90) return { key: 'exemplary',    label: 'Exemplary' };
+    if (score >= 75) return { key: 'solid',        label: 'Solid' };
+    if (score >= 60) return { key: 'acceptable',   label: 'Acceptable, with concerns' };
+    if (score >= 40) return { key: 'significant',  label: 'Significant problems' };
+    if (score >= 20) return { key: 'severe',       label: 'Severe' };
+    return { key: 'catastrophic', label: 'Catastrophic' };
+}
+
+function scoreChipHtml(score, confidence) {
+    if (typeof score !== 'number') {
+        return '<span class="xr-audit__chip xr-audit__chip--failed">failed</span>';
+    }
+    // No naked numbers, no exceptions: a score whose confidence is
+    // UNKNOWN must not render cleaner than one whose confidence is
+    // 0.59 — unknown is below the review threshold by definition.
+    if (typeof confidence !== 'number') {
+        return '<span class="xr-audit__chip xr-audit__chip--review" title="this result carries no confidence value — treat as unreviewed">needs human review · no confidence recorded</span>';
+    }
+    if (confidence < 0.6) {
+        return '<span class="xr-audit__chip xr-audit__chip--review" title="confidence ' +
+            escapeHtml(String(confidence)) + ' — below the 0.6 reliability threshold">needs human review</span>';
+    }
+    return `<span class="xr-audit__score">${escapeHtml(String(score))} · conf ${escapeHtml(String(confidence))}</span>`;
+}
+
+function prettyModule(name) {
+    return String(name || '').replace(/_/g, ' ');
+}
+
+// Locate an evidence quote in the article body: selection-only (the
+// body is contenteditable and syncs htmlDraft — DOM mutation here
+// would pollute the draft). Whitespace-normalized search with a
+// single O(n) forward scan mapping normalized positions back to raw
+// offsets — per-character normalized indices, so the selection starts
+// ON the quote (never inside a collapsed whitespace run) and ends at
+// its true tail, across text-node boundaries.
+function locateQuoteInBody(quote) {
+    const body = $('.xr-article__body');
+    if (!body || !quote) return false;
+    const target = String(quote).replace(/\s+/g, ' ').trim();
+    if (!target) return false;
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+    const nodes = [];
+    let full = '';
+    let n;
+    while ((n = walker.nextNode())) {
+        nodes.push({ node: n, start: full.length });
+        full += n.textContent;
+    }
+
+    // One pass: normalized string + the raw index of each normalized
+    // character. A whitespace run contributes one normalized space,
+    // attributed to the run's first raw char.
+    const rawIndexOfNorm = [];
+    let normStr = '';
+    let inWs = false;
+    for (let i = 0; i < full.length; i++) {
+        if (/\s/.test(full[i])) {
+            if (!inWs) { normStr += ' '; rawIndexOfNorm.push(i); inWs = true; }
+        } else {
+            normStr += full[i];
+            rawIndexOfNorm.push(i);
+            inWs = false;
+        }
+    }
+
+    const idx = normStr.indexOf(target);
+    if (idx === -1) return false;
+    const rawStart = rawIndexOfNorm[idx];
+    const rawEndInclusive = rawIndexOfNorm[idx + target.length - 1];
+
+    const nodeFor = (raw) => {
+        let lo = 0;
+        for (let i = 0; i < nodes.length; i++) {
+            if (nodes[i].start <= raw) lo = i; else break;
+        }
+        return nodes[lo];
+    };
+    const startHit = nodeFor(rawStart);
+    const endHit = nodeFor(rawEndInclusive);
+    if (!startHit || !endHit) return false;
+    try {
+        const range = document.createRange();
+        range.setStart(startHit.node, rawStart - startHit.start);
+        range.setEnd(endHit.node, Math.min(rawEndInclusive + 1 - endHit.start, endHit.node.textContent.length));
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+        (startHit.node.parentElement || body).scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return true;
+    } catch (_) { return false; }
+}
+
+function renderModuleRow(r, staleSet) {
+    const quotes = (r.evidence_quotes || []).map((q) => q && q.quote).filter(Boolean);
+    const caveats = r.auditor_caveats || [];
+    const stale = staleSet.has(r.module);
+    return `
+      <details class="xr-audit__module">
+        <summary>
+          <span class="xr-audit__module-name">${escapeHtml(prettyModule(r.module))}</span>
+          <span class="xr-audit__module-version" title="methodology version">v${escapeHtml(r.module_version || '?')}</span>
+          ${stale ? '<span class="xr-audit__chip xr-audit__chip--stale">newer methodology available — re-audit offered</span>' : ''}
+          ${r.module === 'prediction_extraction'
+        ? '<span class="xr-audit__chip" title="not a scored dimension — feeds the ledger">unscored</span>'
+        : scoreChipHtml(r.score, r.confidence)}
+        </summary>
+        <div class="xr-audit__module-body">
+          <div class="xr-audit__provenance">auditor: ${escapeHtml(r.auditor ? `${r.auditor.kind} · ${r.auditor.id}` : 'unknown')} · run ${escapeHtml(r.run_at || '')}</div>
+          ${caveats.length ? `<div class="xr-audit__caveats"><strong>Caveats</strong> — what this scan could not determine:<ul>${caveats.map((c) => `<li>${escapeHtml(c)}</li>`).join('')}</ul></div>` : ''}
+          ${quotes.length ? `<div class="xr-audit__quotes"><strong>Evidence quotes</strong> (click to locate):<ul>${quotes.map((q) => `<li><button type="button" class="xr-audit__quote" data-quote="${escapeHtml(q)}">“${escapeHtml(q.length > 120 ? q.slice(0, 120) + '…' : q)}”</button></li>`).join('')}</ul></div>` : ''}
+        </div>
+      </details>`;
+}
+
+function renderPredictionRow(p) {
+    const promoted = p.claim_ref && p.claim_ref.claim_id;
+    return `
+      <li class="xr-audit__prediction" data-pred-id="${escapeHtml(p.id)}">
+        <div class="xr-audit__prediction-text">${escapeHtml(p.text)}</div>
+        <div class="xr-audit__prediction-meta">
+          <span class="xr-audit__chip">${escapeHtml(p.type)}</span>
+          <span class="xr-audit__chip xr-audit__chip--hedge-${escapeHtml(p.hedge_level)}">${escapeHtml(p.hedge_level)}</span>
+          <span class="xr-audit__chip">${escapeHtml(p.tractability)}</span>
+          <span class="xr-audit__prediction-horizon">horizon: ${escapeHtml(p.horizon || 'unscheduled')}</span>
+          ${promoted
+        ? '<span class="xr-audit__chip xr-audit__chip--claimed" title="atomized into a kind-30040 claim">claim ✓</span>'
+        : `<button type="button" class="xr-reader__btn xr-reader__btn--ghost xr-audit__atomize" data-pred-id="${escapeHtml(p.id)}">Atomize as claim…</button>`}
+        </div>
+        <div class="xr-audit__prediction-criteria" title="resolution criteria">resolves when: ${escapeHtml(p.criteria || '—')}</div>
+      </li>`;
+}
+
+// Full panel render. Keyed strictly to the CURRENT capture hash; runs
+// anchored to retained prior versions surface as a re-audit offer,
+// never as scores for text they didn't score.
 async function refreshAuditStatus() {
-    const el = $('#xr-audit-status');
-    if (!el) return;
+    const statusEl = $('#xr-audit-status');
+    const bodyEl = $('#xr-audit-body');
+    if (!statusEl || !bodyEl) return;
     if (!state.articleHash) {
-        el.textContent = 'No audit imported for this capture.';
+        statusEl.textContent = 'No capture hash for this view — audits key on the exact text.';
+        bodyEl.innerHTML = '';
         return;
     }
+
     const runs = await AuditRunModel.getByArticleHash(state.articleHash);
+    const predictions = await PredictionModel.getByArticleHash(state.articleHash);
+
     if (!runs.length) {
-        el.textContent = 'No audit imported for this capture.';
+        statusEl.textContent = 'No audit imported for this capture.';
+        // Re-audit affordance: audits may anchor to a RETAINED PRIOR
+        // version of this URL's text (13.4 retention).
+        let priorNote = '';
+        try {
+            const record = state.article && state.article.url
+                ? await ArchiveCache.getArticle(state.article.url) : null;
+            const priorHashes = ((record && record.priorVersions) || [])
+                .map((v) => v.articleHash).filter(Boolean);
+            let priorRuns = 0;
+            for (const h of priorHashes) {
+                priorRuns += (await AuditRunModel.getByArticleHash(h)).length;
+            }
+            if (priorRuns > 0) {
+                priorNote = `<div class="xr-audit__prior-note">⚠️ ${priorRuns} audit run${priorRuns === 1 ? '' : 's'} anchor to a <em>previous version</em> of this text. Scores never transfer across edits — re-run the scorer CLI against the current capture and import the result (re-audit).</div>`;
+            }
+        } catch (_) { /* advisory only */ }
+        bodyEl.innerHTML = priorNote;
         return;
     }
-    const latest = runs.slice().sort((a, b) => String(b.runAt).localeCompare(String(a.runAt)))[0];
-    const score = latest.aggregate && typeof latest.aggregate.final_score === 'number'
-        ? latest.aggregate.final_score : null;
-    const conf = latest.aggregate && typeof latest.aggregate.overall_confidence === 'number'
-        ? latest.aggregate.overall_confidence : null;
-    // Display rule (no naked numbers; <0.6 ⇒ needs human review).
-    const scoreLabel = score === null ? 'no aggregate score'
-        : (conf !== null && conf < 0.6) ? 'needs human review (confidence < 0.6)'
-            : `score ${score}` + (conf !== null ? ` · confidence ${conf}` : '');
-    el.textContent = `${runs.length} audit run${runs.length === 1 ? '' : 's'} stored — latest: ${scoreLabel}. Full panel arrives in 13.6.`;
+
+    const sorted = runs.slice().sort((a, b) => String(b.runAt).localeCompare(String(a.runAt)));
+    const latest = sorted[0];
+    const others = sorted.slice(1);
+    const agg = latest.aggregate || {};
+    const score = typeof agg.final_score === 'number' ? agg.final_score : null;
+    const conf = typeof agg.overall_confidence === 'number' ? agg.overall_confidence : null;
+
+    statusEl.textContent = `${runs.length} audit run${runs.length === 1 ? '' : 's'} for this exact text.`;
+
+    // Badge per the display rules. A sub-0.6 confidence never renders
+    // a number, band color included — review-needed is the whole badge.
+    let badge;
+    if (score === null) {
+        badge = '<div class="xr-audit__badge xr-audit__badge--none">no aggregate score</div>';
+    } else if (conf !== null && conf < 0.6) {
+        badge = '<div class="xr-audit__badge xr-audit__badge--review">needs human review<span class="xr-audit__badge-sub">aggregate confidence ' + escapeHtml(String(conf)) + ' — below 0.6</span></div>';
+    } else {
+        const band = auditBand(score);
+        const ceilingLine = agg.ceiling_binding
+            ? `<span class="xr-audit__badge-sub">capped by knowability ${escapeHtml(String(agg.knowability_ceiling))}${agg.knowability_notes ? ' — ' + escapeHtml(agg.knowability_notes) : ''}</span>`
+            : '';
+        badge = `<div class="xr-audit__badge xr-audit__badge--${band.key}" title="${escapeHtml(band.label)}">` +
+            `${escapeHtml(String(score))}<span class="xr-audit__badge-conf">conf ${escapeHtml(String(conf))}</span>` +
+            `<span class="xr-audit__badge-band">${escapeHtml(band.label)}</span>${ceilingLine}</div>`;
+    }
+
+    const provenance = `<div class="xr-audit__provenance">auditor: ${escapeHtml(latest.auditor ? `${latest.auditor.kind} · ${latest.auditor.id}` : 'unknown')} · run ${escapeHtml(latest.runAt)} · ceiling source: ${escapeHtml(agg.ceiling_source || 'unknown')} · imported via ${escapeHtml(latest.source)}</div>`;
+
+    const staleSet = new Set(staleModules(latest, CURRENT_MODULE_VERSIONS).map((s) => s.module));
+    const moduleRows = (latest.moduleResults || []).map((r) => renderModuleRow(r, staleSet)).join('');
+
+    const predBlock = predictions.length
+        ? `<div class="xr-audit__predictions"><h3 class="xr-audit__h">Prediction ledger (${predictions.length})</h3><ul>${predictions.map(renderPredictionRow).join('')}</ul></div>`
+        : '';
+
+    // Disagreement is data: other runs render side-by-side, never
+    // averaged into the badge.
+    const othersBlock = others.length
+        ? `<div class="xr-audit__others"><h3 class="xr-audit__h">Other runs (side-by-side — never averaged)</h3><ul>${others.map((r) => {
+            const a = r.aggregate || {};
+            const s = typeof a.final_score === 'number' ? a.final_score : null;
+            const c = typeof a.overall_confidence === 'number' ? a.overall_confidence : null;
+            return `<li>${scoreChipHtml(s, c)} — ${escapeHtml(r.auditor ? r.auditor.id : 'unknown')} · ${escapeHtml(r.runAt)}</li>`;
+        }).join('')}</ul></div>`
+        : '';
+
+    bodyEl.innerHTML = `
+      ${badge}
+      ${provenance}
+      <div class="xr-audit__modules">${moduleRows}</div>
+      ${predBlock}
+      ${othersBlock}`;
+
+    // Wire quote-locate + atomize offers.
+    bodyEl.querySelectorAll('.xr-audit__quote').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            if (!locateQuoteInBody(btn.dataset.quote)) {
+                toast('Quote not found in the current text — the body may have been edited.', 'warning', 4000);
+            }
+        });
+    });
+    bodyEl.querySelectorAll('.xr-audit__atomize').forEach((btn) => {
+        btn.addEventListener('click', async () => {
+            const pred = predictions.find((p) => p.id === btn.dataset.predId);
+            if (!pred) return;
+            // RQ6: offered action, never automatic — the ordinary claim
+            // pipeline with the user confirming. The promoted claim and
+            // the prediction link both ways.
+            const saved = await openClaimModal({
+                sourceUrl:    state.article.url,
+                initialText:  pred.text,
+                context:      pred.evidence_quote || '',
+                anchor:       pred.anchor || null,
+                initialAbout: state.lastClaimAbout || []
+            });
+            if (saved) {
+                await PredictionModel.setClaimRef(pred.id, {
+                    claim_id: saved.id,
+                    pred_d: 'pred:' + pred.id.slice('pred_'.length)
+                });
+                // Idempotent create may have returned an EXISTING,
+                // already-published claim — which the publish filter
+                // (updated > publishedAt) would skip, so the new
+                // back-reference would never reach the wire. Promotion
+                // changes the published event (it gains the a tag):
+                // that IS an edit — bump so it re-emits.
+                if (saved.publishedAt && !(saved.updated > saved.publishedAt)) {
+                    try { await ClaimModel.update(saved.id, {}); }
+                    catch (err) { console.warn('[X-Ray Reader] claim bump failed:', err); }
+                }
+                toast('Claim saved — it will back-reference this prediction at publish.', 'success', 4000);
+                await refreshClaimsBar();
+                await refreshAuditStatus();
+            }
+        });
+    });
 }
 
 // Stealth-edit surface: the same URL hashed differently on a prior
@@ -1649,6 +1905,12 @@ async function publish() {
 
         const unsignedArticle = await EventBuilder.buildArticleEvent(article, entityRefs, userPubkey, [], authorAccountPubkey);
 
+        // 13.6: predictions are keyed to the CAPTURE hash — snapshot
+        // it before the restamp below, or an edited-body publish would
+        // look the ledger up under the NEW hash, find nothing, and
+        // silently drop every promoted claim's back-reference.
+        const captureHashForLedger = state.articleHash;
+
         // 13.4: the event just built carries the canonical hash of the
         // FINAL (possibly edited) body as its x tag. Stamp it on the
         // article so the post-publish archive save records the hash of
@@ -1840,12 +2102,28 @@ async function publish() {
         const claimBatchBase = entityBatchBase + entitiesToPublish.length;
         const claimResults = { ok: 0, fail: 0, errors: [] };
         const entitiesDict = claimsToPublish.length > 0 ? await EntityModel.getAll() : {};
+        // RQ6 back-references (13.6): claims promoted from prediction-
+        // ledger entries carry an `a` pointer back to their 30058.
+        // Keyed by claim id from the predictions' claim_ref records;
+        // best-effort — a missing map never gates claim publishing.
+        let predictionRefByClaim = {};
+        if (claimsToPublish.length > 0 && captureHashForLedger) {
+            try {
+                const preds = await PredictionModel.getByArticleHash(captureHashForLedger);
+                for (const p of preds) {
+                    if (p.claim_ref && p.claim_ref.claim_id && p.claim_ref.pred_d) {
+                        predictionRefByClaim[p.claim_ref.claim_id] = { pred_d: p.claim_ref.pred_d };
+                    }
+                }
+            } catch (_) { /* enrichment only */ }
+        }
         for (let i = 0; i < claimsToPublish.length; i++) {
             const claim = claimsToPublish[i];
             btn.textContent = `Publishing (${claimBatchBase + i + 1}/${totalEvents})…`;
             try {
                 const unsigned = EventBuilder.buildClaimEvent(
-                    claim, article.url, article.title || 'Untitled', userPubkey, entitiesDict
+                    claim, article.url, article.title || 'Untitled', userPubkey, entitiesDict,
+                    predictionRefByClaim[claim.id] || null
                 );
                 const resp = await browserApi.runtime.sendMessage({
                     type:  'xray:capture:publish',

--- a/src/shared/audit/audit-model.js
+++ b/src/shared/audit/audit-model.js
@@ -240,6 +240,21 @@ export const PredictionModel = {
     },
 
     /**
+     * Record the promotion link (RQ6): this prediction was atomized
+     * into a 30040 claim. `claimRef` carries `{claim_id, pred_d}` —
+     * the local claim id plus this prediction's wire `d`, so the
+     * claim builder can emit the `a` back-reference without an async
+     * derivation. Enrichment, never bumps `updated`.
+     */
+    setClaimRef: async (id, claimRef) => {
+        const record = await getPrediction(id);
+        if (!record) return null;
+        record.claim_ref = claimRef || null;
+        await savePrediction(record);
+        return record;
+    },
+
+    /**
      * Recompute the derived resolution fields from a set of resolution
      * records (own + incoming 30059s). Persists without bumping
      * `updated` — derivation is enrichment, not an edit.

--- a/src/shared/audit/findings-schemas.js
+++ b/src/shared/audit/findings-schemas.js
@@ -288,6 +288,14 @@ const PAYLOADS = {
 
 export const MODULE_NAMES = Object.freeze(Object.keys(PAYLOADS));
 
+// The methodology versions the vendored prompts currently declare —
+// the staleness reference: a stored result whose module_version is
+// older gets a "re-audit under vX.Y" offer (never auto-recompute;
+// old results stay valid under their recorded version, P9/§8). Bump
+// alongside the prompt when a methodology changes.
+export const CURRENT_MODULE_VERSIONS = Object.freeze(
+    Object.fromEntries(MODULE_NAMES.map((m) => [m, '1.0'])));
+
 // prediction_extraction does not score (the ledger does, later).
 export const SCOREABLE_MODULES = Object.freeze(
     MODULE_NAMES.filter((m) => m !== 'prediction_extraction')

--- a/src/shared/audit/import.js
+++ b/src/shared/audit/import.js
@@ -159,10 +159,29 @@ export async function importAuditJson(json, { localArticleHash = null } = {}) {
             failedModules.push({ module, reason: `schema validation (${errors.length} errors)` });
             continue;
         }
+        // Score/confidence come FROM the schema-validated findings —
+        // the wrapper's top-level copies sit outside every gate, and a
+        // divergent (tampered) pair would otherwise import cleanly and
+        // render as a naked, more-authoritative number (the exact
+        // score-theater failure the display rules exist to block).
+        const findingsScore = typeof r.findings.score === 'number' ? r.findings.score : null;
+        const findingsConf = typeof r.findings.confidence === 'number' ? r.findings.confidence : null;
+        const topDiverges = (typeof r.score === 'number' && findingsScore !== null && r.score !== findingsScore)
+            || (typeof r.confidence === 'number' && findingsConf !== null && r.confidence !== findingsConf);
+        if (topDiverges) {
+            storedResults.push({
+                ...base, score: null, confidence: null, findings: r.findings,
+                failed: true,
+                auditor_caveats: [...base.auditor_caveats,
+                    `top-level score/confidence diverge from the validated findings (${r.score}/${r.confidence} vs ${findingsScore}/${findingsConf}) — tampered or corrupt`]
+            });
+            failedModules.push({ module, reason: 'score/confidence diverge from findings' });
+            continue;
+        }
         storedResults.push({
             ...base,
-            score: typeof r.score === 'number' ? r.score : null,
-            confidence: typeof r.confidence === 'number' ? r.confidence : null,
+            score: findingsScore,
+            confidence: findingsConf,
             findings: r.findings,
             failed: false
         });
@@ -187,7 +206,12 @@ export async function importAuditJson(json, { localArticleHash = null } = {}) {
             raw_weighted_score: rawScore,
             knowability_ceiling: ceiling,
             knowability_notes: aggregate.knowability_notes || '',
-            ceiling_binding: aggregate.ceiling_binding === true,
+            // DERIVED, never trusted: the flag controls whether the
+            // badge shows its cap context, and a tampered file could
+            // hide a binding ceiling (or paint a spurious one). Both
+            // operands are validated above; the scorer's own
+            // definition is raw > ceiling.
+            ceiling_binding: rawScore > ceiling,
             // RQ2: the scorer's heuristic is the canonical pipeline
             // source; an import carrying its own source wins.
             ceiling_source: aggregate.ceiling_source || 'heuristic:source-quality/1.0',

--- a/src/shared/event-builder.js
+++ b/src/shared/event-builder.js
@@ -441,13 +441,23 @@ export const EventBuilder = {
   //
   // "What the network says about entity P" is then a single relay query:
   //   { kinds:[30040], "#p":[P_pubkey] }
-  buildClaimEvent: (claim, articleUrl, articleTitle, userPubkey, entities) => {
+  //
+  // `predictionRef` (Phase 13.6, RQ6 — additive optional): when this
+  // claim was promoted from a prediction-ledger entry, `{pred_d}` is
+  // the 30058's wire d, and the claim emits an `a` back-reference so
+  // lineage runs both directions. The coordinate's pubkey is the
+  // publisher's — predictions and their promoted claims share one
+  // signer in the v1 flow.
+  buildClaimEvent: (claim, articleUrl, articleTitle, userPubkey, entities, predictionRef = null) => {
     const dict = entities || {};
     const tags = [
       ['d', claim.id],
       ['r', articleUrl],
     ];
     if (articleTitle) tags.push(['title', articleTitle]);
+    if (predictionRef && predictionRef.pred_d) {
+      tags.push(['a', `30058:${userPubkey}:${predictionRef.pred_d}`, '', 'prediction']);
+    }
 
     // About entities — the queryable core.
     for (const eid of (Array.isArray(claim.about) ? claim.about : [])) {

--- a/tests/audit-capture-hash.test.mjs
+++ b/tests/audit-capture-hash.test.mjs
@@ -140,6 +140,34 @@ test('reconstructArticleFromEvent carries the published hash as _articleHash', a
     assert.equal(EventBuilder.reconstructArticleFromEvent(legacy)._articleHash, null);
 });
 
+test('a promoted claim back-references its prediction (RQ6, additive 30040 wire change)', async () => {
+    const claim = {
+        id: 'claim_1234567890abcdef',
+        text: 'Rates will fall by December.',
+        about: [], source: null, is_key: false, anchor: null
+    };
+    const withRef = EventBuilder.buildClaimEvent(
+        claim, 'https://example.com/story', 'A Story', PUBKEY, {},
+        { pred_d: 'pred:abcdef0123456789' });
+    const aTag = withRef.tags.find((t) => t[0] === 'a');
+    assert.deepEqual(aTag, ['a', `30058:${PUBKEY}:pred:abcdef0123456789`, '', 'prediction'],
+        'lineage runs both directions — the claim points back at the ledger entry');
+
+    // Additive and optional: unpromoted claims are byte-identical to
+    // the pre-13.6 shape (no a tag at all).
+    const without = EventBuilder.buildClaimEvent(
+        claim, 'https://example.com/story', 'A Story', PUBKEY, {});
+    assert.equal(without.tags.find((t) => t[0] === 'a'), undefined);
+});
+
+test('CURRENT_MODULE_VERSIONS covers every module (the staleness reference)', async () => {
+    const { CURRENT_MODULE_VERSIONS, MODULE_NAMES } = await import('../src/shared/audit/findings-schemas.js');
+    assert.deepEqual(Object.keys(CURRENT_MODULE_VERSIONS).sort(), [...MODULE_NAMES].sort());
+    for (const v of Object.values(CURRENT_MODULE_VERSIONS)) {
+        assert.match(v, /^\d+\.\d+(\.\d+)?$/);
+    }
+});
+
 test('archive records carry articleHash, agreeing with the publish-path x tag', async () => {
     await ArchiveCache.clear().catch(() => { /* fresh db */ });
     const article = articleFixture({ url: 'https://example.com/archived-story' });

--- a/tests/audit-import.test.mjs
+++ b/tests/audit-import.test.mjs
@@ -160,6 +160,38 @@ test('malformed predictions are skipped with reasons, never imported or failed-t
     assert.equal((await PredictionModel.getByArticleHash(HASH)).length, 1);
 });
 
+test('top-level score/confidence diverging from validated findings fails the module — no naked authority', async () => {
+    const tampered = coherenceResult({ score: 95 });   // findings say 74
+    const summary = await importAuditJson(scorerExport({
+        module_results: [tampered, predictionExtraction()]
+    }), { localArticleHash: HASH });
+    assert.equal(summary.modulesFailed, 1);
+    assert.match(summary.failedModules[0].reason, /diverge from findings/);
+
+    // And the stored values come FROM the findings on the clean path.
+    await clear();
+    const clean = await importAuditJson(scorerExport(), { localArticleHash: HASH });
+    assert.equal(clean.modulesFailed, 0);
+    const run = (await AuditRunModel.getByArticleHash(HASH))[0];
+    const coherence = run.moduleResults.find((r) => r.module === 'internal_coherence');
+    assert.equal(coherence.score, 74);
+    assert.equal(coherence.confidence, 0.8);
+});
+
+test('ceiling_binding is DERIVED from raw vs ceiling — the file flag is never trusted', async () => {
+    // raw 92 > ceiling 80, final 80 — internally consistent, but the
+    // file lies about binding. The badge's cap context depends on
+    // this flag; derive it.
+    const hidden = scorerExport();
+    hidden.aggregate.raw_weighted_score = 92;
+    hidden.aggregate.final_score = 80;
+    hidden.aggregate.ceiling_binding = false;
+    await importAuditJson(hidden, { localArticleHash: HASH });
+    const run = (await AuditRunModel.getByArticleHash(HASH))[0];
+    assert.equal(run.aggregate.ceiling_binding, true,
+        'a tampered file cannot hide a binding ceiling');
+});
+
 test('an invalid ceiling_source rejects — provenance has a closed grammar (RQ2)', async () => {
     const bad = scorerExport();
     bad.aggregate.ceiling_source = 'banana';

--- a/tests/audit-model.test.mjs
+++ b/tests/audit-model.test.mjs
@@ -146,6 +146,40 @@ test('PredictionModel: idempotent create; publish and derive never bump updated'
     assert.equal(derived.updated, SENTINEL, 'derivation is enrichment, not an edit');
 });
 
+test('setClaimRef records the promotion link (RQ6) without bumping updated', async () => {
+    const pred = await PredictionModel.create({
+        articleHash: HASH, text: 'Promoted prediction.', hedge_level: 'hedged',
+        type: 'explicit', tractability: 'ambiguous', evidence_quote: 'q'
+    });
+    await savePrediction({ ...pred, updated: SENTINEL });
+    const linked = await PredictionModel.setClaimRef(pred.id, {
+        claim_id: 'claim_1234567890abcdef',
+        pred_d: 'pred:' + pred.id.slice('pred_'.length)
+    });
+    assert.equal(linked.claim_ref.claim_id, 'claim_1234567890abcdef');
+    assert.match(linked.claim_ref.pred_d, /^pred:[0-9a-f]{16}$/);
+    assert.equal(linked.updated, SENTINEL, 'promotion linking is enrichment, not an edit');
+
+    // PERSISTED, not just returned — both consumers (the panel chip
+    // and the publish-time back-ref map) re-read from the store.
+    const refetched = await PredictionModel.get(pred.id);
+    assert.equal(refetched.claim_ref.claim_id, 'claim_1234567890abcdef');
+    assert.equal(refetched.updated, SENTINEL);
+});
+
+test('pred_d string surgery equals the wire derivation — the lineage coordinate cannot drift', async () => {
+    // The reader derives the promoted claim's back-ref coordinate as
+    // 'pred:' + localId.slice('pred_'.length). That equals the wire d
+    // ONLY while generatePredictionId and derivePredictionEntryDTag
+    // share preimage and normalizer — pin the equation so either side
+    // drifting fails here instead of dangling published a-tags.
+    const { derivePredictionEntryDTag } = await import('../src/shared/audit/builders.js');
+    const text = '  Rates WILL fall   by December. ';
+    const localId = await generatePredictionId(HASH, text);
+    const surgery = 'pred:' + localId.slice('pred_'.length);
+    assert.equal(surgery, await derivePredictionEntryDTag(HASH, text));
+});
+
 test('deriveResolutionState: latest resolved_at wins; outcomes map to statuses', () => {
     assert.deepEqual(deriveResolutionState([]), { status: 'open', latestId: null });
     const state = deriveResolutionState([


### PR DESCRIPTION
Slice **13.6** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — the imported audit becomes visible. **Draft for smoke-testing** (house cadence for UI slices). Stacked on #66. ⚠️ Additive wire change to kind 30040 (promoted claims back-reference their prediction; CHANGELOG callout).

## What's in it

- **The audit panel** (under the claims bar, firewall-separated from assessment UI): aggregate badge on the framework rubric bands; expandable module rows with auditor caveats and click-to-locate evidence quotes (selection-only — never mutates the contenteditable body); the prediction ledger with **Atomize as claim** offers; a prior-version re-audit notice; staleness chips; other runs side-by-side, never averaged.
- **Display rules enforced structurally**: no naked numbers anywhere — a score with *unknown* confidence renders the review chip (unknown must not look more authoritative than 0.59); sub-0.6 suppresses score, band, *and* color; binding ceilings always show context + provenance.
- **RQ6 lineage end-to-end**: promotion stores `claim_ref` on the prediction; the promoted 30040 emits `["a", "30058:…", "", "prediction"]` at publish; atomizing onto an already-published claim bumps it so the back-ref re-emits.
- **Import hardening** (from this slice's review): module score/confidence now come from the schema-validated findings (divergent top-level copies fail the module as tampered); `ceiling_binding` is derived, never trusted from the file.

## Review

Three-lens adversarial review: **8 confirmed, 0 refuted — one BLOCKING**: the publish flow restamped `state.articleHash` (13.4) before the back-ref map was built (13.6), so an edited-body publish silently dropped every promoted claim's lineage. Fixed by snapshotting the capture hash. Also fixed: the naked-number/unknown-confidence inversion, the trusted `ceiling_binding` flag, a measured 213ms O(n²) quote-locate stall plus a verified off-by-N (selections started inside collapsed whitespace), the published-claim re-emit gap, and a pred_d parity test pinning the lineage coordinate against the wire derivation. JOURNAL has the full record.

## Smoke checks for this draft

1. Import an audit (Reader → *Import audit JSON…*) → badge renders with band + confidence; expand a module row; click an evidence quote → article scrolls and selects the quote text.
2. Set a sub-0.6 `overall_confidence` in a test export → the badge is the review chip only — no number, no band color.
3. *Atomize as claim* on a prediction → claim modal pre-filled → save → `claim ✓` chip appears; publish → the claim event carries the `a` back-reference (`role prediction`).
4. Edit the body, then publish → promoted-claim back-refs still emit (the blocking fix).
5. Re-capture an edited page → the panel shows the prior-version re-audit notice instead of stale scores.

## Verification

802 tests green; build + lint clean.

Next: 13.7 (portal surfaces + the Resolve… form), 13.8 (flag-gated ordered publish), 13.9 (hardening + SMOKE_TEST §Phase 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)