### PR TITLE
feat(audit): Phase 13.7 — portal audit surfaces, dossier block, Resolve form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 13.7 — portal audit surfaces.** The portal corpus now
+  fetches the audit kinds (30056–30061); the Library gains Audits and
+  Predictions facets plus an audit chip on article cards (joined by
+  canonical hash — scores never transfer across edits); the item
+  inspector shows every audit run anchored to an article side-by-side
+  (never averaged), including local unpublished imports; entity views
+  gain a derived **Audit dossier** (shrinkage always shown with its
+  parameters; the per-hedge calibration rate table; calibration-v1
+  displayed as informational, never applied); and the timeline gains
+  a predictions-coming-due strip with an evidence-bound **Resolve…**
+  form (resolutions file locally; publishing is the flag-gated 13.8
+  step).
+
 - **Phase 13.6 — reader audit panel.** The imported audit renders
   under the claims bar: aggregate badge on the framework's rubric
   bands (a score never renders without its confidence; aggregate

--- a/docs/EPISTEMIC_AUDIT_DESIGN.md
+++ b/docs/EPISTEMIC_AUDIT_DESIGN.md
@@ -895,6 +895,10 @@ Phase 12's portal already owns read-back surfaces. Division of labor:
   (via 30023 `p…author` tags + 32126 accounts + `t` beats), plus the
   local audit ledger for unpublished runs. Reproducible by
   construction — anyone with the events derives the same numbers.
+  Confidence rule (added in 13.7): aggregates below the 0.6 review
+  threshold are **excluded from the rollup and counted as pending
+  review** — a number the display rules refuse to show must not move
+  a reputation either.
 - **Published 30060 (optional cache):** "Publish dossier snapshot" from
   the dossier block, flag-gated like everything else. Latest-wins per
   subject. Consumers MUST prefer re-derivation when they hold the

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,67 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.7: the portal joins, and what a dossier refuses to be
+
+**Tags:** design
+
+Slice 13.7 (portal audit surfaces, draft PR). The calls worth a
+paper trail:
+
+- **Hash-first joins, URL fallback only for hashless events.** An
+  audit chip on an article card means "this exact text was scored."
+  Pre-13.4 articles carry no `x` tag, so they fall back to the URL
+  join — and post-13.4 articles NEVER do, even when audits share
+  their URL: scores don't transfer across edits, full stop. Pinned by
+  test.
+- **The dossier rolls up the latest judgment per (article, auditor)**
+  — older runs by the same auditor are superseded judgments, not
+  extra data points; cross-auditor disagreement stays visible in the
+  inspector instead (side-by-side, never averaged). And no audited
+  articles → NO dossier, not an empty one at the population prior —
+  a dossier that is pure prior is noise dressed as reputation.
+- **`DEFAULT_POPULATION_MEAN = 77` is a published assumption**,
+  displayed in the dossier line every time it shrinks a mean
+  ("shrunk to 77.27 toward population 77, k=10, factor 0.91") — §4's
+  publish-the-shrinkage rule, applied literally.
+- **The Resolve… form derives unpublished-prediction coordinates
+  from the primary identity** — the v1 flow signs predictions and
+  resolutions with one key, so the coordinate the local resolution
+  keys on is the one the 13.8 publish will mint. No identity → the
+  affordance disables rather than guessing.
+- **The kind-list and TYPE_DEFS pins fired** when the corpus gained
+  the audit family — updated deliberately, which is exactly what
+  those pins are for.
+- **The adversarial review confirmed 20 findings (0 refuted), the
+  most of any slice — two blocking roots.** (1) The hash join was
+  DEAD in production: `buildItem` spreads extras flat, my joins read
+  the nested `item.extra.articleHash` my own test fixtures had
+  invented — every article silently fell to the URL join, local runs
+  never surfaced, and dossier predictions were always empty. Fixed
+  with a both-shapes accessor and, more importantly, a
+  production-pipeline test that builds events with the real builders
+  and runs them through `buildItems` — the seam can't silently split
+  again. (2) Locally-filed resolutions were invisible everywhere:
+  `updateDerived` had zero production callers, `listResolutions` was
+  never imported, and the strip re-offered Resolve… forever. Now the
+  resolve flow derives the prediction's status, merges the record
+  into the index, and the strip matches resolutions by sha16 identity
+  (so the coordinate's pubkey can't hide a local filing). Also from
+  the review: URL joins now carry an explicit "URL match — text
+  unverified" marker everywhere they render; sub-0.6 aggregates are
+  EXCLUDED from dossier rollups and counted as pending review (a new
+  design-note rule: a number the display refuses must not move a
+  reputation); the dossier line now distinguishes audited articles
+  from auditor judgments (shrinkage n = judgments, documented); the
+  inspector gained module rows + dispute lineage (`modulesByHash` had
+  zero consumers); case views gained the dossier block the design
+  assigned them; re-filing a resolution upserts instead of silently
+  returning the first record; and the resolver identity skips the
+  reserved sync key (with NIP-07, `identities[0]` IS the sync key —
+  a coordinate minted under it would never match the 13.8 publish).
+
+---
+
 ## 2026-06-11 — 13.6: the audit panel, and where the promotion link lives
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1026,6 +1026,19 @@ Implementation slices 13.1+ are in progress.
   change, CHANGELOG callout), prior-version re-audit notice,
   staleness chips (`CURRENT_MODULE_VERSIONS` reference), other runs
   side-by-side (never averaged). — #67
+- 🔄 **13.7** Portal surfaces (draft PR for smoke-testing) — the
+  corpus fetches the audit family (30056–30061; kind-list pin updated
+  deliberately); Library gains `Audits`/`Predictions` facets and an
+  audit chip on article cards (hash-first join, URL fallback only for
+  pre-13.4 hashless events); inspector drawer shows the full audit
+  record per article (every run side-by-side, never averaged; local
+  unpublished runs marked); entity view gains the **Audit dossier**
+  block (derived, computed-on-open via `computeDossier`, shrinkage
+  shown with k/factor/population, rate table + informational
+  calibration-v1, unmapped-beat review list); timeline gains the
+  **predictions-due strip** (90-day window, merged published+local,
+  deduped) with the minimal **Resolve…** form (evidence-bound;
+  resolutions file locally, publish in 13.8). — #68
 
 ---
 

--- a/src/portal/audit-data.js
+++ b/src/portal/audit-data.js
@@ -1,0 +1,341 @@
+// Portal audit data assembly (Phase 13.7). PURE — every function maps
+// library items (+ local ledger records) to display inputs, so the
+// joins are testable in node and reproducible by construction.
+//
+// Join discipline: audit events anchor to the canonical article hash
+// (the `x` tag). Articles published since 13.4 carry it; older ones
+// join by URL as a fallback — and URL joins are ADVISORY (the design's
+// audit-rot posture): callers receive `joinedBy` and must mark them.
+// Scores NEVER transfer across hashes: an article WITH a hash never
+// falls back to URL, even when the hash finds nothing.
+//
+// Library items spread their extras FLAT (buildItem's `...extra`);
+// test fixtures sometimes nest them. `extraOf` accepts both — the
+// production shape is the flat one.
+
+import { normalizeEventBeats, computeDossier, DEFAULT_SHRINKAGE_K } from '../shared/audit/dossier.js';
+
+// The §4 population mean, a PUBLISHED assumption (the design's worked
+// examples use it; competent journalism's expected mean is 70–85).
+// Displayed wherever it shrinks a rollup — never silently applied.
+export const DEFAULT_POPULATION_MEAN = 77;
+
+function extraOf(item) {
+    return (item && item.extra) || item || {};
+}
+
+function latestFirst(a, b) {
+    return String(b.runAt || '').localeCompare(String(a.runAt || ''));
+}
+
+function predKeyFromCoord(coord) {
+    const i = String(coord || '').lastIndexOf('pred:');
+    return i === -1 ? null : String(coord).slice(i + 'pred:'.length);
+}
+
+/**
+ * Build the audit index from library items: aggregates/modules/
+ * predictions/resolutions/disputes, keyed for the joins every surface
+ * needs.
+ */
+export function buildAuditIndex(items) {
+    const index = {
+        aggregatesByHash: new Map(),    // articleHash → [{...parsedAudit, coordinate, source:'relay'}]
+        aggregatesByUrl: new Map(),     // url → same (ADVISORY fallback join)
+        modulesByHash: new Map(),       // articleHash → [parsedModule]
+        predictions: [],                // [{...parsedPrediction, coordinate, source:'relay'}]
+        resolutionsByCoord: new Map(),  // predictionCoord → [resolution-ish {outcome, resolvedAt, source}]
+        disputesByTarget: new Map()     // targetCoord → [parsedDispute]
+    };
+    for (const item of items || []) {
+        const x = extraOf(item);
+        if (item.typeKey === 'audit' && x.parsedAudit) {
+            const a = {
+                ...x.parsedAudit,
+                coordinate: item.event ? `30057:${item.event.pubkey}:${x.parsedAudit.id}` : null,
+                source: 'relay'
+            };
+            const list = index.aggregatesByHash.get(a.articleHash) || [];
+            list.push(a);
+            index.aggregatesByHash.set(a.articleHash, list);
+            if (a.url) {
+                const byUrl = index.aggregatesByUrl.get(a.url) || [];
+                byUrl.push(a);
+                index.aggregatesByUrl.set(a.url, byUrl);
+            }
+        } else if (item.typeKey === 'audit' && x.parsedModule) {
+            const m = x.parsedModule;
+            const list = index.modulesByHash.get(m.articleHash) || [];
+            list.push(m);
+            index.modulesByHash.set(m.articleHash, list);
+        } else if (item.typeKey === 'audit' && x.parsedDispute) {
+            const d = x.parsedDispute;
+            const list = index.disputesByTarget.get(d.targetCoord) || [];
+            list.push(d);
+            index.disputesByTarget.set(d.targetCoord, list);
+        } else if (item.typeKey === 'prediction' && x.parsedPrediction) {
+            const p = x.parsedPrediction;
+            index.predictions.push({
+                ...p,
+                coordinate: item.event ? `30058:${item.event.pubkey}:${p.id}` : null,
+                source: 'relay'
+            });
+        } else if (item.typeKey === 'prediction' && x.parsedResolution) {
+            const r = x.parsedResolution;
+            const list = index.resolutionsByCoord.get(r.predictionCoord) || [];
+            list.push({ outcome: r.outcome, resolvedAt: r.resolvedAt, source: 'relay' });
+            index.resolutionsByCoord.set(r.predictionCoord, list);
+        }
+    }
+    for (const list of index.aggregatesByHash.values()) list.sort(latestFirst);
+    for (const list of index.aggregatesByUrl.values()) list.sort(latestFirst);
+    return index;
+}
+
+/**
+ * Merge LOCAL audit runs (the xray-audits ledger — imported but maybe
+ * unpublished) into the index. Local runs carry their aggregate in
+ * the 13.1 record shape; normalize to the parsed-event field names.
+ */
+export function mergeLocalRuns(index, localRuns) {
+    for (const run of localRuns || []) {
+        const agg = run.aggregate || {};
+        const normalized = {
+            articleHash: run.articleHash,
+            runAt: run.runAt,
+            finalScore: typeof agg.final_score === 'number' ? agg.final_score : null,
+            rawScore: typeof agg.raw_weighted_score === 'number' ? agg.raw_weighted_score : null,
+            ceiling: typeof agg.knowability_ceiling === 'number' ? agg.knowability_ceiling : null,
+            ceilingBinding: agg.ceiling_binding === true,
+            ceilingSource: agg.ceiling_source || null,
+            confidence: typeof agg.overall_confidence === 'number' ? agg.overall_confidence : null,
+            knowabilityNotes: agg.knowability_notes || '',
+            auditor: run.auditor || null,
+            moduleContributions: agg.module_contributions || [],
+            coordinate: null,            // unpublished — minted at publish (13.8)
+            source: 'local',
+            localRunId: run.id
+        };
+        const list = index.aggregatesByHash.get(run.articleHash) || [];
+        // A published copy of the same run (same auditor + runAt) wins
+        // over the local record — don't double-list.
+        if (!list.some((a) => a.runAt === normalized.runAt
+                && a.auditor && normalized.auditor && a.auditor.id === normalized.auditor.id)) {
+            list.push(normalized);
+            list.sort(latestFirst);
+        }
+        index.aggregatesByHash.set(run.articleHash, list);
+    }
+    return index;
+}
+
+/**
+ * Merge LOCAL resolutions (filed via the Resolve… form, unpublished
+ * until 13.8) so the strip and the dossier see them immediately.
+ */
+export function mergeLocalResolutions(index, localResolutions) {
+    for (const r of localResolutions || []) {
+        if (!r || !r.prediction_coord || !r.outcome) continue;
+        const list = index.resolutionsByCoord.get(r.prediction_coord) || [];
+        list.push({ outcome: r.outcome, resolvedAt: r.resolved_at || null, source: 'local' });
+        index.resolutionsByCoord.set(r.prediction_coord, list);
+    }
+    return index;
+}
+
+/**
+ * The aggregates anchored to one article — hash join first; URL
+ * fallback ONLY when the article carries no hash at all (pre-13.4
+ * events), and marked as such. An article WITH a hash that finds no
+ * audits gets an EMPTY result, never another text's scores.
+ *
+ * @returns {{runs: Array, joinedBy: 'hash'|'url'|null}}
+ */
+export function auditsForArticle(index, articleItem) {
+    const hash = extraOf(articleItem).articleHash;
+    if (hash) {
+        return { runs: index.aggregatesByHash.get(hash) || [], joinedBy: 'hash' };
+    }
+    const url = articleItem && articleItem.url;
+    const runs = url ? (index.aggregatesByUrl.get(url) || []) : [];
+    return { runs, joinedBy: runs.length ? 'url' : null };
+}
+
+/**
+ * The latest aggregate for an article's card chip (or null), with the
+ * join provenance so URL matches can carry their advisory marker.
+ */
+export function latestAuditFor(index, articleItem) {
+    const { runs, joinedBy } = auditsForArticle(index, articleItem);
+    if (!runs.length) return null;
+    const a = runs[0];
+    return { final_score: a.finalScore, overall_confidence: a.confidence, joinedBy };
+}
+
+/**
+ * Dossier inputs for an entity (author/publication/case pubkey): the
+ * articles whose 30023 p-tags include the entity, the latest USABLE
+ * aggregate per (article, auditor), and the subject's resolved
+ * predictions.
+ *
+ * Usable means confidence ≥ 0.6: the display rules refuse to show a
+ * sub-0.6 score as a number, so the reputation rollup must not
+ * aggregate it either — excluded runs are counted, not hidden.
+ * Returns null when no usable aggregates exist (a dossier that is
+ * pure prior is noise dressed as reputation).
+ */
+export function dossierInputsForEntity(items, index, focusPubkey) {
+    const articles = (items || []).filter((i) => i.typeKey === 'article'
+        && (i.event.tags || []).some((t) => t[0] === 'p' && t[1] === focusPubkey));
+    if (!articles.length) return null;
+
+    const aggregates = [];
+    const hashes = new Set();
+    const auditedArticles = new Set();
+    const unmappedBeats = new Set();
+    let excludedForReview = 0;
+    for (const art of articles) {
+        const { runs } = auditsForArticle(index, art);
+        if (!runs.length) continue;
+        const artHash = extraOf(art).articleHash;
+        if (artHash) hashes.add(artHash);
+        // Latest USABLE judgment per auditor, per article — older runs
+        // by the same auditor are superseded judgments, not data.
+        const seen = new Set();
+        for (const a of runs) {
+            const key = a.auditor ? a.auditor.id : 'unknown';
+            if (seen.has(key)) continue;
+            seen.add(key);
+            if (typeof a.confidence !== 'number' || a.confidence < 0.6) {
+                excludedForReview += 1;
+                continue;
+            }
+            aggregates.push(a);
+            auditedArticles.add(a.articleHash || art.url || art.id);
+        }
+        const { unmapped } = normalizeEventBeats((art.event.tags || [])
+            .filter((t) => t[0] === 't').map((t) => t[1]));
+        unmapped.forEach((b) => unmappedBeats.add(b));
+    }
+    if (!aggregates.length) return null;
+
+    const resolvedPredictions = [];
+    let totalPredictions = 0;
+    for (const p of index.predictions) {
+        if (!hashes.has(p.articleHash)) continue;
+        totalPredictions += 1;
+        const resolutions = p.coordinate ? (index.resolutionsByCoord.get(p.coordinate) || []) : [];
+        if (!resolutions.length) continue;
+        const latest = resolutions.slice().sort((a, b) =>
+            String(b.resolvedAt || '').localeCompare(String(a.resolvedAt || '')))[0];
+        resolvedPredictions.push({ hedge_level: p.hedgeLevel, outcome: latest.outcome });
+    }
+
+    return {
+        auditedArticles: auditedArticles.size,
+        excludedForReview,
+        aggregates: aggregates.map((a) => ({
+            finalScore: a.finalScore,
+            moduleContributions: a.moduleContributions || []
+        })),
+        resolvedPredictions,
+        totalPredictions,
+        unmappedBeats: [...unmappedBeats]
+    };
+}
+
+/**
+ * The computed dossier (the canonical, reproducible form). Note the
+ * two counts: `auditedArticles` (distinct articles) for "over N
+ * articles" display, and `judgments` (latest-per-auditor aggregates —
+ * computeDossier's n, which also drives the shrinkage; documented:
+ * each auditor's current judgment is a sample).
+ */
+export function computeEntityDossier(inputs, { k = DEFAULT_SHRINKAGE_K, populationMean = DEFAULT_POPULATION_MEAN } = {}) {
+    if (!inputs) return null;
+    const dossier = computeDossier({
+        aggregates: inputs.aggregates,
+        resolvedPredictions: inputs.resolvedPredictions,
+        totalPredictions: inputs.totalPredictions,
+        k,
+        populationMean
+    });
+    return {
+        ...dossier,
+        judgments: dossier.articleCount,
+        auditedArticles: inputs.auditedArticles,
+        excludedForReview: inputs.excludedForReview,
+        unmappedBeats: inputs.unmappedBeats
+    };
+}
+
+/**
+ * Predictions coming due: open predictions (remote + local merged,
+ * deduped by their sha16 identity) with horizon-iso inside the
+ * window — INCLUDING already-overdue ones — soonest first; plus the
+ * open-but-unscheduled count. Resolution-awareness matches on the
+ * sha16 identity, so a locally-filed resolution clears its
+ * prediction regardless of which pubkey's coordinate it used.
+ */
+export function predictionsDue(index, localPredictions, { nowMs, windowDays = 90 } = {}) {
+    const now = Number.isFinite(nowMs) ? nowMs : 0;
+    const horizonLimit = now + windowDays * 86400 * 1000;
+
+    const resolvedKeys = new Set();
+    for (const coord of index.resolutionsByCoord.keys()) {
+        const key = predKeyFromCoord(coord);
+        if (key) resolvedKeys.add(key);
+    }
+
+    const byKey = new Map();
+    for (const p of index.predictions) {
+        const key = String(p.id || '').replace(/^pred:/, '');
+        byKey.set(key, {
+            key,
+            text: p.text,
+            hedge: p.hedgeLevel,
+            horizonIso: p.horizonIso,
+            coordinate: p.coordinate,
+            resolved: resolvedKeys.has(key),
+            source: 'relay'
+        });
+    }
+    for (const p of localPredictions || []) {
+        const key = String(p.id || '').replace(/^pred_/, '');
+        if (byKey.has(key)) continue;   // published copy already listed
+        byKey.set(key, {
+            key,
+            text: p.text,
+            hedge: p.hedge_level,
+            horizonIso: p.horizon_iso,
+            coordinate: null,            // unpublished — coordinate at publish (13.8)
+            resolved: p.resolution_status !== 'open' || resolvedKeys.has(key),
+            localId: p.id,
+            source: 'local'
+        });
+    }
+
+    const open = [...byKey.values()].filter((p) => !p.resolved);
+    const due = open.filter((p) => {
+        if (!p.horizonIso) return false;
+        const t = Date.parse(p.horizonIso);
+        return Number.isFinite(t) && t <= horizonLimit;
+    }).sort((a, b) => String(a.horizonIso).localeCompare(String(b.horizonIso)));
+    const unscheduled = open.filter((p) => !p.horizonIso).length;
+
+    return { due, unscheduled, openCount: open.length };
+}
+
+/**
+ * Pick the identity that will sign predictions/resolutions in the v1
+ * flow: the signer when known; otherwise any identity that is not
+ * solely the reserved sync key (which signs entity-sync blobs, never
+ * audit events). Null when nothing qualifies — the Resolve affordance
+ * disables rather than minting a coordinate under the wrong key.
+ */
+export function resolverIdentity(identities) {
+    const list = identities || [];
+    const signer = list.find((i) => (i.sources || []).includes('signer'));
+    if (signer) return signer;
+    return list.find((i) => (i.sources || []).some((s) => s !== 'sync-key')) || null;
+}

--- a/src/portal/case-view.js
+++ b/src/portal/case-view.js
@@ -10,6 +10,7 @@
 import { el, svgEl, clear, truncate } from './dom.js';
 import { kindLabel, TYPE_DEFS } from './library.js';
 import { buildBuckets } from './timeline.js';
+import { renderDossierBlock } from './dossier-block.js';
 
 function latestAssessmentByCoord(items) {
     const map = new Map();
@@ -41,7 +42,7 @@ function contradictedCoords(items) {
  *                                      onOpenGraph(pubkey), onOpenItem(item)}
  */
 export function renderCaseView(host, params) {
-    const { items, entityIndex, casePubkey, callbacks } = params;
+    const { items, entityIndex, casePubkey, callbacks, dossier, populationMean } = params;
     clear(host);
 
     const caseEnt = entityIndex[casePubkey];
@@ -84,6 +85,10 @@ export function renderCaseView(host, params) {
         rollup.appendChild(el('span', 'xr-badge', `${def.label}: ${n}`));
     }
     host.appendChild(rollup);
+
+    // --- Audit dossier (13.7) — the design assigns the block to
+    // entity AND case views; a case is a pubkey-keyed entity.
+    renderDossierBlock(host, dossier, populationMean);
 
     // --- publish-density strip ---
     const { buckets } = buildBuckets(everything);

--- a/src/portal/corpus.js
+++ b/src/portal/corpus.js
@@ -37,7 +37,8 @@ export const CONTENT_KINDS = [
     32126, // platform accounts
     10002, // NIP-65 relay list (signed by the xray:user sync key)
     30078, // entity-sync blobs (ciphertext; listed, never decrypted)
-    30050, 30051, 30052, 30053, 9803 // dormant metadata kinds (flag-gated writers)
+    30050, 30051, 30052, 30053, 9803, // dormant metadata kinds (flag-gated writers)
+    30056, 30057, 30058, 30059, 30060, 30061 // Phase 13 audit kinds (publish lands in 13.8; read always)
 ];
 
 // Mirrors the background service worker's hardcoded fallback

--- a/src/portal/dossier-block.js
+++ b/src/portal/dossier-block.js
@@ -1,0 +1,59 @@
+// The Audit-dossier block (Phase 13.7) — shared by the entity and
+// case views (the design assigns it to both). Derived,
+// computed-on-open, and the shrinkage is SHOWN with its parameters
+// (§4): a raw three-article mean is not a stable reputation and must
+// not read like one.
+
+import { el } from './dom.js';
+
+export function renderDossierBlock(host, dossier, populationMean) {
+    if (!dossier) return;
+    const block = el('div', 'xr-view__dossier');
+    block.appendChild(el('h3', 'xr-case__heading', 'Audit dossier (derived — recompute, don\'t trust)'));
+
+    if (dossier.scoreMeanRaw === null) {
+        block.appendChild(el('div', 'xr-view__dossier-line',
+            'No scored aggregates yet.'));
+    } else {
+        block.appendChild(el('div', 'xr-view__dossier-line',
+            `raw mean ${dossier.scoreMeanRaw} over ${dossier.auditedArticles} audited article(s) `
+            + `(${dossier.judgments} auditor judgment(s)), `
+            + `shrunk to ${dossier.scoreMean} toward population ${populationMean} `
+            + `(k=${dossier.shrinkageK}, factor ${dossier.shrinkageFactor}) · `
+            + `median ${dossier.scoreMedian} · stdev ${dossier.scoreStdev}`));
+    }
+    if (dossier.excludedForReview > 0) {
+        block.appendChild(el('div', 'xr-view__dossier-line xr-view__dossier-line--dim',
+            `${dossier.excludedForReview} run(s) excluded pending review (confidence < 0.6 — `
+            + 'a number the display rules refuse to show must not move a reputation either)'));
+    }
+
+    const moduleEntries = Object.entries(dossier.perModuleMeans || {});
+    if (moduleEntries.length) {
+        const chips = el('div', 'xr-view__dossier-modules');
+        for (const [mod, mean] of moduleEntries) {
+            chips.appendChild(el('span', 'xr-badge', `${mod.replace(/_/g, ' ')}: ${mean}`));
+        }
+        block.appendChild(chips);
+    }
+
+    const preds = dossier.predictions || {};
+    if (preds.total > 0) {
+        const cal = preds.calibration || {};
+        const rate = (row) => (row && row.resolved > 0
+            ? `${row.true_count}/${row.resolved} true` : '—');
+        block.appendChild(el('div', 'xr-view__dossier-line',
+            `predictions: ${preds.resolved}/${preds.total} resolved · `
+            + `confident ${rate(cal.confident)} · hedged ${rate(cal.hedged)} · speculative ${rate(cal.speculative)}`));
+        const calV1 = preds.calibration_v1 || {};
+        if (calV1.resolved_count > 0) {
+            block.appendChild(el('div', 'xr-view__dossier-line xr-view__dossier-line--dim',
+                `calibration-v1 (informational, not applied): mean Brier ${calV1.mean_brier} over ${calV1.resolved_count} · multiplier ${calV1.multiplier === null ? 'inactive' : calV1.multiplier}`));
+        }
+    }
+    if (dossier.unmappedBeats && dossier.unmappedBeats.length) {
+        block.appendChild(el('div', 'xr-view__dossier-line xr-view__dossier-line--dim',
+            `unmapped beat tags (review — these never mint dossiers): ${dossier.unmappedBeats.join(', ')}`));
+    }
+    host.appendChild(block);
+}

--- a/src/portal/entity-view.js
+++ b/src/portal/entity-view.js
@@ -13,6 +13,7 @@
 import { el, svgEl, clear, truncate, shortKey } from './dom.js';
 import { buildEgoGraph, layoutEgoGraph } from './graph.js';
 import { kindLabel } from './library.js';
+import { renderDossierBlock } from './dossier-block.js';
 
 const SIZE = 720;
 
@@ -39,7 +40,7 @@ const NODE_RADIUS = {
  *                                        onBack(), onExpand(type)}
  */
 export function renderEntityView(host, params) {
-    const { items, entityIndex, focusPubkey, expandedTypes, callbacks } = params;
+    const { items, entityIndex, focusPubkey, expandedTypes, callbacks, dossier, populationMean } = params;
     clear(host);
 
     const graph = buildEgoGraph(items, { focusPubkey, entityIndex, expandedTypes });
@@ -65,6 +66,9 @@ export function renderEntityView(host, params) {
     locate.placeholder = 'Locate in graph…';
     head.appendChild(locate);
     host.appendChild(head);
+
+    // --- Audit dossier (13.7) — shared block, also on case views.
+    renderDossierBlock(host, dossier, populationMean);
 
     if (graph.nodes.length === 0) {
         host.appendChild(el('p', 'xr-view__empty',

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -645,3 +645,119 @@ button.xr-badge--case { cursor: pointer; background: transparent; }
   color: var(--xr-text-dim);
   font-size: 12px;
 }
+
+/* ---------------- Phase 13.7: audit surfaces ----------------------------- */
+
+/* Audit chips on Library rows — bands follow the framework rubric;
+   "acceptable" (60–74) is deliberately NOT green. */
+.xr-badge--audit-exemplary   { color: var(--xr-success); border-color: var(--xr-success); }
+.xr-badge--audit-solid       { color: color-mix(in srgb, var(--xr-success) 65%, var(--xr-accent)); border-color: currentColor; }
+.xr-badge--audit-acceptable  { color: var(--xr-accent); border-color: var(--xr-accent); }
+.xr-badge--audit-significant { color: var(--xr-warning); border-color: var(--xr-warning); }
+.xr-badge--audit-severe      { color: color-mix(in srgb, var(--xr-danger) 70%, var(--xr-warning)); border-color: currentColor; }
+.xr-badge--audit-catastrophic{ color: var(--xr-danger); border-color: var(--xr-danger); }
+.xr-badge--audit-review      { color: var(--xr-text-dim); border-color: var(--xr-text-dim); }
+
+/* Predictions-due strip above the timeline. */
+.xr-predue {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  padding: 6px 0;
+  border-bottom: 1px dashed var(--xr-border);
+  margin-bottom: 6px;
+}
+.xr-predue__label { font-weight: 600; color: var(--xr-text-dim); white-space: nowrap; }
+.xr-predue__item { display: inline-flex; align-items: center; gap: 6px; }
+.xr-predue__date { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--xr-warning); }
+.xr-predue__text { color: var(--xr-text); }
+.xr-predue__more { color: var(--xr-text-dim); }
+
+/* Inspector audit record. */
+.xr-inspector__audit { margin: 12px 0; }
+.xr-inspector__audit-run {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--xr-border);
+  font-size: 12px;
+}
+.xr-inspector__audit-ceiling { color: var(--xr-warning); }
+.xr-inspector__audit-lineage { color: var(--xr-text-dim); }
+
+/* Entity-view dossier block. */
+.xr-view__dossier {
+  margin: 10px 0;
+  padding: 10px 14px;
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  background: var(--xr-surface);
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.xr-view__dossier-line { color: var(--xr-text); }
+.xr-view__dossier-line--dim { color: var(--xr-text-dim); }
+.xr-view__dossier-modules { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* Resolve… modal. */
+.xr-resolve {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 80;
+}
+.xr-resolve__card {
+  width: min(560px, 92vw);
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--xr-surface);
+  border: 1px solid var(--xr-border);
+  border-radius: 8px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 13px;
+}
+.xr-resolve__title { margin: 0; font-size: 15px; }
+.xr-resolve__pred {
+  margin: 0;
+  padding: 8px 12px;
+  border-left: 3px solid var(--xr-accent);
+  background: var(--xr-surface-2);
+  font-style: italic;
+}
+.xr-resolve__row { display: flex; align-items: center; gap: 8px; }
+.xr-resolve__input {
+  background: var(--xr-surface-2);
+  border: 1px solid var(--xr-border);
+  border-radius: 4px;
+  color: var(--xr-text);
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.xr-resolve__evrow { display: flex; gap: 6px; margin-bottom: 6px; }
+.xr-resolve__input--value { flex: 2; }
+.xr-resolve__input--desc { flex: 1; }
+.xr-resolve__notes {
+  min-height: 70px;
+  background: var(--xr-surface-2);
+  border: 1px solid var(--xr-border);
+  border-radius: 4px;
+  color: var(--xr-text);
+  padding: 6px 8px;
+  font-size: 12px;
+  resize: vertical;
+}
+.xr-resolve__error { color: var(--xr-danger); font-size: 12px; min-height: 14px; }
+.xr-resolve__actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+.xr-inspector__audit-modules { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px; }

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -27,6 +27,15 @@ import { renderEntityView } from './entity-view.js';
 import { renderCaseView } from './case-view.js';
 import { loadLocalLedger, reconcile, countLocalOnly } from './reconcile.js';
 import { renderInspector } from './inspector.js';
+import {
+    buildAuditIndex, mergeLocalRuns, mergeLocalResolutions, auditsForArticle,
+    latestAuditFor, dossierInputsForEntity, computeEntityDossier,
+    predictionsDue, resolverIdentity, DEFAULT_POPULATION_MEAN
+} from './audit-data.js';
+import { auditCardChipData } from '../shared/audit/display.js';
+import { listRuns, listPredictions, listResolutions } from '../shared/audit/audit-cache.js';
+import { PredictionModel } from '../shared/audit/audit-model.js';
+import { openResolveForm } from './resolve-form.js';
 
 const $ = (sel) => document.querySelector(sel);
 
@@ -182,7 +191,23 @@ function openInspector(item) {
     const status = state.reconciliation
         ? state.reconciliation.statusByEventId[item.id] || 'no-ledger'
         : 'no-ledger';
-    renderInspector($('#xr-inspector'), item, { status });
+    // 13.7: articles get their audit record in the drawer — every
+    // run, side-by-side, never averaged, with module results and
+    // dispute lineage joined in.
+    let audit = null;
+    if (item.typeKey === 'article' && state.auditIndex) {
+        const { runs, joinedBy } = auditsForArticle(state.auditIndex, item);
+        if (runs.length) {
+            const hash = item.articleHash || (item.extra && item.extra.articleHash) || null;
+            audit = {
+                runs,
+                joinedBy,
+                modules: hash ? (state.auditIndex.modulesByHash.get(hash) || []) : [],
+                disputesByTarget: state.auditIndex.disputesByTarget
+            };
+        }
+    }
+    renderInspector($('#xr-inspector'), item, { status, audit });
 }
 
 function buildRow(item) {
@@ -209,6 +234,22 @@ function buildRow(item) {
     const relayBadge = el('span', 'xr-badge', `${item.relays.length} relay${item.relays.length === 1 ? '' : 's'}`);
     relayBadge.title = item.relays.join('\n');
     badges.appendChild(relayBadge);
+    // Audit chip (13.7) — the latest aggregate anchored to this
+    // article. Display rules hold at chip size: review states show no
+    // number, bands follow the rubric. URL joins (pre-13.4 hashless
+    // articles only) are ADVISORY and say so.
+    if (item.typeKey === 'article' && state.auditIndex) {
+        const latest = latestAuditFor(state.auditIndex, item);
+        const chip = auditCardChipData(latest);
+        if (chip) {
+            const advisory = latest.joinedBy === 'url';
+            const b = el('span', `xr-badge xr-badge--audit-${chip.bandKey}`,
+                chip.text + (advisory ? ' (URL match)' : ''));
+            b.title = chip.title + (advisory
+                ? ' — joined by URL, text unverified: this capture predates content hashing' : '');
+            badges.appendChild(b);
+        }
+    }
     if (isOtherClient(item)) {
         badges.appendChild(el('span', 'xr-badge xr-badge--warn', `via ${truncate(item.client, 24)}`));
     }
@@ -313,6 +354,77 @@ function fmtDay(ts) {
     return new Date(ts * 1000).toLocaleDateString();
 }
 
+// The predictions-due strip (13.7). Merges published 30058s with the
+// local ledger (deduped by their shared sha16 identity); each open,
+// scheduled entry offers Resolve… — resolutions file locally
+// (ResolutionModel); the 30059 publishes in 13.8 behind the flag.
+function renderPredictionsStrip(host) {
+    if (!state.auditIndex) return;
+    const { due, unscheduled } = predictionsDue(state.auditIndex, state.localPredictions, {
+        nowMs: Date.now(), windowDays: 90
+    });
+    if (due.length === 0 && unscheduled === 0) return;
+
+    const strip = el('div', 'xr-predue');
+    const label = el('span', 'xr-predue__label',
+        `Predictions due (90d): ${due.length}` + (unscheduled ? ` · ${unscheduled} unscheduled` : ''));
+    strip.appendChild(label);
+
+    // The resolver identity: the signer when known, never the
+    // reserved sync key — a coordinate minted under the wrong key
+    // would never match the 13.8 publish.
+    const resolver = resolverIdentity(state.identities);
+    for (const p of due.slice(0, 6)) {
+        const row = el('span', 'xr-predue__item');
+        row.appendChild(el('span', 'xr-predue__date', p.horizonIso));
+        const text = el('span', 'xr-predue__text', truncate(p.text, 70));
+        text.title = p.text;
+        row.appendChild(text);
+        // Coordinate: published entries carry it; local unpublished
+        // ones resolve under the resolver identity (the v1 flow signs
+        // predictions and resolutions with one key).
+        const coordinate = p.coordinate
+            || (resolver && p.localId ? `30058:${resolver.pubkey}:pred:${p.key}` : null);
+        if (coordinate) {
+            const btn = el('button', 'xr-badge xr-badge--action', 'Resolve…');
+            btn.type = 'button';
+            btn.title = 'File an evidence-bound resolution for this prediction';
+            btn.addEventListener('click', async () => {
+                const record = await openResolveForm({
+                    text: p.text,
+                    coordinate,
+                    resolverAuditor: resolver ? { kind: 'human', id: resolver.pubkey } : null
+                });
+                if (record) {
+                    // Make the resolution visible NOW, not at next
+                    // boot: derive the local prediction's status,
+                    // merge the record into the index, refresh the
+                    // local snapshots.
+                    try {
+                        if (p.localId) await PredictionModel.updateDerived(p.localId, [record]);
+                        mergeLocalResolutions(state.auditIndex, [record]);
+                        state.localPredictions = await listPredictions();
+                    } catch (err) {
+                        Utils.error('Portal: resolution refresh failed', err);
+                    }
+                    setStatus(`Resolution filed (${record.outcome}) — publishes with the 13.8 batch.`);
+                    renderLibrary();
+                }
+            });
+            row.appendChild(btn);
+        } else {
+            const why = el('span', 'xr-badge', 'no signing identity');
+            why.title = 'Resolving needs a signing identity (not the sync key) — connect a signer or add one above.';
+            row.appendChild(why);
+        }
+        strip.appendChild(row);
+    }
+    if (due.length > 6) {
+        strip.appendChild(el('span', 'xr-predue__more', `+${due.length - 6} more`));
+    }
+    host.appendChild(strip);
+}
+
 function renderTimeline() {
     const host = $('#xr-timeline');
     clear(host);
@@ -345,6 +457,11 @@ function renderTimeline() {
         head.appendChild(chip);
     }
     host.appendChild(head);
+
+    // Predictions coming due (13.7) — the long-game asset made
+    // visible: open ledger entries with a horizon inside 90 days,
+    // each with the Resolve… affordance.
+    renderPredictionsStrip(host);
 
     const svg = svgEl('svg', {
         viewBox: `0 0 ${buckets.length * TL_BAR_W} ${TL_HEIGHT}`,
@@ -511,6 +628,13 @@ function render() {
             entityIndex: state.entityIndex,
             focusPubkey: state.view.pubkey,
             expandedTypes: state.expandedTypes,
+            // 13.7: the audit dossier — derived, computed-on-open,
+            // reproducible from the same events by anyone (the 30060
+            // snapshot is just a cache of this).
+            dossier: state.auditIndex
+                ? computeEntityDossier(dossierInputsForEntity(state.items, state.auditIndex, state.view.pubkey))
+                : null,
+            populationMean: DEFAULT_POPULATION_MEAN,
             callbacks: viewCallbacks
         });
     } else if (state.view.name === 'case') {
@@ -519,6 +643,10 @@ function render() {
             items: state.items,
             entityIndex: state.entityIndex,
             casePubkey: state.view.pubkey,
+            dossier: state.auditIndex
+                ? computeEntityDossier(dossierInputsForEntity(state.items, state.auditIndex, state.view.pubkey))
+                : null,
+            populationMean: DEFAULT_POPULATION_MEAN,
             callbacks: viewCallbacks
         });
     } else {
@@ -544,6 +672,22 @@ function rebuildItems(records) {
     // The cache stores only the latest version per replaceable address,
     // so records arrive pre-deduped.
     state.items = buildItems(records, { entityIndex: state.entityIndex });
+
+    // 13.7: the audit index — published audit events joined to
+    // articles by canonical hash (URL fallback for pre-13.4 events),
+    // then merged with the LOCAL xray-audits ledger (imported but
+    // possibly unpublished runs). Async enrichment: render proceeds,
+    // surfaces refresh when it lands.
+    state.auditIndex = buildAuditIndex(state.items);
+    state.localPredictions = [];
+    Promise.all([listRuns(), listPredictions(), listResolutions()])
+        .then(([runs, preds, resolutions]) => {
+            mergeLocalRuns(state.auditIndex, runs);
+            mergeLocalResolutions(state.auditIndex, resolutions);
+            state.localPredictions = preds;
+            render();
+        })
+        .catch((err) => Utils.error('Portal: audit ledger load failed', err));
 }
 
 function setBusy(busy) {

--- a/src/portal/inspector.js
+++ b/src/portal/inspector.js
@@ -13,6 +13,72 @@ import { kindLabel } from './library.js';
 import { replaceableKey } from '../shared/nostr-events.js';
 import { EventBuilder } from '../shared/event-builder.js';
 import { Utils } from '../shared/utils.js';
+import { auditCardChipData } from '../shared/audit/display.js';
+
+// Audit section (13.7): every run anchored to this article —
+// side-by-side, never averaged (PHILOSOPHY P8) — with module results
+// and dispute lineage joined in. Display rules hold: no naked
+// numbers, review states carry no band, a binding ceiling always
+// shows its context; URL joins (pre-13.4 hashless articles) are
+// marked advisory.
+function renderAuditSection(host, audit) {
+    const { runs, joinedBy, modules = [], disputesByTarget } = audit;
+    const section = el('div', 'xr-inspector__audit');
+    section.appendChild(el('h3', 'xr-case__heading',
+        `Audit record — ${runs.length} run(s)${runs.length > 1 ? ' (side-by-side, never averaged)' : ''}`));
+    if (joinedBy === 'url') {
+        section.appendChild(el('div', 'xr-inspector__audit-lineage',
+            '⚠ joined by URL — this capture predates content hashing, so the audited text is unverified'));
+    }
+    for (const a of runs) {
+        const row = el('div', 'xr-inspector__audit-run');
+        const chip = auditCardChipData({ final_score: a.finalScore, overall_confidence: a.confidence });
+        row.appendChild(el('span',
+            `xr-badge xr-badge--audit-${chip ? chip.bandKey : 'review'}`,
+            chip ? chip.text : 'no aggregate score'));
+        row.appendChild(el('span', 'xr-inspector__mono',
+            `${a.auditor ? `${a.auditor.kind} · ${a.auditor.id}` : 'unknown auditor'} · ${a.runAt || ''}${a.source === 'local' ? ' · local (unpublished)' : ''}`));
+        if (a.ceilingBinding) {
+            row.appendChild(el('div', 'xr-inspector__audit-ceiling',
+                `capped by knowability ${a.ceiling}${a.knowabilityNotes ? ` — ${a.knowabilityNotes}` : ''} (source: ${a.ceilingSource || 'unknown'})`));
+        }
+        // Module results: published 30056s matching this run, with
+        // methodology versions (provenance rule 4); local runs fall
+        // back to the aggregate's own contributions.
+        const runModules = modules.filter((m) => m.runAt === a.runAt);
+        const moduleRows = runModules.length
+            ? runModules.map((m) => ({ name: m.module, version: m.moduleVersion, score: m.score, confidence: m.confidence }))
+            : (a.moduleContributions || []).map((c) => ({ name: c.module, version: null, score: c.score, confidence: c.confidence }));
+        if (moduleRows.length) {
+            const wrap = el('div', 'xr-inspector__audit-modules');
+            for (const m of moduleRows) {
+                const mChip = auditCardChipData({ final_score: m.score, overall_confidence: m.confidence });
+                wrap.appendChild(el('span', 'xr-badge',
+                    `${String(m.name || '').replace(/_/g, ' ')}${m.version ? ` v${m.version}` : ''}: `
+                    + (mChip ? mChip.text.replace(/^audit /, '').replace('audit: review', 'review') : (m.score === null ? 'unscored' : 'review'))));
+            }
+            row.appendChild(wrap);
+        }
+        if (a.supersedesEventId) {
+            row.appendChild(el('div', 'xr-inspector__audit-lineage',
+                `supersedes ${a.supersedesEventId.slice(0, 12)}… — the prior audit remains visible`));
+        }
+        if (a.resolvesDisputeEventId) {
+            row.appendChild(el('div', 'xr-inspector__audit-lineage',
+                `resolves dispute ${a.resolvesDisputeEventId.slice(0, 12)}…`));
+        }
+        // Disputes targeting this aggregate (30061s, wire-format-only
+        // in v1 — but a filed challenge must be visible where the
+        // score is).
+        const disputes = (a.coordinate && disputesByTarget) ? (disputesByTarget.get(a.coordinate) || []) : [];
+        for (const d of disputes) {
+            row.appendChild(el('div', 'xr-inspector__audit-lineage',
+                `⚠ dispute (${d.status}) filed by ${shortKey(d.pubkey || '')} — ${truncate(d.disputeSummary || '', 80)}`));
+        }
+        section.appendChild(row);
+    }
+    host.appendChild(section);
+}
 
 const STATUS_TEXT = {
     'confirmed':   ['✓ in ledger & on relays', 'xr-badge--agree'],
@@ -27,7 +93,7 @@ const STATUS_TEXT = {
  * @param {string} opts.status  reconciliation status for this event id
  * @param {function} opts.onClose
  */
-export function renderInspector(host, item, { status = 'no-ledger', onClose } = {}) {
+export function renderInspector(host, item, { status = 'no-ledger', onClose, audit = null } = {}) {
     clear(host);
     host.hidden = false;
 
@@ -111,6 +177,11 @@ export function renderInspector(host, item, { status = 'no-ledger', onClose } = 
         actions.appendChild(open);
     }
     host.appendChild(actions);
+
+    // 13.7: the audit record for articles, when any run anchors here.
+    if (audit && audit.runs && audit.runs.length > 0) {
+        renderAuditSection(host, audit);
+    }
 
     const details = el('details', 'xr-inspector__raw');
     details.open = true;

--- a/src/portal/library.js
+++ b/src/portal/library.js
@@ -17,6 +17,11 @@ import { parseClaimEvent } from '../shared/claim-model.js';
 import { parseAssessmentEvent } from '../shared/assessment-model.js';
 import { parseRelationshipEvent } from '../shared/evidence-linker.js';
 import { EventBuilder } from '../shared/event-builder.js';
+import {
+    parseModuleResultEvent, parseAggregateAuditEvent,
+    parsePredictionEntryEvent, parsePredictionResolutionEvent,
+    parseDossierSnapshotEvent, parseAuditDisputeEvent
+} from '../shared/audit/builders.js';
 
 // Tags written by this extension (current + userscript-era value).
 export const OUR_CLIENT_TAGS = new Set(['xray', 'nostr-article-capture']);
@@ -30,6 +35,8 @@ export const TYPE_DEFS = [
     { key: 'claim',      label: 'Claims' },
     { key: 'comment',    label: 'Comments' },
     { key: 'assessment', label: 'Assessments' },
+    { key: 'audit',      label: 'Audits' },
+    { key: 'prediction', label: 'Predictions' },
     { key: 'link',       label: 'Links' },
     { key: 'entity',     label: 'Entities' },
     { key: 'case',       label: 'Cases' },
@@ -53,7 +60,13 @@ const KIND_LABELS = {
     30051: 'Fact-check',
     30052: 'Rating',
     30053: 'Topic trust',
-    9803:  'Vote'
+    9803:  'Vote',
+    30056: 'Module result',
+    30057: 'Aggregate audit',
+    30058: 'Prediction',
+    30059: 'Resolution',
+    30060: 'Dossier',
+    30061: 'Dispute'
 };
 
 export function kindLabel(kind) {
@@ -99,6 +112,9 @@ function buildItem(record, entityIndex) {
             typeKey = 'article';
             title = firstTag(event, 'title') || '(untitled capture)';
             sub = domainOf(url) || url;
+            // 13.7: the canonical article hash (13.4's x tag) — the
+            // join key audit events anchor on. Null on pre-13.4 events.
+            extra.articleHash = firstTag(event, 'x') || null;
             haystack.push(title, sub, url, ...tagValues(event, 't'), firstTag(event, 'author'));
             break;
         }
@@ -205,6 +221,87 @@ function buildItem(record, entityIndex) {
             title = `${firstTag(event, 'entity-name') || '(entity)'} — ${firstTag(event, 'relationship') || 'related'}`;
             sub = url;
             haystack.push(firstTag(event, 'entity-name'), firstTag(event, 'relationship'));
+            break;
+        }
+        // ---- Phase 13 audit kinds (13.7) --------------------------
+        // Display rules hold even in list titles: a score never
+        // renders without its confidence, and sub-0.6 renders as
+        // "needs human review" — never a number.
+        case 30056: {
+            const m = parseModuleResultEvent(event);
+            if (m) {
+                typeKey = 'audit';
+                title = `Module result — ${m.module.replace(/_/g, ' ')}`;
+                sub = url || `article ${m.articleHash.slice(0, 16)}…`;
+                extra.articleHash = m.articleHash;
+                extra.auditRole = 'module';
+                extra.parsedModule = m;
+                haystack.push(m.module, m.articleHash);
+            }
+            break;
+        }
+        case 30057: {
+            const a = parseAggregateAuditEvent(event);
+            if (a) {
+                typeKey = 'audit';
+                const reviewNeeded = typeof a.confidence !== 'number' || a.confidence < 0.6;
+                title = reviewNeeded
+                    ? 'Aggregate audit — needs human review'
+                    : `Aggregate audit — ${a.finalScore} · conf ${a.confidence}`;
+                sub = url || `article ${a.articleHash.slice(0, 16)}…`;
+                extra.articleHash = a.articleHash;
+                extra.auditRole = 'aggregate';
+                extra.parsedAudit = a;
+                haystack.push(a.articleHash, a.ceilingSource);
+            }
+            break;
+        }
+        case 30058: {
+            const p = parsePredictionEntryEvent(event);
+            if (p) {
+                typeKey = 'prediction';
+                title = p.text;
+                sub = `prediction · ${p.hedgeLevel} · horizon ${p.horizonIso || p.horizon || 'unscheduled'}`;
+                extra.articleHash = p.articleHash;
+                extra.parsedPrediction = p;
+                haystack.push(p.text, p.hedgeLevel);
+            }
+            break;
+        }
+        case 30059: {
+            const r = parsePredictionResolutionEvent(event);
+            if (r) {
+                typeKey = 'prediction';
+                title = `Resolution — ${r.outcome}`;
+                sub = r.predictionCoord;
+                extra.articleHash = r.articleHash;
+                extra.parsedResolution = r;
+                haystack.push(r.outcome, r.predictionCoord);
+            }
+            break;
+        }
+        case 30060: {
+            const d = parseDossierSnapshotEvent(event);
+            if (d) {
+                typeKey = 'audit';
+                title = `Dossier snapshot — ${d.subjectKind}${d.beat ? ` · ${d.beat}` : ''}`;
+                sub = `window ${d.windowStart || '?'} → ${d.windowEnd || '?'}`;
+                extra.auditRole = 'dossier';
+                haystack.push(d.subjectKind, d.beat);
+            }
+            break;
+        }
+        case 30061: {
+            const dis = parseAuditDisputeEvent(event);
+            if (dis) {
+                typeKey = 'audit';
+                title = `Dispute — ${dis.status}`;
+                sub = dis.targetCoord;
+                extra.articleHash = dis.articleHash;
+                extra.auditRole = 'dispute';
+                extra.parsedDispute = dis;
+                haystack.push(dis.targetKind, dis.status);
+            }
             break;
         }
         default: {

--- a/src/portal/resolve-form.js
+++ b/src/portal/resolve-form.js
@@ -1,0 +1,159 @@
+// The minimal Resolve… form (Phase 13.7) — the prediction ledger's
+// write side. Files a LOCAL resolution record (ResolutionModel);
+// publishing the 30059 is slice 13.8, behind the flag.
+//
+// Resolutions are evidence-bound (P3): the form requires at least one
+// typed evidence entry — challenges without evidence are returned,
+// and so are resolutions. nostr_event values must be a raw coordinate
+// or 64-hex event id (the wire grammar).
+
+import { el, clear } from './dom.js';
+import { ResolutionModel } from '../shared/audit/audit-model.js';
+
+const OUTCOMES = ['true', 'false', 'partial', 'unresolvable'];
+const EVIDENCE_KINDS = ['url', 'nostr_event', 'document_hash', 'quote'];
+
+/**
+ * Open the form for one prediction. `prediction` needs {text,
+ * coordinate} — the coordinate is the 30058's `kind:pubkey:d`
+ * (remote events carry it; local unpublished ones derive it from the
+ * resolver identity, since the v1 flow publishes both under one key).
+ * Resolves with the created resolution record, or null on cancel.
+ */
+export function openResolveForm(prediction) {
+    return new Promise((resolve) => {
+        const host = el('div', 'xr-resolve');
+        const card = el('div', 'xr-resolve__card');
+        host.appendChild(card);
+
+        card.appendChild(el('h3', 'xr-resolve__title', 'Resolve prediction'));
+        const quote = el('blockquote', 'xr-resolve__pred', prediction.text);
+        card.appendChild(quote);
+
+        // Outcome
+        const outcomeRow = el('label', 'xr-resolve__row', 'Outcome ');
+        const outcomeSel = el('select', 'xr-resolve__input');
+        for (const o of OUTCOMES) {
+            const opt = el('option', null, o);
+            opt.value = o;
+            outcomeSel.appendChild(opt);
+        }
+        outcomeRow.appendChild(outcomeSel);
+        card.appendChild(outcomeRow);
+
+        // Confidence
+        const confRow = el('label', 'xr-resolve__row', 'Confidence (0–1) ');
+        const confInput = el('input', 'xr-resolve__input');
+        confInput.type = 'number';
+        confInput.min = '0';
+        confInput.max = '1';
+        confInput.step = '0.05';
+        confInput.value = '0.9';
+        confRow.appendChild(confInput);
+        card.appendChild(confRow);
+
+        // Evidence rows (at least one)
+        card.appendChild(el('div', 'xr-resolve__row', 'Evidence — what shows this outcome (at least one):'));
+        const evidenceList = el('div', 'xr-resolve__evidence');
+        card.appendChild(evidenceList);
+        const addEvidenceRow = () => {
+            const row = el('div', 'xr-resolve__evrow');
+            const kindSel = el('select', 'xr-resolve__input xr-resolve__input--kind');
+            for (const k of EVIDENCE_KINDS) {
+                const opt = el('option', null, k);
+                opt.value = k;
+                kindSel.appendChild(opt);
+            }
+            const valueInput = el('input', 'xr-resolve__input xr-resolve__input--value');
+            valueInput.placeholder = 'value (URL, coordinate/event id, sha256, or verbatim quote)';
+            const descInput = el('input', 'xr-resolve__input xr-resolve__input--desc');
+            descInput.placeholder = 'description';
+            row.appendChild(kindSel);
+            row.appendChild(valueInput);
+            row.appendChild(descInput);
+            evidenceList.appendChild(row);
+        };
+        addEvidenceRow();
+        const addBtn = el('button', 'xr-portal__btn xr-portal__btn--ghost', '+ evidence');
+        addBtn.type = 'button';
+        addBtn.addEventListener('click', addEvidenceRow);
+        card.appendChild(addBtn);
+
+        // Notes
+        const notes = el('textarea', 'xr-resolve__notes');
+        notes.placeholder = 'Notes — what happened, why this outcome (markdown)';
+        card.appendChild(notes);
+
+        const errLine = el('div', 'xr-resolve__error');
+        card.appendChild(errLine);
+
+        // Actions
+        const actions = el('div', 'xr-resolve__actions');
+        const cancel = el('button', 'xr-portal__btn xr-portal__btn--ghost', 'Cancel');
+        cancel.type = 'button';
+        const save = el('button', 'xr-portal__btn', 'File resolution');
+        save.type = 'button';
+        actions.appendChild(cancel);
+        actions.appendChild(save);
+        card.appendChild(actions);
+
+        const close = (result) => {
+            document.removeEventListener('keydown', onKey);
+            if (host.parentNode) host.parentNode.removeChild(host);
+            resolve(result);
+        };
+        const onKey = (ev) => { if (ev.key === 'Escape') close(null); };
+        document.addEventListener('keydown', onKey);
+        host.addEventListener('click', (ev) => { if (ev.target === host) close(null); });
+        cancel.addEventListener('click', () => close(null));
+
+        save.addEventListener('click', async () => {
+            const evidence = [...evidenceList.querySelectorAll('.xr-resolve__evrow')]
+                .map((row) => ({
+                    kind: row.querySelector('.xr-resolve__input--kind').value,
+                    value: row.querySelector('.xr-resolve__input--value').value.trim(),
+                    description: row.querySelector('.xr-resolve__input--desc').value.trim()
+                }))
+                .filter((e) => e.value);
+            const confidence = Number(confInput.value);
+            if (evidence.length === 0) {
+                errLine.textContent = 'Resolutions are evidence-bound — add at least one evidence entry.';
+                return;
+            }
+            if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+                errLine.textContent = 'Confidence must be a number between 0 and 1.';
+                return;
+            }
+            try {
+                const chosen = {
+                    outcome: outcomeSel.value,
+                    confidence,
+                    evidence,
+                    notes: notes.value.trim()
+                };
+                let record = await ResolutionModel.create({
+                    predictionCoord: prediction.coordinate,
+                    ...chosen,
+                    auditor: prediction.resolverAuditor || null
+                });
+                // create is idempotent on the coordinate — a SECOND
+                // filing returns the FIRST record untouched. Filing
+                // again IS the designed revision path (the resolver's
+                // own latest-wins), so upsert through update when the
+                // returned record differs from what was just entered.
+                if (record.outcome !== chosen.outcome
+                        || record.confidence !== chosen.confidence
+                        || record.notes !== chosen.notes
+                        || JSON.stringify(record.evidence) !== JSON.stringify(chosen.evidence)) {
+                    record = await ResolutionModel.update(record.id, chosen);
+                }
+                close(record);
+            } catch (err) {
+                errLine.textContent = 'Could not file: ' + (err && err.message);
+            }
+        });
+
+        document.body.appendChild(host);
+        clear(errLine);
+    });
+}

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -30,6 +30,7 @@ import { articleHash as canonicalArticleHash } from '../shared/audit/article-has
 import { importAuditJson } from '../shared/audit/import.js';
 import { AuditRunModel, PredictionModel, staleModules } from '../shared/audit/audit-model.js';
 import { CURRENT_MODULE_VERSIONS } from '../shared/audit/findings-schemas.js';
+import { auditBand, scoreChipHtml, prettyModule } from '../shared/audit/display.js';
 
 const browserApi = typeof browser !== 'undefined' && browser.runtime ? browser : chrome;
 
@@ -435,36 +436,9 @@ function updateHashLine() {
 // provenance one tap away; disagreement side-by-side, never averaged;
 // audit and assessment UI never visually merge.
 
-// The framework rubric bands (prompts/00; PHILOSOPHY §4).
-function auditBand(score) {
-    if (score >= 90) return { key: 'exemplary',    label: 'Exemplary' };
-    if (score >= 75) return { key: 'solid',        label: 'Solid' };
-    if (score >= 60) return { key: 'acceptable',   label: 'Acceptable, with concerns' };
-    if (score >= 40) return { key: 'significant',  label: 'Significant problems' };
-    if (score >= 20) return { key: 'severe',       label: 'Severe' };
-    return { key: 'catastrophic', label: 'Catastrophic' };
-}
-
-function scoreChipHtml(score, confidence) {
-    if (typeof score !== 'number') {
-        return '<span class="xr-audit__chip xr-audit__chip--failed">failed</span>';
-    }
-    // No naked numbers, no exceptions: a score whose confidence is
-    // UNKNOWN must not render cleaner than one whose confidence is
-    // 0.59 — unknown is below the review threshold by definition.
-    if (typeof confidence !== 'number') {
-        return '<span class="xr-audit__chip xr-audit__chip--review" title="this result carries no confidence value — treat as unreviewed">needs human review · no confidence recorded</span>';
-    }
-    if (confidence < 0.6) {
-        return '<span class="xr-audit__chip xr-audit__chip--review" title="confidence ' +
-            escapeHtml(String(confidence)) + ' — below the 0.6 reliability threshold">needs human review</span>';
-    }
-    return `<span class="xr-audit__score">${escapeHtml(String(score))} · conf ${escapeHtml(String(confidence))}</span>`;
-}
-
-function prettyModule(name) {
-    return String(name || '').replace(/_/g, ' ');
-}
+// Band/chip helpers live in shared/audit/display.js — ONE enforcement
+// point for the display rules across the reader and the portal
+// (imported at the top of this file).
 
 // Locate an evidence quote in the article body: selection-only (the
 // body is contenteditable and syncs htmlDraft — DOM mutation here

--- a/src/shared/audit/display.js
+++ b/src/shared/audit/display.js
@@ -1,0 +1,85 @@
+// X-Ray — audit display helpers (Phase 13.6/13.7).
+//
+// The display rules are wire-adjacent law (docs/EPISTEMIC_AUDIT_DESIGN.md
+// §"Score display — honest by construction"), so the helpers that
+// enforce them live in ONE place and every surface (reader panel,
+// portal chips/inspector/dossier) imports them:
+//
+//   1. No naked numbers — a score renders with its confidence, and a
+//      score with UNKNOWN confidence renders the review chip (unknown
+//      must never look more authoritative than 0.59).
+//   2. Confidence < 0.6 renders "needs human review", not a number.
+//   3. Badge bands are the framework rubric (90/75/60/40/20) — the
+//      scale anchors at 70–85 normal, so nothing below 75 reads as
+//      good and there is no green at 50.
+
+const ESCAPE_RE = /[&<>"']/g;
+const ESCAPE_MAP = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+
+export function escapeAuditHtml(value) {
+    return String(value == null ? '' : value).replace(ESCAPE_RE, (c) => ESCAPE_MAP[c]);
+}
+
+/** The framework rubric bands (prompts/00; PHILOSOPHY §4). */
+export function auditBand(score) {
+    if (score >= 90) return { key: 'exemplary',    label: 'Exemplary' };
+    if (score >= 75) return { key: 'solid',        label: 'Solid' };
+    if (score >= 60) return { key: 'acceptable',   label: 'Acceptable, with concerns' };
+    if (score >= 40) return { key: 'significant',  label: 'Significant problems' };
+    if (score >= 20) return { key: 'severe',       label: 'Severe' };
+    return { key: 'catastrophic', label: 'Catastrophic' };
+}
+
+/**
+ * The score-with-confidence chip, rules 1+2 enforced structurally.
+ * Returns HTML using the xr-audit__* vocabulary (the reader and the
+ * portal share these class names; each surface styles them).
+ */
+export function scoreChipHtml(score, confidence) {
+    if (typeof score !== 'number') {
+        return '<span class="xr-audit__chip xr-audit__chip--failed">failed</span>';
+    }
+    if (typeof confidence !== 'number') {
+        return '<span class="xr-audit__chip xr-audit__chip--review" title="this result carries no confidence value — treat as unreviewed">needs human review · no confidence recorded</span>';
+    }
+    if (confidence < 0.6) {
+        return '<span class="xr-audit__chip xr-audit__chip--review" title="confidence ' +
+            escapeAuditHtml(String(confidence)) + ' — below the 0.6 reliability threshold">needs human review</span>';
+    }
+    return `<span class="xr-audit__score">${escapeAuditHtml(String(score))} · conf ${escapeAuditHtml(String(confidence))}</span>`;
+}
+
+export function prettyModule(name) {
+    return String(name || '').replace(/_/g, ' ');
+}
+
+/**
+ * The compact card-chip as DATA — {text, bandKey, title} or null —
+ * for surfaces that build DOM with createElement (the portal's
+ * no-innerHTML discipline). Same rules as everything else here.
+ */
+export function auditCardChipData(aggregate) {
+    if (!aggregate) return null;
+    const score = typeof aggregate.final_score === 'number' ? aggregate.final_score : null;
+    const conf = typeof aggregate.overall_confidence === 'number' ? aggregate.overall_confidence : null;
+    if (score === null) return null;
+    if (conf === null || conf < 0.6) {
+        return { text: 'audit: review', bandKey: 'review', title: 'audit needs human review' };
+    }
+    const band = auditBand(score);
+    return {
+        text: `audit ${score} · ${conf}`,
+        bandKey: band.key,
+        title: `${band.label} · confidence ${conf}`
+    };
+}
+
+/** The same chip as HTML (reader surfaces). */
+export function auditCardChipHtml(aggregate) {
+    const data = auditCardChipData(aggregate);
+    if (!data) return null;
+    if (data.bandKey === 'review') {
+        return `<span class="xr-audit__chip xr-audit__chip--review" title="${escapeAuditHtml(data.title)}">${escapeAuditHtml(data.text)}</span>`;
+    }
+    return `<span class="xr-audit__chip xr-audit__chip--band-${escapeAuditHtml(data.bandKey)}" title="${escapeAuditHtml(data.title)}">${escapeAuditHtml(data.text)}</span>`;
+}

--- a/tests/audit-display.test.mjs
+++ b/tests/audit-display.test.mjs
@@ -1,0 +1,53 @@
+// Phase 13.7 — the shared display helpers: the ONE enforcement point
+// for the score-display rules across reader and portal.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    auditBand, scoreChipHtml, prettyModule, auditCardChipHtml, escapeAuditHtml
+} from '../src/shared/audit/display.js';
+
+test('bands are the framework rubric — boundaries exact, no green near 50', () => {
+    assert.equal(auditBand(100).key, 'exemplary');
+    assert.equal(auditBand(90).key, 'exemplary');
+    assert.equal(auditBand(89.9).key, 'solid');
+    assert.equal(auditBand(75).key, 'solid');
+    assert.equal(auditBand(74.9).key, 'acceptable');
+    assert.equal(auditBand(60).key, 'acceptable');
+    assert.equal(auditBand(59.9).key, 'significant');
+    assert.equal(auditBand(50).key, 'significant',
+        '50 is a meaningfully concerning article — never the midpoint of anything');
+    assert.equal(auditBand(40).key, 'significant');
+    assert.equal(auditBand(39.9).key, 'severe');
+    assert.equal(auditBand(20).key, 'severe');
+    assert.equal(auditBand(19.9).key, 'catastrophic');
+    assert.equal(auditBand(0).key, 'catastrophic');
+});
+
+test('scoreChipHtml: the no-naked-numbers ladder', () => {
+    assert.match(scoreChipHtml(null, null), /failed/);
+    assert.match(scoreChipHtml(95, undefined), /needs human review · no confidence recorded/,
+        'unknown confidence must not render cleaner than 0.59');
+    assert.ok(!scoreChipHtml(95, undefined).includes('95'), 'no number leaks through the review chip');
+    assert.match(scoreChipHtml(95, 0.59), /needs human review/);
+    assert.ok(!scoreChipHtml(95, 0.59).includes('95'));
+    assert.match(scoreChipHtml(95, 0.6), /95 · conf 0\.6/);
+    assert.match(scoreChipHtml(0, 0.9), /0 · conf 0\.9/, 'zero is a score, not a missing value');
+});
+
+test('auditCardChipHtml: compact chip, same rules', () => {
+    assert.equal(auditCardChipHtml(null), null);
+    assert.equal(auditCardChipHtml({ overall_confidence: 0.9 }), null, 'no score, no chip');
+    assert.match(auditCardChipHtml({ final_score: 80, overall_confidence: 0.5 }), /audit: review/);
+    assert.match(auditCardChipHtml({ final_score: 80 }), /audit: review/, 'unknown confidence = review');
+    const chip = auditCardChipHtml({ final_score: 80, overall_confidence: 0.8 });
+    assert.match(chip, /audit 80 · 0\.8/);
+    assert.match(chip, /band-solid/);
+});
+
+test('escapeAuditHtml escapes attribute-context characters too', () => {
+    assert.equal(escapeAuditHtml('<img src=x onerror="a">\'&'),
+        '&lt;img src=x onerror=&quot;a&quot;&gt;&#39;&amp;');
+    assert.equal(prettyModule('headline_body_fidelity'), 'headline body fidelity');
+});

--- a/tests/portal-audit-data.test.mjs
+++ b/tests/portal-audit-data.test.mjs
@@ -1,0 +1,278 @@
+// Phase 13.7 — the portal's audit data joins. Fixtures use the
+// PRODUCTION item shape (extras spread FLAT, the buildItem contract);
+// one test goes through the real buildItems pipeline end-to-end so
+// the library↔audit-data seam can never silently split again.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// library.js transitively imports Storage (chrome at module load).
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const {
+    buildAuditIndex, mergeLocalRuns, mergeLocalResolutions, auditsForArticle,
+    latestAuditFor, dossierInputsForEntity, computeEntityDossier,
+    predictionsDue, resolverIdentity, DEFAULT_POPULATION_MEAN
+} = await import('../src/portal/audit-data.js');
+
+const HASH_A = 'a'.repeat(64);
+const HASH_B = 'b'.repeat(64);
+const PK = 'c'.repeat(64);
+const ENTITY_PK = 'd'.repeat(64);
+
+// PRODUCTION SHAPE: extras flat on the item (buildItem's `...extra`).
+function articleItem({ hash = HASH_A, url = 'https://example.com/a', pTags = [] } = {}) {
+    return {
+        typeKey: 'article',
+        url,
+        articleHash: hash,
+        event: { kind: 30023, pubkey: PK, tags: [['r', url], ...(hash ? [['x', hash]] : []), ...pTags] }
+    };
+}
+
+function aggregateItem({ hash = HASH_A, url = 'https://example.com/a', score = 74, conf = 0.8, runAt = '2026-06-11T20:00:00Z', auditorId = 'xray-auditor/0.1.0', d = 'agg:1234123412341234' } = {}) {
+    return {
+        typeKey: 'audit',
+        articleHash: hash,
+        auditRole: 'aggregate',
+        parsedAudit: {
+            id: d, articleHash: hash, url, runAt,
+            finalScore: score, rawScore: score, ceiling: 90,
+            ceilingBinding: false, ceilingSource: 'heuristic:source-quality/1.0',
+            confidence: conf, knowabilityNotes: '',
+            auditor: { kind: 'pipeline', id: auditorId },
+            moduleContributions: [{ module: 'omission', score: 70 }]
+        },
+        event: { kind: 30057, pubkey: PK, tags: [] }
+    };
+}
+
+function predictionItem({ hash = HASH_A, d = 'pred:1111111111111111', text = 'X by December.', hedge = 'confident', horizonIso = '2026-12-31' } = {}) {
+    return {
+        typeKey: 'prediction',
+        articleHash: hash,
+        parsedPrediction: { id: d, articleHash: hash, text, hedgeLevel: hedge, horizonIso, horizon: 'by December' },
+        event: { kind: 30058, pubkey: PK, tags: [] }
+    };
+}
+
+function resolutionItem({ coord = `30058:${PK}:pred:1111111111111111`, outcome = 'true', resolvedAt = '2027-01-02T00:00:00Z' } = {}) {
+    return {
+        typeKey: 'prediction',
+        parsedResolution: { id: 'res:x', predictionCoord: coord, outcome, resolvedAt, articleHash: HASH_A },
+        event: { kind: 30059, pubkey: PK, tags: [] }
+    };
+}
+
+test('hash-first joins: scores never transfer across hashes — even when the hash finds nothing', () => {
+    const index = buildAuditIndex([
+        aggregateItem({ hash: HASH_A, url: 'https://example.com/a' }),
+        aggregateItem({ hash: HASH_B, url: 'https://example.com/a', score: 30, conf: 0.9, runAt: '2026-06-12T08:00:00Z', d: 'agg:5678567856785678' })
+    ]);
+    const hashed = auditsForArticle(index, articleItem({ hash: HASH_A }));
+    assert.equal(hashed.runs.length, 1);
+    assert.equal(hashed.joinedBy, 'hash');
+    assert.equal(latestAuditFor(index, articleItem({ hash: HASH_A })).final_score, 74);
+
+    // THE invariant: an article WITH a hash that finds no audits gets
+    // an empty result — never the URL-mates' scores.
+    const miss = auditsForArticle(index, articleItem({ hash: 'e'.repeat(64) }));
+    assert.deepEqual(miss.runs, []);
+    assert.equal(miss.joinedBy, 'hash');
+
+    // A pre-13.4 article (no x tag) falls back to URL — marked advisory.
+    const legacy = auditsForArticle(index, articleItem({ hash: null }));
+    assert.equal(legacy.runs.length, 2);
+    assert.equal(legacy.joinedBy, 'url');
+    assert.equal(latestAuditFor(index, articleItem({ hash: null })).joinedBy, 'url',
+        'the chip layer can mark URL matches as text-unverified');
+});
+
+test('PRODUCTION pipeline: buildItems output joins without any fixture shimming', async () => {
+    const { buildItems } = await import('../src/portal/library.js');
+    const { buildModuleResultEvent, buildAggregateAuditEvent, buildPredictionEntryEvent } =
+        await import('../src/shared/audit/builders.js');
+
+    const findings = {
+        module: 'internal_coherence', version: '1.0', score: 62, confidence: 0.78,
+        auditor_caveats: ['x'], contradictions: [], logical_gaps: []
+    };
+    const mod = await buildModuleResultEvent({
+        articleHash: HASH_A, module: 'internal_coherence', runAt: '2026-06-11T20:14:00Z',
+        findings, articleUrl: 'https://example.com/a',
+        auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' }
+    });
+    const agg = await buildAggregateAuditEvent({
+        articleHash: HASH_A, runAt: '2026-06-11T20:14:05Z',
+        finalScore: 64.5, rawScore: 71.2, ceiling: 80,
+        ceilingSource: 'heuristic:source-quality/1.0', confidence: 0.71,
+        articleUrl: 'https://example.com/a',
+        auditor: { kind: 'pipeline', id: 'xray-auditor/0.1.0' }
+    });
+    const pred = await buildPredictionEntryEvent({
+        articleHash: HASH_A, predictionText: 'X by December.',
+        predictionType: 'explicit', hedgeLevel: 'confident', attribution: 'article_voice',
+        horizon: 'by December', horizonIso: '2026-12-31', criteria: 'c',
+        tractability: 'publicly_resolvable', evidenceQuote: 'q', moduleVersion: '1.0',
+        auditor: { kind: 'model', id: 'anthropic/claude-sonnet-4-6' }
+    });
+    const articleEvent = {
+        kind: 30023, pubkey: PK, created_at: 1765000000, id: '1'.repeat(64),
+        tags: [['d', 'dddd'], ['title', 'T'], ['r', 'https://example.com/a'], ['x', HASH_A]],
+        content: 'body'
+    };
+    const records = [articleEvent, { ...mod.event, pubkey: PK, id: '2'.repeat(64) },
+        { ...agg.event, pubkey: PK, id: '3'.repeat(64) },
+        { ...pred.event, pubkey: PK, id: '4'.repeat(64) }]
+        .map((event) => ({ event, relays: [] }));
+
+    const items = buildItems(records, { entityIndex: {} });
+    const article = items.find((i) => i.typeKey === 'article');
+    assert.equal(article.articleHash, HASH_A, 'buildItem extracts the x tag FLAT');
+
+    const index = buildAuditIndex(items);
+    const { runs, joinedBy } = auditsForArticle(index, article);
+    assert.equal(joinedBy, 'hash', 'the hash join fires on real items');
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].finalScore, 64.5);
+    assert.equal((index.modulesByHash.get(HASH_A) || []).length, 1);
+    assert.equal(index.predictions.length, 1);
+    assert.equal(index.predictions[0].coordinate, `30058:${PK}:${pred.dTag}`);
+});
+
+test('local runs merge without double-listing — including hashes with NO relay copy', () => {
+    const index = buildAuditIndex([aggregateItem({ runAt: '2026-06-11T20:00:00Z' })]);
+    mergeLocalRuns(index, [
+        { id: 'audit_1', articleHash: HASH_A, runAt: '2026-06-11T20:00:00Z',
+            auditor: { kind: 'pipeline', id: 'xray-auditor/0.1.0' },
+            aggregate: { final_score: 74, overall_confidence: 0.8 } },
+        // A never-published import on a hash the relays know nothing
+        // about — the ONLY kind of run that exists before 13.8.
+        { id: 'audit_2', articleHash: HASH_B, runAt: '2026-06-12T09:00:00Z',
+            auditor: { kind: 'pipeline', id: 'xray-auditor/0.1.0' },
+            aggregate: {
+                final_score: 71, overall_confidence: 0.7, raw_weighted_score: 88,
+                knowability_ceiling: 71, ceiling_binding: true,
+                ceiling_source: 'heuristic:source-quality/1.0', knowability_notes: 'n'
+            } }
+    ]);
+    assert.equal(index.aggregatesByHash.get(HASH_A).length, 1, 'published copy wins');
+    const localOnly = auditsForArticle(index, articleItem({ hash: HASH_B }));
+    assert.equal(localOnly.runs.length, 1, 'local-only hashes surface too');
+    const a = localOnly.runs[0];
+    assert.equal(a.source, 'local');
+    // The 13.1-record → parsed-event field mapping, pinned.
+    assert.equal(a.finalScore, 71);
+    assert.equal(a.rawScore, 88);
+    assert.equal(a.ceiling, 71);
+    assert.equal(a.ceilingBinding, true);
+    assert.equal(a.ceilingSource, 'heuristic:source-quality/1.0');
+    assert.equal(a.confidence, 0.7);
+});
+
+test('entity dossier: per-article auditor dedup, hash-scoped predictions, honest counts', () => {
+    const items = [
+        articleItem({ hash: HASH_A, pTags: [['p', ENTITY_PK, '', 'author']] }),
+        articleItem({ hash: HASH_B, url: 'https://example.com/b', pTags: [['p', ENTITY_PK, '', 'author']] }),
+        aggregateItem({ hash: HASH_A, score: 80, runAt: '2026-06-12T08:00:00Z' }),
+        aggregateItem({ hash: HASH_A, score: 60, runAt: '2026-06-10T08:00:00Z', d: 'agg:0000111100001111' }),  // older, same auditor — superseded
+        aggregateItem({ hash: HASH_B, url: 'https://example.com/b', score: 70, runAt: '2026-06-12T09:00:00Z', d: 'agg:2222333322223333' }),  // SAME auditor, second article — counts
+        predictionItem({ hash: HASH_A }),
+        predictionItem({ hash: 'f'.repeat(64), d: 'pred:9999999999999999', text: 'Other article.' }),  // outside the entity — excluded
+        resolutionItem({})
+    ];
+    const index = buildAuditIndex(items);
+    const inputs = dossierInputsForEntity(items, index, ENTITY_PK);
+    assert.equal(inputs.aggregates.length, 2, 'latest per (article, auditor) — dedup resets per article');
+    assert.equal(inputs.auditedArticles, 2);
+    assert.equal(inputs.totalPredictions, 1, 'predictions scope to the entity\'s audited hashes');
+    assert.deepEqual(inputs.resolvedPredictions, [{ hedge_level: 'confident', outcome: 'true' }]);
+
+    const dossier = computeEntityDossier(inputs);
+    assert.equal(dossier.auditedArticles, 2);
+    assert.equal(dossier.judgments, 2);
+    assert.equal(dossier.populationMean, DEFAULT_POPULATION_MEAN);
+    assert.equal(dossier.predictions.calibration_v1.multiplier, null, 'logged, never applied');
+
+    assert.equal(dossierInputsForEntity(items, index, 'e'.repeat(64)), null,
+        'no audited articles → no dossier, not an empty one');
+    assert.equal(computeEntityDossier(null), null,
+        'null passthrough — every unaudited entity view depends on this');
+    assert.deepEqual(dossier.unmappedBeats, inputs.unmappedBeats);
+});
+
+test('sub-0.6-confidence aggregates are EXCLUDED from the rollup and counted', () => {
+    const items = [
+        articleItem({ pTags: [['p', ENTITY_PK, '', 'author']] }),
+        aggregateItem({ score: 95, conf: 0.5, runAt: '2026-06-12T08:00:00Z' }),
+        aggregateItem({ score: 70, conf: 0.8, runAt: '2026-06-11T08:00:00Z', auditorId: 'other-auditor/1.0', d: 'agg:4444555544445555' })
+    ];
+    const index = buildAuditIndex(items);
+    const inputs = dossierInputsForEntity(items, index, ENTITY_PK);
+    assert.equal(inputs.aggregates.length, 1, 'a number the display refuses must not move a reputation');
+    assert.equal(inputs.aggregates[0].finalScore, 70);
+    assert.equal(inputs.excludedForReview, 1);
+
+    // ALL excluded → no dossier at all.
+    const onlyReview = [
+        articleItem({ pTags: [['p', ENTITY_PK, '', 'author']] }),
+        aggregateItem({ score: 95, conf: 0.5 })
+    ];
+    assert.equal(dossierInputsForEntity(onlyReview, buildAuditIndex(onlyReview), ENTITY_PK), null);
+});
+
+test('predictions due: merged, deduped, windowed — overdue included, boundary inclusive, local resolutions clear', () => {
+    const index = buildAuditIndex([
+        predictionItem({ d: 'pred:1111111111111111', horizonIso: '2026-07-01' }),
+        predictionItem({ d: 'pred:2222222222222222', text: 'Resolved on relay.', horizonIso: '2026-07-15' }),
+        resolutionItem({ coord: `30058:${PK}:pred:2222222222222222` }),
+        predictionItem({ d: 'pred:6666666666666666', text: 'OVERDUE.', horizonIso: '2026-05-01' }),
+        predictionItem({ d: 'pred:7777777777777777', text: 'Exactly at limit.', horizonIso: '2026-09-09' }),
+        predictionItem({ d: 'pred:3333333333333333', text: 'Far future.', horizonIso: '2027-06-01' }),
+        predictionItem({ d: 'pred:4444444444444444', text: 'Unscheduled.', horizonIso: null })
+    ]);
+    const local = [
+        { id: 'pred_1111111111111111', text: 'X by December.', hedge_level: 'confident',
+            horizon_iso: '2026-07-01', resolution_status: 'open' },
+        { id: 'pred_5555555555555555', text: 'Local-only call.', hedge_level: 'hedged',
+            horizon_iso: '2026-06-20', resolution_status: 'open' },
+        { id: 'pred_8888888888888888', text: 'Locally resolved.', hedge_level: 'hedged',
+            horizon_iso: '2026-06-25', resolution_status: 'open' }
+    ];
+    // A locally-filed (unpublished) resolution under the resolver's
+    // own coordinate — must clear the prediction by sha16 identity.
+    mergeLocalResolutions(index, [{
+        prediction_coord: `30058:${'9'.repeat(64)}:pred:8888888888888888`,
+        outcome: 'false', resolved_at: 1765000000
+    }]);
+
+    const nowMs = Date.parse('2026-06-11T00:00:00Z');
+    const { due, unscheduled, openCount } = predictionsDue(index, local, { nowMs, windowDays: 90 });
+
+    assert.deepEqual(due.map((p) => p.key), [
+        '6666666666666666',   // overdue leads — most important entry on the strip
+        '5555555555555555',   // 2026-06-20 local-only
+        '1111111111111111',   // 2026-07-01 (deduped — published copy)
+        '7777777777777777'    // exactly at now+90d — inclusive
+    ]);
+    assert.equal(due[2].source, 'relay', 'published copy wins the dedup');
+    assert.equal(unscheduled, 1);
+    assert.equal(openCount, 6, 'open = due(4) + far-future(1) + unscheduled(1); resolved entries cleared');
+});
+
+test('resolverIdentity: signer first, never the bare sync key', () => {
+    assert.equal(resolverIdentity([]), null);
+    assert.equal(resolverIdentity([{ pubkey: 'k1', sources: ['sync-key'] }]), null,
+        'the sync key signs entity blobs, never audit events');
+    assert.equal(resolverIdentity([
+        { pubkey: 'k1', sources: ['sync-key'] },
+        { pubkey: 'k2', sources: ['publish-history'] },
+        { pubkey: 'k3', sources: ['signer'] }
+    ]).pubkey, 'k3', 'the signer wins regardless of order');
+    assert.equal(resolverIdentity([
+        { pubkey: 'k1', sources: ['sync-key'] },
+        { pubkey: 'k2', sources: ['manual'] }
+    ]).pubkey, 'k2');
+});

--- a/tests/portal-corpus.test.mjs
+++ b/tests/portal-corpus.test.mjs
@@ -55,7 +55,10 @@ function reset(handler) {
 test('CONTENT_KINDS pins the full corpus kind list from the design note', () => {
     assert.deepEqual([...CONTENT_KINDS].sort((a, b) => a - b), [
         1985, 9803, 10002, 30023, 30040, 30041, 30050, 30051, 30052,
-        30053, 30054, 30055, 30078, 32125, 32126
+        30053, 30054, 30055,
+        // Phase 13.7: the audit family (docs/EPISTEMIC_AUDIT_DESIGN.md)
+        30056, 30057, 30058, 30059, 30060, 30061,
+        30078, 32125, 32126
     ]);
 });
 

--- a/tests/portal-library.test.mjs
+++ b/tests/portal-library.test.mjs
@@ -168,7 +168,10 @@ test('EMPTY_FILTERS and TYPE_DEFS are pinned', () => {
     assert.deepEqual(EMPTY_FILTERS,
         { type: 'all', platform: '', domain: '', caseName: '', client: 'all', status: 'all', query: '', after: 0, before: 0 });
     assert.deepEqual(TYPE_DEFS.map((d) => d.key),
-        ['article', 'claim', 'comment', 'assessment', 'link', 'entity', 'case', 'account', 'other']);
+        ['article', 'claim', 'comment', 'assessment',
+            // Phase 13.7 facets:
+            'audit', 'prediction',
+            'link', 'entity', 'case', 'account', 'other']);
     assert.equal(kindLabel(30040), 'Claim');
     assert.equal(kindLabel(12345), 'kind 12345');
 });


### PR DESCRIPTION
Slice **13.7** of [`docs/EPISTEMIC_AUDIT_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/phase-13-audit-design/docs/EPISTEMIC_AUDIT_DESIGN.md) — the portal reads the audit corpus. **Draft for smoke-testing.** Stacked on #67.

## What's in it

- **Corpus + Library**: the audit family fetches (30056–30061); `Audits`/`Predictions` facets; audit chips on article cards with the **hash-first join** — URL fallback only for pre-13.4 hashless events, marked *"(URL match)" advisory* everywhere it renders. An article with a hash that finds no audits gets an empty result, never another text's scores.
- **Inspector**: every run side-by-side (never averaged) with module rows + methodology versions, ceiling context, supersession **and dispute lineage**, local unpublished runs marked.
- **Entity *and* case views**: the derived **Audit dossier** (shared block) — shrinkage always shown with its parameters; audited articles distinguished from auditor judgments; **sub-0.6 aggregates excluded from the rollup and counted as pending review** (new design rule, threaded into the design note: a number the display rules refuse to show must not move a reputation); rate table + informational calibration-v1; unmapped-beat review list.
- **Timeline**: predictions-due strip (overdue first, 90-day window, published+local merged) with the evidence-bound **Resolve…** form — upserts on re-filing, resolver identity is the signer (never the reserved sync key), and filed resolutions clear the strip immediately.

## Review

**20 confirmed, 0 refuted — the most of any slice, with two blocking roots.** (1) The hash join was *dead in production*: `buildItem` spreads extras flat, the joins read a nested shape my own fixtures had invented — every article silently fell to URL joins. Fixed, plus a production-pipeline test that runs real builder events through `buildItems` so the seam can't silently split again. (2) Locally-filed resolutions were invisible everywhere (`updateDerived` had zero callers; the strip re-offered Resolve… forever). Full record in the JOURNAL.

## Smoke checks for this draft

1. Import an audit (reader), open the portal → the article card shows the audit chip; click into the inspector → run row + module chips + provenance; a *local (unpublished)* marker on the run.
2. Open the entity view for the article's author → the dossier block shows raw vs shrunk mean with k/factor; predictions line when a ledger exists.
3. On the timeline strip, click **Resolve…** on a due prediction → file with one evidence row → the entry leaves the strip immediately and survives reload.
4. Re-open Resolve on the same prediction → change the outcome → the record updates (no silent first-outcome echo).
5. A pre-13.4 article (no hash) with a URL-matching audit shows the chip with "(URL match)" and the inspector's advisory line.

## Verification

7 portal-data tests; full suite **813 pass / 0 fail**; build + lint clean.

Remaining: 13.8 (flag-gated ordered publish batch), 13.9 (hardening + SMOKE_TEST §Phase 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)