### PR TITLE
Phase 13.8 — flag-gated ordered audit publish batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 13.8 — audit publish path.** A new `epistemicAuditing`
+  feature flag (default **off**, Options ▸ Advanced, with an explicit
+  public-visibility disclosure) lets the reader's Publish batch also
+  emit the published article's audit record: module results (30056),
+  the aggregate (30057), prediction ledger entries (30058, stamped
+  with the extraction methodology version that actually produced
+  them), and resolutions (30059 — including resolutions of *other
+  auditors'* predictions, anchored to the prediction's own article
+  hash). Ordering is enforced on the wire: referenced events always
+  land before their referencers, and anything whose referent failed
+  defers to the next publish via per-event ledger marks (a resumed
+  batch never duplicates, never orphans). One malformed record never
+  blocks the rest — every skip is counted and surfaced in the publish
+  summary. The portal's reconciliation panel now covers the audit
+  kinds (a published audit that vanishes from relays surfaces as
+  `missing`, like everything else). CLI import additionally enforces
+  the wrapper/findings `module_version` agreement — the field feeds
+  the wire address — and validates aggregate contribution rows at the
+  door. Kind-30060 dossier snapshots remain unpublished by design
+  (the portal stays read-only).
+
 - **Phase 13.7 — portal audit surfaces.** The portal corpus now
   fetches the audit kinds (30056–30061); the Library gains Audits and
   Predictions facets plus an audit chip on article cards (joined by

--- a/docs/EPISTEMIC_AUDIT_DESIGN.md
+++ b/docs/EPISTEMIC_AUDIT_DESIGN.md
@@ -829,8 +829,22 @@ export-included, not droppable.)
   atomized-claim `a` reference publishes **after that claim** — the
   Phase 11 claims-before-assessments rule, inherited verbatim
   (otherwise 30058s are independent); resolutions any time after their
-  prediction. The flag (`epistemicAuditing`) gates every publish path;
-  local capture/import/render is ungated — the Phase 11 split.
+  prediction. Ordering holds **on the wire, not just in the list**: a
+  referencer whose referent failed (or never published) this batch
+  defers to the next one rather than minting a dangling reference, and
+  a promoted 30058 carries the claim's *published* address — never the
+  current signing key's. The flag (`epistemicAuditing`) gates every
+  publish path; local capture/import/render is ungated — the Phase 11
+  split.
+- **Resolution identity rule (13.8):** a 30059 whose prediction
+  coordinate matches a *local* prediction but was minted under a
+  different pubkey is refused at publish — that address will never
+  exist (the local prediction publishes under the signing key); re-file
+  under the signing identity. A coordinate with **no** local
+  counterpart is someone else's published prediction, and resolving it
+  is a designed workflow — it publishes verbatim, anchored to the
+  *prediction's* article hash (`article_hash` on the resolution
+  record, stamped by the Resolve… form).
 
 ## Predictions as first-class records
 

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,71 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-11 — 13.8: the publish batch, and what "ordered" has to mean on the wire
+
+**Tags:** design, bug
+
+Slice 13.8 (flag-gated audit publish, draft PR). The calls worth a
+paper trail:
+
+- **"Ordered" is a wire property, not a list property.** The first
+  cut emitted 30056s → 30057 → 30058s → 30059s in order and called it
+  done; the adversarial review (30 confirmed, 10 refuted) pulled the
+  thread: under PARTIAL failure the order still inverts — an
+  aggregate can land while its module result bounced, a promoted
+  30058 while its 30040 was rejected by every relay. Now an aggregate
+  defers when any of its run's module events failed this batch, a
+  resolution defers when its prediction failed or deferred, and a
+  promoted prediction defers until its claim has a **published
+  address** — `claimPubkeys` is read from the claim records *after*
+  the claims block runs, so "failed this batch" and "never published"
+  collapse into one check, and the back-reference is minted at the
+  claim's actual address (its `publishedPubkey`), never the current
+  signing key's. The marks make every deferral a next-batch retry,
+  not a loss.
+- **`findings.version` is the d-preimage source of truth.** The
+  builder derives the 30056 wire `d` from `findings.version`; the
+  batch and the reconcile ledger were deriving coordinates from the
+  WRAPPER's `module_version` — a divergent pair would have minted
+  30057 contribution coords pointing at addresses that never exist,
+  with both events happily on relays. Import now enforces agreement
+  (failed-module posture on divergence, findings win when the wrapper
+  is absent), and every derivation site reads findings-first. Same
+  trust boundary as the score/confidence gate, missed for the one
+  field that feeds an address.
+- **Per-record hash anchoring.** Records publish against the vintage
+  they audited (`run.articleHash`/`p.articleHash`), and the reader
+  gathers ledger records across every hash the article has carried
+  (current + archive + priorVersions) — otherwise the publish-time
+  restamp stranded a resumed batch, and an edited-body publish
+  silently dropped the whole thing.
+- **The resolution identity rule.** A 30059 whose coordinate matches
+  a local prediction under a different pubkey is refused (that
+  address will never exist — re-file under the signing identity); a
+  coordinate with no local counterpart is someone else's published
+  prediction and publishes verbatim, anchored to the prediction's own
+  article via the new `article_hash` field the Resolve… form now
+  stamps (and backfills on revision). The first cut refused ALL
+  foreign coordinates — which made the portal's "publishes with the
+  13.8 batch" promise false for the resolver-≠-predictor workflow the
+  design explicitly supports.
+- **One malformed record never blocks the batch.** assembleAuditBatch
+  isolates every build; a refused record is a counted skip with the
+  builder's reason, and the summary line carries `ok/count (skipped)`
+  — the import module's per-module posture, applied at publish. The
+  end-of-loop audit toast was deleted as dead: the summary toast
+  replaced it in the same tick (single-slot toast), which would have
+  hidden every skip explanation.
+- **Known gaps, decided not patched:** `xray:flags:reload` is
+  documented in two places but has no sender or listener — benign
+  today (the reader `loadFlags()`s before the gate) — left for a
+  flags-bus slice; the reader's defer-discipline loop is DOM-bound
+  and untested (the property contract it consumes is pinned in the
+  batch tests; SMOKE_TEST coverage lands in 13.9); 30060 snapshot
+  publish stays deferred (portal read-only).
+
+---
+
 ## 2026-06-11 — 13.7: the portal joins, and what a dossier refuses to be
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1039,6 +1039,24 @@ Implementation slices 13.1+ are in progress.
   **predictions-due strip** (90-day window, merged published+local,
   deduped) with the minimal **Resolve…** form (evidence-bound;
   resolutions file locally, publish in 13.8). — #68
+- 🔄 **13.8** Publish path (draft PR for smoke-testing) — flag-gated
+  (`epistemicAuditing`, default off, Options ▸ Advanced toggle with
+  public-visibility disclosure) ordered batch in the reader's publish
+  flow: 30056s → 30057 → 30058s → 30059s with per-event ledger marks
+  (resume never duplicates); referenced-before-referencer enforced on
+  the WIRE (aggregates defer when a module fails this batch, promoted
+  30058s defer until their claim has a published address — at that
+  address, not the signing key's), per-record hash anchoring (records
+  publish against their audited vintage, resumes survive the publish
+  restamp), per-entry build isolation (one malformed record never
+  blocks the batch, every skip counted into the summary), the
+  resolution identity rule (stale-identity filings refused with
+  re-file guidance; remote-prediction resolutions publish verbatim,
+  anchored via the new `article_hash` record field), import-side
+  version trust boundary (wrapper `module_version` must agree with
+  `findings.version` — the wire-address preimage), portal
+  reconciliation for 30056–30059 (30060/30061 stay no-ledger; 30060
+  snapshot publish deferred — portal stays read-only). — #69
 
 ---
 

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -482,6 +482,8 @@ async function loadAdvanced() {
     await loadFlags();
     document.getElementById('pref-assessment-publishing').checked =
         isEnabled('assessmentPublishing');
+    document.getElementById('pref-epistemic-auditing').checked =
+        isEnabled('epistemicAuditing');
 
     const overrides = prefs.config_overrides || {};
     document.getElementById('pref-cache-enabled').checked =
@@ -516,6 +518,8 @@ async function saveAdvanced() {
     // clear the override back to the default (off).
     const publishJudgments = document.getElementById('pref-assessment-publishing').checked;
     await setOverride('assessmentPublishing', publishJudgments ? true : null);
+    const publishAudits = document.getElementById('pref-epistemic-auditing').checked;
+    await setOverride('epistemicAuditing', publishAudits ? true : null);
 
     flash(document.getElementById('advanced-status'), 'Saved.');
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -235,6 +235,20 @@
 
       <hr />
       <h3 class="xr-opt__subhead">Epistemic audits</h3>
+      <label class="xr-opt__field xr-opt__field--inline">
+        <input type="checkbox" id="pref-epistemic-auditing" />
+        <span>Publish audit events to relays</span>
+      </label>
+      <p class="xr-opt__hint" style="margin-top:-8px">
+        Off by default. When on, the reader's Publish batch also emits
+        the published article's imported audit results (kinds
+        30056/30057), its prediction ledger entries (30058), and your
+        resolutions of its predictions (30059) — scoped to that one
+        article per publish, signed by your publishing identity, and
+        <strong>publicly visible to anyone with relay access</strong>.
+        A published low score is a public, attributed, disputable
+        record. Local import and rendering never need this switch.
+      </p>
       <p class="xr-opt__hint">
         Run the companion scorer CLI (<code>docs/auditor-prototype/scorer/</code>)
         against a captured article, then import its JSON here. Imports

--- a/src/portal/audit-data.js
+++ b/src/portal/audit-data.js
@@ -296,6 +296,7 @@ export function predictionsDue(index, localPredictions, { nowMs, windowDays = 90
             hedge: p.hedgeLevel,
             horizonIso: p.horizonIso,
             coordinate: p.coordinate,
+            articleHash: p.articleHash || null,
             resolved: resolvedKeys.has(key),
             source: 'relay'
         });
@@ -309,6 +310,7 @@ export function predictionsDue(index, localPredictions, { nowMs, windowDays = 90
             hedge: p.hedge_level,
             horizonIso: p.horizon_iso,
             coordinate: null,            // unpublished — coordinate at publish (13.8)
+            articleHash: p.articleHash || null,
             resolved: p.resolution_status !== 'open' || resolvedKeys.has(key),
             localId: p.id,
             source: 'local'

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -393,6 +393,7 @@ function renderPredictionsStrip(host) {
                 const record = await openResolveForm({
                     text: p.text,
                     coordinate,
+                    articleHash: p.articleHash || null,
                     resolverAuditor: resolver ? { kind: 'human', id: resolver.pubkey } : null
                 });
                 if (record) {

--- a/src/portal/reconcile.js
+++ b/src/portal/reconcile.js
@@ -26,12 +26,18 @@ import { AssessmentModel } from '../shared/assessment-model.js';
 import { EvidenceLinker } from '../shared/evidence-linker.js';
 import { EntityModel } from '../shared/entity-model.js';
 import { listArticles } from '../shared/archive-cache.js';
+import { listRuns, listPredictions, listResolutions } from '../shared/audit/audit-cache.js';
+import {
+    deriveModuleResultDTag, deriveAggregateAuditDTag
+} from '../shared/audit/builders.js';
 import { Crypto } from '../shared/crypto.js';
 import { isSymmetricRelationship } from '../shared/assessment-taxonomy.js';
 import { replaceableKey } from '../shared/nostr-events.js';
 import { Utils } from '../shared/utils.js';
 
-const LEDGERED_KINDS = new Set([30023, 30040, 30054, 30055, 0]);
+// 30060 (snapshots) and 30061 (disputes) have no publish path in 13.8
+// — they stay 'no-ledger' below, never an anomaly.
+const LEDGERED_KINDS = new Set([30023, 30040, 30054, 30055, 0, 30056, 30057, 30058, 30059]);
 
 async function sha16(s) {
     return (await Crypto.sha256(String(s))).slice(0, 16);
@@ -152,6 +158,79 @@ export async function loadLocalLedger({ pubkeys = [] } = {}) {
         }
     } catch (err) { Utils.error('Reconcile: article ledger scan failed', err); }
 
+    // Audit kinds (13.8). The run's per-event ledger marks which of
+    // its 30056s/30057 went out; predictions and resolutions carry
+    // plain publishedEventId. Wire d-tags are recomputable from the
+    // records (the local-id discipline shares the sha16 inputs), and
+    // — like assessments — the signer's pubkey isn't recorded, so
+    // addresses fan out across the resolved identity set.
+    try {
+        for (const run of (await listRuns()) || []) {
+            if (!run || !run.events) continue;
+            for (const [eventKey, mark] of Object.entries(run.events)) {
+                if (!mark || !mark.publishedEventId) continue;
+                const addrs = [];
+                if (eventKey === 'agg') {
+                    const d = await deriveAggregateAuditDTag(
+                        run.articleHash, run.auditor && run.auditor.id, run.runAt);
+                    for (const pk of pubkeys) addrs.push(`30057:${pk}:${d}`);
+                } else if (eventKey.startsWith('mod:')) {
+                    const r = (run.moduleResults || [])
+                        .find((m) => m && m.module === eventKey.slice('mod:'.length));
+                    if (r) {
+                        // The wire d derives from findings.version
+                        // (the builder's source) — the wrapper field
+                        // is only the fallback for failed results.
+                        const d = await deriveModuleResultDTag(
+                            run.articleHash, r.module,
+                            (r.findings && r.findings.version) || r.module_version, r.run_at);
+                        for (const pk of pubkeys) addrs.push(`30056:${pk}:${d}`);
+                    }
+                }
+                entries.push({
+                    source: 'audit',
+                    localId: `${run.id}/${eventKey}`,
+                    label: eventKey === 'agg'
+                        ? `aggregate audit (${run.runAt})`
+                        : `module ${eventKey.slice('mod:'.length)} (${run.runAt})`,
+                    publishedAt: mark.publishedAt || null,
+                    publishedEventId: mark.publishedEventId,
+                    addrs
+                });
+            }
+        }
+    } catch (err) { Utils.error('Reconcile: audit-run ledger scan failed', err); }
+
+    try {
+        for (const p of (await listPredictions()) || []) {
+            if (!p || !p.publishedEventId) continue;
+            const d = 'pred:' + String(p.id || '').slice('pred_'.length);
+            entries.push({
+                source: 'prediction',
+                localId: p.id,
+                label: (p.text || p.id).slice(0, 60),
+                publishedAt: p.publishedAt || null,
+                publishedEventId: p.publishedEventId,
+                addrs: pubkeys.map((pk) => `30058:${pk}:${d}`)
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: prediction ledger scan failed', err); }
+
+    try {
+        for (const r of (await listResolutions()) || []) {
+            if (!r || !r.publishedEventId) continue;
+            const d = 'res:' + String(r.id || '').slice('res_'.length);
+            entries.push({
+                source: 'resolution',
+                localId: r.id,
+                label: `${r.outcome || 'resolution'} (${r.prediction_coord || r.id})`.slice(0, 60),
+                publishedAt: r.publishedAt || null,
+                publishedEventId: r.publishedEventId,
+                addrs: pubkeys.map((pk) => `30059:${pk}:${d}`)
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: resolution ledger scan failed', err); }
+
     return entries;
 }
 
@@ -161,10 +240,14 @@ export async function loadLocalLedger({ pubkeys = [] } = {}) {
  * Display-only, like everything else here.
  *
  * @returns {Promise<{claim: number, assessment: number, link: number,
- *                    entity: number, article: number, total: number}>}
+ *                    entity: number, article: number, auditRun: number,
+ *                    prediction: number, resolution: number, total: number}>}
  */
 export async function countLocalOnly() {
-    const counts = { claim: 0, assessment: 0, link: 0, entity: 0, article: 0, total: 0 };
+    const counts = {
+        claim: 0, assessment: 0, link: 0, entity: 0, article: 0,
+        auditRun: 0, prediction: 0, resolution: 0, total: 0
+    };
     const unpublished = (r) => r && (!r.publishedAt || !r.publishedEventId);
     try {
         for (const c of Object.values(await ClaimModel.getAll() || {})) if (unpublished(c)) counts.claim++;
@@ -183,7 +266,22 @@ export async function countLocalOnly() {
             if (r && (!r.publishedToRelay || !r.publishedEventId)) counts.article++;
         }
     } catch (_) { /* counted as zero */ }
-    counts.total = counts.claim + counts.assessment + counts.link + counts.entity + counts.article;
+    try {
+        // A run is "local only" when NONE of its events went out — a
+        // partially-published run is a `missing` problem, not this one.
+        for (const run of (await listRuns()) || []) {
+            const marks = Object.values((run && run.events) || {});
+            if (!marks.some((m) => m && m.publishedEventId)) counts.auditRun++;
+        }
+    } catch (_) { /* counted as zero */ }
+    try {
+        for (const p of (await listPredictions()) || []) if (unpublished(p)) counts.prediction++;
+    } catch (_) { /* counted as zero */ }
+    try {
+        for (const r of (await listResolutions()) || []) if (unpublished(r)) counts.resolution++;
+    } catch (_) { /* counted as zero */ }
+    counts.total = counts.claim + counts.assessment + counts.link + counts.entity + counts.article
+                 + counts.auditRun + counts.prediction + counts.resolution;
     return counts;
 }
 

--- a/src/portal/resolve-form.js
+++ b/src/portal/resolve-form.js
@@ -133,6 +133,7 @@ export function openResolveForm(prediction) {
                 };
                 let record = await ResolutionModel.create({
                     predictionCoord: prediction.coordinate,
+                    articleHash: prediction.articleHash || null,
                     ...chosen,
                     auditor: prediction.resolverAuditor || null
                 });
@@ -144,8 +145,14 @@ export function openResolveForm(prediction) {
                 if (record.outcome !== chosen.outcome
                         || record.confidence !== chosen.confidence
                         || record.notes !== chosen.notes
-                        || JSON.stringify(record.evidence) !== JSON.stringify(chosen.evidence)) {
-                    record = await ResolutionModel.update(record.id, chosen);
+                        || JSON.stringify(record.evidence) !== JSON.stringify(chosen.evidence)
+                        || (!record.article_hash && prediction.articleHash)) {
+                    record = await ResolutionModel.update(record.id, {
+                        ...chosen,
+                        // Backfill the article scope on revision —
+                        // pre-13.8 records were filed without it.
+                        ...(prediction.articleHash ? { article_hash: prediction.articleHash } : {})
+                    });
                 }
                 close(record);
             } catch (err) {

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -28,7 +28,9 @@ import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirro
 import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
 import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
 import { importAuditJson } from '../shared/audit/import.js';
-import { AuditRunModel, PredictionModel, staleModules } from '../shared/audit/audit-model.js';
+import { AuditRunModel, PredictionModel, ResolutionModel, staleModules } from '../shared/audit/audit-model.js';
+import { listResolutions as listAuditResolutions } from '../shared/audit/audit-cache.js';
+import { assembleAuditBatch } from '../shared/audit/publish-batch.js';
 import { CURRENT_MODULE_VERSIONS } from '../shared/audit/findings-schemas.js';
 import { auditBand, scoreChipHtml, prettyModule } from '../shared/audit/display.js';
 
@@ -2354,6 +2356,162 @@ async function publish() {
             }
         }
 
+        // ---- Audit events (13.8, flag-gated) ---------------------------
+        // The ordered audit batch for this capture: 30056s → 30057 →
+        // 30058s (claims published above, so claim back-refs resolve)
+        // → 30059s. Per-event ledger marks make a relay hiccup
+        // mid-batch resumable instead of duplicating. Uses the
+        // CAPTURE hash — predictions and runs anchor to the text that
+        // was audited, not the possibly-edited published text.
+        const auditResults = { ok: 0, fail: 0, errors: [], skipped: 0 };
+        let auditCount = 0;
+        if (isEnabled('epistemicAuditing') && captureHashForLedger) {
+            let batch = { entries: [], skipped: [] };
+            try {
+                // The ledger may be keyed to an EARLIER capture vintage
+                // than this publish (body edited since import; or a
+                // resume after the first publish restamped
+                // state.articleHash) — gather every hash this article
+                // has carried, current first.
+                const hashCandidates = [captureHashForLedger];
+                try {
+                    const arch = state.article.url ? await ArchiveCache.getArticle(state.article.url) : null;
+                    if (arch && arch.articleHash) hashCandidates.push(arch.articleHash);
+                    for (const v of (arch && arch.priorVersions) || []) {
+                        if (v && v.articleHash) hashCandidates.push(v.articleHash);
+                    }
+                } catch (_) { /* archive lookup is enrichment */ }
+                const hashes = [...new Set(hashCandidates.filter(Boolean))];
+
+                const auditRuns = [];
+                const auditPreds = [];
+                for (const h of hashes) {
+                    for (const r of await AuditRunModel.getByArticleHash(h)) {
+                        if (!auditRuns.some((x) => x.id === r.id)) auditRuns.push(r);
+                    }
+                    for (const p of await PredictionModel.getByArticleHash(h)) {
+                        if (!auditPreds.some((x) => x.id === p.id)) auditPreds.push(p);
+                    }
+                }
+
+                // Resolutions: anything referencing one of this
+                // article's predictions (under ANY pubkey — the batch
+                // sorts stale-identity filings from remote-prediction
+                // ones), plus anything filed with this article's hash
+                // (resolutions of remote predictions about it).
+                const predSuffixes = new Set(auditPreds.map((p) => `pred:${String(p.id).slice('pred_'.length)}`));
+                const auditResolutions = (await listAuditResolutions()).filter((r) => {
+                    if (!r) return false;
+                    const suffix = String(r.prediction_coord || '').split(':').slice(2).join(':');
+                    return predSuffixes.has(suffix) || (r.article_hash && hashes.includes(r.article_hash));
+                });
+
+                // Promoted predictions reference their claim's PUBLISHED
+                // address — read it fresh (the claims block just ran,
+                // so a claim that landed this batch already carries
+                // its publishedPubkey). Absent → the batch defers.
+                const claimPubkeys = {};
+                try {
+                    for (const c of await ClaimModel.getBySourceUrl(state.article.url)) {
+                        if (c && c.publishedPubkey) claimPubkeys[c.id] = c.publishedPubkey;
+                    }
+                } catch (_) { /* defer-on-absence is the safe posture */ }
+
+                // The article's own coordinate — attached only when at
+                // least one relay holds the 30023 (referenced-before-
+                // referencer applies to the article join too).
+                const articleDTag = (unsignedArticle.tags.find((t) => t[0] === 'd') || [])[1];
+                const auditArticleCoord = (articleResults.successful > 0 && articleDTag)
+                    ? `30023:${userPubkey}:${articleDTag}` : null;
+
+                batch = await assembleAuditBatch({
+                    articleHash: captureHashForLedger,
+                    userPubkey,
+                    runs: auditRuns,
+                    predictions: auditPreds,
+                    resolutions: auditResolutions,
+                    claimPubkeys,
+                    articleUrl: state.article.url || '',
+                    articleCoord: auditArticleCoord
+                });
+            } catch (err) {
+                console.warn('[X-Ray Reader] audit batch assembly failed:', err);
+                auditResults.fail++;
+                auditResults.errors.push(`batch assembly: ${err.message || String(err)}`);
+            }
+            auditResults.skipped = batch.skipped.length;
+            auditCount = batch.entries.length;
+            if (batch.entries.length > 0) {
+                const auditBase = totalEvents;
+                totalEvents += batch.entries.length;
+                toast(`Also publishing ${batch.entries.length} audit event${batch.entries.length === 1 ? '' : 's'} — public, signed, disputable…`, 'warning', 4000);
+                // Referenced-before-referencer holds on the WIRE, not
+                // just in the list: an aggregate defers when one of
+                // its run's module events failed THIS batch, and a
+                // resolution defers when the prediction minting its
+                // coordinate failed this batch (the failed30054
+                // discipline, per dependency). Resume re-offers both.
+                const failedModuleRuns = new Set();
+                const failedPredCoords = new Set();
+                let aStep = 0;
+                for (const entry of batch.entries) {
+                    btn.textContent = `Publishing (${auditBase + (++aStep)}/${totalEvents})…`;
+                    const isAgg = entry.mark.type === 'run-event' && entry.mark.eventKey === 'agg';
+                    if ((isAgg && failedModuleRuns.has(entry.mark.runId))
+                        || (entry.mark.type === 'resolution' && failedPredCoords.has(entry.predictionCoord))) {
+                        auditResults.fail++;
+                        auditResults.errors.push(`${entry.label}: deferred — its referent failed this batch`);
+                        setProgress(auditBase + aStep, totalEvents);
+                        if (aStep < batch.entries.length) await sleep(BATCH_PUBLISH_DELAY_MS);
+                        continue;
+                    }
+                    let landed = false;
+                    try {
+                        entry.event.pubkey = userPubkey;
+                        const resp = await browserApi.runtime.sendMessage({
+                            type: 'xray:capture:publish', id: state.id, event: entry.event
+                        });
+                        if (resp && resp.ok && resp.results && resp.results.successful > 0) {
+                            recordRelayResults(resp.results);
+                            auditResults.ok++;
+                            landed = true;
+                            const signedId = resp.signedEvent?.id || null;
+                            try {
+                                if (entry.mark.type === 'run-event') {
+                                    await AuditRunModel.markEventPublished(entry.mark.runId, entry.mark.eventKey, signedId);
+                                } else if (entry.mark.type === 'prediction') {
+                                    await PredictionModel.markPublished(entry.mark.id, signedId);
+                                } else if (entry.mark.type === 'resolution') {
+                                    await ResolutionModel.markPublished(entry.mark.id, signedId);
+                                }
+                            } catch (_) { /* ledger mark is best-effort */ }
+                        } else {
+                            if (resp && resp.results) recordRelayResults(resp.results);
+                            auditResults.fail++;
+                            auditResults.errors.push(`${entry.label}: ${(resp && resp.error) || 'no relays accepted'}`);
+                        }
+                    } catch (err) {
+                        auditResults.fail++;
+                        auditResults.errors.push(`${entry.label}: ${err.message || String(err)}`);
+                        console.warn('[X-Ray Reader] audit publish failed:', entry.label, err);
+                    }
+                    if (!landed) {
+                        if (entry.mark.type === 'run-event' && entry.mark.eventKey !== 'agg') {
+                            failedModuleRuns.add(entry.mark.runId);
+                        } else if (entry.mark.type === 'prediction' && entry.coord) {
+                            failedPredCoords.add(entry.coord);
+                        }
+                    }
+                    setProgress(auditBase + aStep, totalEvents);
+                    if (aStep < batch.entries.length) await sleep(BATCH_PUBLISH_DELAY_MS);
+                }
+                // No toast here — showPublishSummary's toast replaces
+                // it in the same tick (single-slot); the audit segment
+                // and skipped count ride the summary line instead.
+                refreshAuditStatus().catch(() => { /* display refresh only */ });
+            }
+        }
+
         // Build + surface the end-of-batch summary.
         showPublishSummary({
             includeComments,
@@ -2372,6 +2530,8 @@ async function publish() {
             mirrorCount: mirrorSel.length,
             jLinkResults,
             jLinkCount: linkSel.length,
+            auditResults,
+            auditCount,
             relayStats
         });
 
@@ -2544,6 +2704,7 @@ function showPublishSummary({
     claimResults, claimCount, relationshipResults, relationshipCount,
     assessResults, assessCount = 0, mirrorResults, mirrorCount = 0,
     jLinkResults, jLinkCount = 0,
+    auditResults = { ok: 0, fail: 0, errors: [], skipped: 0 }, auditCount = 0,
     relayStats
 }) {
     // Console breakdown (always useful for debugging)
@@ -2556,6 +2717,7 @@ function showPublishSummary({
     if (assessResults && assessCount > 0)                    console.log('assessments:',    assessResults);
     if (mirrorResults && mirrorCount > 0)                    console.log('label mirrors:',  mirrorResults);
     if (jLinkResults && jLinkCount > 0)                      console.log('claim links:',    jLinkResults);
+    if (auditResults && (auditCount > 0 || auditResults.errors.length > 0 || auditResults.skipped > 0)) console.log('audit events:', auditResults);
     console.log('per relay:', Object.fromEntries(relayStats));
     console.groupEnd();
 
@@ -2571,6 +2733,7 @@ function showPublishSummary({
     const jdgFails  = ((assessResults && assessResults.fail) || 0)
                     + ((mirrorResults && mirrorResults.fail) || 0)
                     + ((jLinkResults && jLinkResults.fail) || 0);
+    const audFails  = (auditResults && auditResults.fail) || 0;
 
     const segments = [];
     segments.push(articleResults.successful > 0
@@ -2597,6 +2760,10 @@ function showPublishSummary({
     if (jLinkCount > 0) {
         segments.push(`${jLinkResults.ok}/${jLinkCount} claim link${jLinkCount === 1 ? '' : 's'}`);
     }
+    if (auditCount > 0 || (auditResults && (auditResults.skipped > 0 || auditResults.fail > 0))) {
+        segments.push(`${auditResults.ok}/${auditCount} audit event${auditCount === 1 ? '' : 's'}`
+            + (auditResults.skipped > 0 ? ` (${auditResults.skipped} skipped)` : ''));
+    }
     let line = 'Published: ' + segments.join(', ') + '.';
 
     const acceptedAll = [...relayStats.values()].filter((s) => s.fail === 0 && s.ok > 0).length;
@@ -2609,7 +2776,7 @@ function showPublishSummary({
         line += ` Rejected by ${names} — consider removing in Options.`;
     }
 
-    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0 || jdgFails > 0;
+    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0 || jdgFails > 0 || audFails > 0;
     const level = (anyFail || articleResults.successful === 0)
         ? (articleResults.successful > 0 ? 'warning' : 'error')
         : 'success';
@@ -2627,7 +2794,7 @@ function showPublishSummary({
             : 'X-Ray: Publish complete';
     notify(notifyTitle, line, level);
 
-    return totalEvents - cmtFails - entFails - clmFails - relFails - jdgFails
+    return totalEvents - cmtFails - entFails - clmFails - relFails - jdgFails - audFails
                        - (articleResults.successful === 0 ? 1 : 0);
 }
 

--- a/src/shared/audit/audit-model.js
+++ b/src/shared/audit/audit-model.js
@@ -212,6 +212,10 @@ export const PredictionModel = {
             tractability: fields.tractability || 'ambiguous',
             evidence_quote: fields.evidence_quote || '',
             anchor: fields.anchor || null,
+            // prediction_extraction's methodology version, persisted
+            // so the published 30058 states the version that actually
+            // produced it (P9) — never re-stamped at publish time.
+            module_version: fields.module_version || null,
             claim_ref: fields.claim_ref || null,   // set on promotion (RQ6)
             auditor: fields.auditor ? { ...fields.auditor } : null,
             extracted_at: fields.extracted_at || null,
@@ -319,6 +323,10 @@ export const ResolutionModel = {
         const record = {
             id,
             prediction_coord: predictionCoord.trim(),
+            // The PREDICTION's article hash (x on the published 30059)
+            // — without it, a resolution of a remote prediction can't
+            // be scoped to an article at publish time.
+            article_hash: fields.articleHash || null,
             outcome: fields.outcome,
             evidence: Array.isArray(fields.evidence) ? fields.evidence : [],
             notes: fields.notes || '',
@@ -359,7 +367,7 @@ export const ResolutionModel = {
         if (updates && 'outcome' in updates) {
             assertOutcome(updates.outcome, 'ResolutionModel.update');
         }
-        const allowed = ['outcome', 'evidence', 'notes', 'confidence', 'resolved_at'];
+        const allowed = ['outcome', 'evidence', 'notes', 'confidence', 'resolved_at', 'article_hash'];
         for (const key of allowed) {
             if (updates && key in updates) record[key] = updates[key];
         }

--- a/src/shared/audit/import.js
+++ b/src/shared/audit/import.js
@@ -118,6 +118,24 @@ export async function importAuditJson(json, { localArticleHash = null } = {}) {
     if (aggregate.ceiling_source != null && !isValidCeilingSource(aggregate.ceiling_source)) {
         throw fail(`aggregate.ceiling_source is not a valid provenance (got ${aggregate.ceiling_source})`);
     }
+    // Contribution rows feed the published 30057's content verbatim —
+    // the NIP's "aggregation is auditable from the event alone"
+    // property dies if a malformed weight/confidence silently coerces
+    // to 0 at publish. Rejected at the persistence boundary (P9).
+    if (aggregate.module_contributions != null) {
+        if (!Array.isArray(aggregate.module_contributions)) {
+            throw fail('aggregate.module_contributions must be an array when present');
+        }
+        for (const c of aggregate.module_contributions) {
+            const ok = c && typeof c.module === 'string'
+                && (c.score === null || (typeof c.score === 'number' && Number.isFinite(c.score)))
+                && typeof c.confidence === 'number' && Number.isFinite(c.confidence) && c.confidence >= 0 && c.confidence <= 1
+                && typeof c.weight === 'number' && Number.isFinite(c.weight) && c.weight >= 0 && c.weight <= 1;
+            if (!ok) {
+                throw fail(`aggregate.module_contributions has a malformed row (module ${c && c.module}) — score number|null, confidence/weight in [0,1] required`);
+            }
+        }
+    }
     const auditor = normalizeAuditor(aggregate.auditor, 'xray-auditor-import/unknown');
 
     // --- 3: per-module validation, failure posture per module --------------
@@ -178,8 +196,25 @@ export async function importAuditJson(json, { localArticleHash = null } = {}) {
             failedModules.push({ module, reason: 'score/confidence diverge from findings' });
             continue;
         }
+        // Same trust boundary for the VERSION: findings.version feeds
+        // the wire d (the builder derives the address from it), so a
+        // wrapper module_version diverging from it would mint
+        // 30056/30057 coordinates that never agree. Findings win;
+        // a present-and-different wrapper is the tamper signal.
+        const findingsVersion = r.findings.version;
+        if (typeof r.module_version === 'string' && r.module_version !== findingsVersion) {
+            storedResults.push({
+                ...base, score: null, confidence: null, findings: r.findings,
+                failed: true,
+                auditor_caveats: [...base.auditor_caveats,
+                    `wrapper module_version ${r.module_version} diverges from findings.version ${findingsVersion} — the wire address would dangle`]
+            });
+            failedModules.push({ module, reason: 'module_version diverges from findings.version' });
+            continue;
+        }
         storedResults.push({
             ...base,
+            module_version: findingsVersion,
             score: findingsScore,
             confidence: findingsConf,
             findings: r.findings,
@@ -260,6 +295,10 @@ export async function importAuditJson(json, { localArticleHash = null } = {}) {
             skippedPredictions.push({ text: candidate.text.slice(0, 60), reason });
             continue;
         }
+        // The extraction methodology's version, from this run's own
+        // prediction_extraction result — the published 30058 states
+        // the version that actually produced it, not a constant.
+        const extraction = storedResults.find((m) => m.module === 'prediction_extraction');
         await PredictionModel.create({
             articleHash: recomputed,
             text: candidate.text,
@@ -273,6 +312,7 @@ export async function importAuditJson(json, { localArticleHash = null } = {}) {
             criteria: candidate.criteria,
             tractability: candidate.tractability,
             evidence_quote: candidate.evidence_quote,
+            module_version: (extraction && extraction.module_version) || '1.0',
             auditor: normalizeAuditor(p.extracted_by, null) || auditor,
             extracted_at: p.extracted_at || aggregate.run_at
         });

--- a/src/shared/audit/publish-batch.js
+++ b/src/shared/audit/publish-batch.js
@@ -1,0 +1,277 @@
+// X-Ray — the audit publish batch (Phase 13, slice 13.8).
+//
+// Assembles the ORDERED list of unsigned audit events for one capture,
+// honoring the design's publish ordering: 30056 module results before
+// the 30057 that references them; claims before claim-referencing
+// 30058s (the claims publish earlier in the same reader batch, and a
+// promoted prediction DEFERS when its claim isn't on relays yet);
+// 30059 resolutions last, after their predictions. Per-event ledger
+// marks ride along so the publisher can resume a partially-published
+// batch instead of duplicating — the markPublished-never-bumps-updated
+// rule, per event.
+//
+// Every event anchors to ITS OWN record's article hash (a run imported
+// against one capture vintage publishes against that vintage even when
+// the reader's current hash has moved on). The articleHash param is
+// only the fallback for records that predate per-record hashes.
+//
+// Skips, all counted: failed module results (score null — they never
+// publish), already-published events (the resume path), records a
+// builder refuses (one malformed record never blocks the rest — the
+// import module's posture, applied at publish), promoted predictions
+// whose claim has no published address yet, and resolutions whose
+// prediction coordinate belongs to a LOCAL prediction minted under a
+// different pubkey (a stale signing identity — re-file; a coordinate
+// with no local counterpart is a remote prediction someone else
+// published, and resolving those is a designed workflow).
+
+import {
+    buildModuleResultEvent, buildAggregateAuditEvent,
+    buildPredictionEntryEvent, buildPredictionResolutionEvent,
+    deriveModuleResultDTag
+} from './builders.js';
+
+function alreadyPublished(run, eventKey) {
+    return !!(run.events && run.events[eventKey] && run.events[eventKey].publishedEventId);
+}
+
+// The wire d derives from findings.version (the builder's rule);
+// import enforces wrapper agreement, but derive from the same source
+// the builder uses so the two can never disagree here.
+function moduleWireVersion(r) {
+    return (r.findings && r.findings.version) || r.module_version || '1.0';
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.articleHash - the capture's canonical hash
+ *   (fallback anchor for records without their own)
+ * @param {string} params.userPubkey - the signing pubkey (producer ≠
+ *   publisher: auditor tags ride the events; this key signs)
+ * @param {Array} params.runs - AuditRun records for the article
+ * @param {Array} params.predictions - Prediction records for the article
+ * @param {Array} params.resolutions - Resolution records (the user's own)
+ * @param {Object<string,string>} [params.claimPubkeys] - claim_id →
+ *   the pubkey the claim is PUBLISHED under (its address). A promoted
+ *   prediction whose claim_id is absent here defers — the claim isn't
+ *   on relays, and the back-reference must never precede its referent.
+ * @param {string} [params.articleUrl] - the article's r value, verbatim
+ * @param {string|null} [params.articleCoord] - 30023 coordinate
+ * @param {string} [params.relayHint]
+ * @returns {Promise<{entries: Array<{label: string, event: object, mark: object}>, skipped: Array<{what: string, reason: string}>}>}
+ */
+export async function assembleAuditBatch({
+    articleHash, userPubkey, runs = [], predictions = [], resolutions = [],
+    claimPubkeys = {}, articleUrl = '', articleCoord = null, relayHint = ''
+}) {
+    const entries = [];
+    const skipped = [];
+
+    for (const run of runs) {
+        const runHash = run.articleHash || articleHash;
+        // --- 30056s first: the aggregate's a-coords must reference
+        // events that exist (or are in this very batch).
+        const coordByModule = {};
+        for (const r of run.moduleResults || []) {
+            if (r.failed || !r.findings || typeof r.findings !== 'object') {
+                skipped.push({ what: `module ${r.module} (run ${run.runAt})`, reason: 'failed result — never publishes' });
+                continue;
+            }
+            const eventKey = `mod:${r.module}`;
+            try {
+                const dTag = await deriveModuleResultDTag(runHash, r.module, moduleWireVersion(r), r.run_at);
+                if (alreadyPublished(run, eventKey)) {
+                    coordByModule[r.module] = `30056:${userPubkey}:${dTag}`;
+                    skipped.push({ what: `module ${r.module} (run ${run.runAt})`, reason: 'already published — resume skips it' });
+                    continue;
+                }
+                const built = await buildModuleResultEvent({
+                    articleHash: runHash,
+                    module: r.module,
+                    runAt: r.run_at,
+                    findings: r.findings,
+                    // An empty index is a recompute trigger, not data —
+                    // the builder dedupes quotes out of the findings.
+                    evidenceQuotes: Array.isArray(r.evidence_quotes) && r.evidence_quotes.length
+                        ? r.evidence_quotes : null,
+                    articleCoord, relayHint, articleUrl,
+                    auditor: r.auditor,
+                });
+                coordByModule[r.module] = `30056:${userPubkey}:${dTag}`;
+                entries.push({
+                    label: `module ${r.module}`,
+                    event: built.event,
+                    mark: { type: 'run-event', runId: run.id, eventKey }
+                });
+            } catch (err) {
+                // One malformed record never blocks the batch — and a
+                // module that won't build must not be referenced by
+                // the aggregate either (no coordByModule entry).
+                skipped.push({ what: `module ${r.module} (run ${run.runAt})`, reason: `build refused: ${err.message || err}` });
+            }
+        }
+
+        // --- then the 30057.
+        const agg = run.aggregate;
+        if (!agg || typeof agg.final_score !== 'number') {
+            skipped.push({ what: `aggregate (run ${run.runAt})`, reason: 'no scored aggregate' });
+        } else if (alreadyPublished(run, 'agg')) {
+            skipped.push({ what: `aggregate (run ${run.runAt})`, reason: 'already published — resume skips it' });
+        } else {
+            try {
+                const contributions = (agg.module_contributions || [])
+                    .filter((c) => coordByModule[c.module])
+                    .map((c) => ({
+                        module: c.module,
+                        coord: coordByModule[c.module],
+                        score: typeof c.score === 'number' ? c.score : null,
+                        confidence: typeof c.confidence === 'number' ? c.confidence : 0,
+                        weight: typeof c.weight === 'number' ? c.weight : 0
+                    }));
+                const built = await buildAggregateAuditEvent({
+                    articleHash: runHash,
+                    runAt: run.runAt,
+                    finalScore: agg.final_score,
+                    rawScore: typeof agg.raw_weighted_score === 'number' ? agg.raw_weighted_score : agg.final_score,
+                    ceiling: typeof agg.knowability_ceiling === 'number' ? agg.knowability_ceiling : 100,
+                    ceilingSource: agg.ceiling_source || 'heuristic:source-quality/1.0',
+                    confidence: typeof agg.overall_confidence === 'number' ? agg.overall_confidence : 0,
+                    knowabilityNotes: agg.knowability_notes || '',
+                    modelEstimatedCeiling: typeof agg.model_estimated_ceiling === 'number' ? agg.model_estimated_ceiling : null,
+                    moduleContributions: contributions,
+                    topStrengths: agg.top_strengths || [],
+                    topConcerns: agg.top_concerns || [],
+                    articleCoord, relayHint, articleUrl,
+                    auditor: run.auditor,
+                });
+                entries.push({
+                    label: 'aggregate audit',
+                    event: built.event,
+                    mark: { type: 'run-event', runId: run.id, eventKey: 'agg' }
+                    // The publisher must defer this if any of the SAME
+                    // run's module events fail in this batch (mark.runId
+                    // is the dependency key) — the ordering promise is
+                    // referenced-before-referencer on the wire, not just
+                    // in the list.
+                });
+            } catch (err) {
+                skipped.push({ what: `aggregate (run ${run.runAt})`, reason: `build refused: ${err.message || err}` });
+            }
+        }
+    }
+
+    // --- 30058s. A promoted prediction defers until its claim has a
+    // published address (claims publish earlier in the same reader
+    // batch — a claim that landed THIS batch is already in
+    // claimPubkeys by the time this assembles).
+    const predCoordById = {};
+    const predHashById = {};
+    const deferredPredCoords = new Set();
+    for (const p of predictions) {
+        const predD = 'pred:' + String(p.id || '').slice('pred_'.length);
+        const coord = `30058:${userPubkey}:${predD}`;
+        predCoordById[p.id] = coord;
+        predHashById[p.id] = p.articleHash || articleHash;
+        if (p.publishedEventId) {
+            skipped.push({ what: `prediction ${predD}`, reason: 'already published' });
+            continue;
+        }
+        const claimId = p.claim_ref && p.claim_ref.claim_id;
+        if (claimId && !claimPubkeys[claimId]) {
+            deferredPredCoords.add(coord);
+            skipped.push({
+                what: `prediction ${predD}`,
+                reason: 'atomized claim has no published address yet — defers until the claim lands'
+            });
+            continue;
+        }
+        try {
+            const built = await buildPredictionEntryEvent({
+                articleHash: p.articleHash || articleHash,
+                predictionText: p.text,
+                predictionType: p.type,
+                hedgeLevel: p.hedge_level,
+                attribution: p.attributed_to,
+                attributedName: p.attributed_source_name || null,
+                condition: p.condition || null,
+                horizon: p.horizon,
+                horizonIso: p.horizon_iso || null,
+                criteria: p.criteria,
+                tractability: p.tractability,
+                evidenceQuote: p.evidence_quote,
+                anchor: p.anchor || null,
+                moduleVersion: p.module_version || '1.0',
+                claimCoord: claimId ? `30040:${claimPubkeys[claimId]}:${claimId}` : null,
+                articleCoord, relayHint, articleUrl,
+                auditor: p.auditor || { kind: 'human', id: userPubkey },
+            });
+            entries.push({
+                label: 'prediction',
+                event: built.event,
+                mark: { type: 'prediction', id: p.id },
+                coord
+            });
+        } catch (err) {
+            deferredPredCoords.add(coord);
+            skipped.push({ what: `prediction ${predD}`, reason: `build refused: ${err.message || err}` });
+        }
+    }
+
+    // --- 30059s last.
+    const ownCoords = new Set(Object.values(predCoordById));
+    const localPredByDSuffix = new Map();
+    for (const [id, coord] of Object.entries(predCoordById)) {
+        localPredByDSuffix.set(coord.split(':').slice(2).join(':'), id);
+    }
+    for (const r of resolutions) {
+        if (r.publishedEventId) {
+            skipped.push({ what: `resolution ${r.id}`, reason: 'already published' });
+            continue;
+        }
+        if (deferredPredCoords.has(r.prediction_coord)) {
+            skipped.push({ what: `resolution ${r.id}`, reason: 'its prediction deferred this batch' });
+            continue;
+        }
+        const coordPubkey = String(r.prediction_coord || '').split(':')[1] || '';
+        const dSuffix = String(r.prediction_coord || '').split(':').slice(2).join(':');
+        const localPredId = localPredByDSuffix.get(dSuffix);
+        if (coordPubkey !== userPubkey && !ownCoords.has(r.prediction_coord) && localPredId) {
+            // The coordinate's d belongs to a LOCAL prediction, but it
+            // was minted under a different identity — that address
+            // will never exist (this batch publishes the prediction
+            // under the signing key). A coordinate with NO local
+            // counterpart is a remote prediction and publishes fine.
+            skipped.push({
+                what: `resolution ${r.id}`,
+                reason: 'prediction coordinate minted under a different pubkey — re-file under the signing identity'
+            });
+            continue;
+        }
+        try {
+            const built = await buildPredictionResolutionEvent({
+                predictionCoord: r.prediction_coord,
+                articleHash: r.article_hash || (localPredId && predHashById[localPredId]) || articleHash,
+                outcome: r.outcome,
+                confidence: typeof r.confidence === 'number' ? r.confidence : 0.9,
+                resolvedAt: new Date((r.resolved_at || 0) * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+                evidence: r.evidence || [],
+                notes: r.notes || '',
+                relayHint,
+                auditor: r.auditor || { kind: 'human', id: userPubkey },
+            });
+            entries.push({
+                label: 'resolution',
+                event: built.event,
+                mark: { type: 'resolution', id: r.id },
+                // Dependency key: the publisher defers this resolution
+                // if the prediction minting this coordinate fails in
+                // this very batch.
+                predictionCoord: r.prediction_coord
+            });
+        } catch (err) {
+            skipped.push({ what: `resolution ${r.id}`, reason: `build refused: ${err.message || err}` });
+        }
+    }
+
+    return { entries, skipped };
+}

--- a/tests/audit-import.test.mjs
+++ b/tests/audit-import.test.mjs
@@ -276,3 +276,59 @@ test('re-import is idempotent: same run converges, predictions never duplicate',
     assert.equal((await AuditRunModel.getByArticleHash(HASH)).length, 1);
     assert.equal((await PredictionModel.getByArticleHash(HASH)).length, 1);
 });
+
+// ------------------------------------------------------------------
+// 13.8 review hardening — version trust boundary + contribution rows
+// ------------------------------------------------------------------
+
+test('wrapper module_version diverging from findings.version fails the module (wire address would dangle)', async () => {
+    const json = scorerExport({
+        module_results: [coherenceResult({ module_version: '1.1' }), predictionExtraction()]
+    });
+    const summary = await importAuditJson(json, { localArticleHash: HASH });
+    assert.equal(summary.modulesFailed, 1);
+    assert.match(summary.failedModules[0].reason, /module_version diverges/);
+    const runs = await AuditRunModel.getByArticleHash(HASH);
+    const stored = runs[0].moduleResults.find((m) => m.module === 'internal_coherence');
+    assert.equal(stored.failed, true);
+    assert.equal(stored.score, null, 'failed posture — never publishes');
+});
+
+test('missing wrapper module_version adopts findings.version — the d-preimage source of truth', async () => {
+    const result = coherenceResult({
+        findings: {
+            module: 'internal_coherence', version: '1.2',
+            score: 74, confidence: 0.8,
+            auditor_caveats: ['x'], contradictions: [], logical_gaps: []
+        }
+    });
+    delete result.module_version;
+    const summary = await importAuditJson(
+        scorerExport({ module_results: [result, predictionExtraction()] }),
+        { localArticleHash: HASH });
+    assert.equal(summary.modulesFailed, 0);
+    const runs = await AuditRunModel.getByArticleHash(HASH);
+    const stored = runs[0].moduleResults.find((m) => m.module === 'internal_coherence');
+    assert.equal(stored.module_version, '1.2',
+        'stored version = findings.version, so every later address derivation agrees with the wire');
+});
+
+test('malformed module_contributions reject the import — never coerced to fabricated zeros at publish', async () => {
+    const json = scorerExport();
+    json.aggregate.module_contributions = [
+        { module: 'internal_coherence', score: 74, confidence: '0.8', weight: 0.1 }
+    ];
+    await assert.rejects(importAuditJson(json, { localArticleHash: HASH }), /malformed row/);
+});
+
+test('imported predictions persist the extraction methodology version from their own run', async () => {
+    const extraction = predictionExtraction();
+    extraction.findings.version = '1.3';
+    delete extraction.module_version;   // wrapper absent — findings win
+    await importAuditJson(
+        scorerExport({ module_results: [coherenceResult(), extraction] }),
+        { localArticleHash: HASH });
+    const preds = await PredictionModel.getByArticleHash(HASH);
+    assert.equal(preds[0].module_version, '1.3',
+        'the published 30058 states the version that actually produced it');
+});

--- a/tests/audit-publish-batch.test.mjs
+++ b/tests/audit-publish-batch.test.mjs
@@ -1,0 +1,395 @@
+// Phase 13.8 — the ordered audit publish batch.
+//
+// assembleAuditBatch is pure over passed-in ledger records (no
+// IndexedDB), so these tests pin the contract directly: publish
+// ordering (30056s → 30057 → 30058s → 30059s), the three skip rules
+// (failed modules never publish, already-published events resume
+// instead of duplicating, foreign-pubkey resolution coordinates are
+// refused), per-event marks, and the claim back-reference (RQ6).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+import { assembleAuditBatch } from '../src/shared/audit/publish-batch.js';
+
+const HASH = 'a'.repeat(64);
+const USER_PK = 'f'.repeat(64);
+const OTHER_PK = '9'.repeat(64);
+const RUN_AT = '2026-06-11T20:14:05Z';
+const MODEL = { kind: 'model', id: 'anthropic/claude-sonnet-4-6' };
+const URL = 'https://example.com/story';
+
+function sha16(s) {
+    return createHash('sha256').update(s, 'utf8').digest('hex').slice(0, 16);
+}
+function firstTag(event, name) { return event.tags.find((t) => t[0] === name); }
+function tagsNamed(event, name) { return event.tags.filter((t) => t[0] === name); }
+
+const COHERENCE_FINDINGS = {
+    module: 'internal_coherence', version: '1.0',
+    score: 62, confidence: 0.78,
+    auditor_caveats: ['Surface scan only.'],
+    contradictions: [], logical_gaps: []
+};
+
+const OMISSION_FINDINGS = {
+    module: 'omission', version: '1.0', score: 70, confidence: 0.8,
+    auditor_caveats: ['x'],
+    topic_summary: 't', voices_directly_quoted: [], voices_paraphrased_only: [],
+    voices_referenced_but_silent: [], natural_stakeholder_set: [],
+    voices_expected_but_absent: [], speaks_for_instances: []
+};
+
+function makeRun(overrides = {}) {
+    return {
+        id: 'audit_1234567890abcdef',
+        articleHash: HASH,
+        auditor: MODEL,
+        runAt: RUN_AT,
+        source: 'cli-import',
+        moduleResults: [
+            {
+                module: 'internal_coherence', module_version: '1.0',
+                run_at: RUN_AT, auditor: MODEL,
+                score: 62, confidence: 0.78,
+                findings: COHERENCE_FINDINGS,
+                evidence_quotes: [], failed: false
+            },
+            {
+                module: 'omission', module_version: '1.0',
+                run_at: RUN_AT, auditor: MODEL,
+                score: 70, confidence: 0.8,
+                findings: OMISSION_FINDINGS,
+                evidence_quotes: [], failed: false
+            },
+            {
+                module: 'source_quality', module_version: '1.0',
+                run_at: RUN_AT, auditor: MODEL,
+                score: null, confidence: null,
+                findings: null, evidence_quotes: [], failed: true
+            }
+        ],
+        aggregate: {
+            final_score: 64.5, raw_weighted_score: 71.2,
+            knowability_ceiling: 80, ceiling_source: 'heuristic:source-quality/1.0',
+            overall_confidence: 0.71, knowability_notes: 'sourcing pattern',
+            model_estimated_ceiling: null,
+            module_contributions: [
+                { module: 'internal_coherence', score: 62, confidence: 0.78, weight: 0.10 },
+                { module: 'omission', score: 70, confidence: 0.8, weight: 0.15 },
+                { module: 'source_quality', score: null, confidence: 0, weight: 0.20 }
+            ],
+            top_strengths: [], top_concerns: []
+        },
+        events: {},
+        ...overrides
+    };
+}
+
+const PRED_TEXT = 'Rates will fall by December.';
+const PRED_ID = `pred_${sha16(`${HASH}|rates will fall by december.`)}`;
+
+function makePrediction(overrides = {}) {
+    return {
+        id: PRED_ID,
+        articleHash: HASH,
+        text: PRED_TEXT,
+        type: 'explicit',
+        hedge_level: 'confident',
+        attributed_to: 'article_voice',
+        attributed_source_name: null,
+        condition: null,
+        horizon: 'by the end of the year',
+        horizon_iso: '2026-12-31',
+        criteria: 'target below current on Dec 31',
+        tractability: 'publicly_resolvable',
+        evidence_quote: 'rates will come down',
+        anchor: null,
+        claim_ref: null,
+        auditor: MODEL,
+        publishedAt: null,
+        publishedEventId: null,
+        ...overrides
+    };
+}
+
+const OWN_PRED_COORD = `30058:${USER_PK}:pred:${sha16(`${HASH}|rates will fall by december.`)}`;
+
+function makeResolution(overrides = {}) {
+    return {
+        id: `res_${sha16(OWN_PRED_COORD)}`,
+        prediction_coord: OWN_PRED_COORD,
+        outcome: 'true',
+        evidence: [{ kind: 'url', value: 'https://example.com/followup', description: 'follow-up' }],
+        notes: '',
+        confidence: 0.95,
+        auditor: { kind: 'human', id: USER_PK },
+        resolved_at: 1781208845,        // 2026-06-11T20:14:05Z
+        publishedAt: null,
+        publishedEventId: null,
+        ...overrides
+    };
+}
+
+test('full batch: 30056s → 30057 → 30058 → 30059, with per-event marks', async () => {
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [makeRun()],
+        predictions: [makePrediction()],
+        resolutions: [makeResolution()],
+        articleUrl: URL
+    });
+
+    assert.deepEqual(entries.map((e) => e.event.kind), [30056, 30056, 30057, 30058, 30059],
+        'the design ordering — referenced events always precede their referencers');
+
+    // Marks: resumability is per event, keyed back into the ledger.
+    assert.deepEqual(entries[0].mark, { type: 'run-event', runId: 'audit_1234567890abcdef', eventKey: 'mod:internal_coherence' });
+    assert.deepEqual(entries[1].mark, { type: 'run-event', runId: 'audit_1234567890abcdef', eventKey: 'mod:omission' });
+    assert.deepEqual(entries[2].mark, { type: 'run-event', runId: 'audit_1234567890abcdef', eventKey: 'agg' });
+    assert.deepEqual(entries[3].mark, { type: 'prediction', id: PRED_ID });
+    assert.deepEqual(entries[4].mark, { type: 'resolution', id: `res_${sha16(OWN_PRED_COORD)}` });
+
+    // Dependency keys for the publisher's defer-on-failure discipline:
+    // a resolution's predictionCoord must equal the coordinate its
+    // prediction entry carries, or the publisher can't link them.
+    assert.equal(entries[3].coord, OWN_PRED_COORD);
+    assert.equal(entries[4].predictionCoord, OWN_PRED_COORD);
+
+    // The failed module never publishes — counted, not silent.
+    assert.equal(skipped.length, 1);
+    assert.match(skipped[0].reason, /failed result/);
+    assert.match(skipped[0].what, /source_quality/);
+
+    // The aggregate's contributions reference exactly the publishable
+    // modules' coordinates (failed module contributes no coord).
+    const agg = entries[2].event;
+    const contribCoords = tagsNamed(agg, 'a')
+        .filter((t) => t[1].startsWith('30056:'))
+        .map((t) => t[1]);
+    assert.equal(contribCoords.length, 2);
+    const cohD = 'mod:' + sha16(`${HASH}|internal_coherence|1.0|${RUN_AT}`);
+    assert.ok(contribCoords.includes(`30056:${USER_PK}:${cohD}`),
+        'contribution coordinate recomputable from the record, minted under the signing pubkey');
+
+    // Resolution timestamps convert epoch → strict ISO seconds.
+    assert.deepEqual(firstTag(entries[4].event, 'resolved-at'),
+        ['resolved-at', '2026-06-11T20:14:05Z']);
+});
+
+test('resume: already-published events skip, the rest still publish', async () => {
+    const run = makeRun({
+        events: {
+            'mod:internal_coherence': { publishedAt: 1781208000, publishedEventId: '1'.repeat(64) }
+        }
+    });
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [run],
+        predictions: [makePrediction({ publishedAt: 1781208000, publishedEventId: '2'.repeat(64) })],
+        resolutions: [],
+        articleUrl: URL
+    });
+
+    assert.deepEqual(entries.map((e) => e.event.kind), [30056, 30057],
+        'only the unpublished module + the aggregate go out');
+    assert.equal(entries[0].mark.eventKey, 'mod:omission');
+
+    // The resumed aggregate STILL references the previously-published
+    // module's coordinate — replaceable addresses are stable.
+    const cohD = 'mod:' + sha16(`${HASH}|internal_coherence|1.0|${RUN_AT}`);
+    assert.ok(tagsNamed(entries[1].event, 'a').some((t) => t[1] === `30056:${USER_PK}:${cohD}`),
+        'a resume must not orphan the aggregate from its already-published constituents');
+
+    const reasons = skipped.map((s) => s.reason);
+    assert.equal(reasons.filter((r) => /already published/.test(r)).length, 2,
+        'one module + one prediction skipped as already published');
+});
+
+test('aggregate-only resume: published agg skips, run contributes nothing twice', async () => {
+    const run = makeRun({
+        events: {
+            'mod:internal_coherence': { publishedAt: 1, publishedEventId: '1'.repeat(64) },
+            'mod:omission': { publishedAt: 1, publishedEventId: '2'.repeat(64) },
+            'agg': { publishedAt: 1, publishedEventId: '3'.repeat(64) }
+        }
+    });
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [run], predictions: [], resolutions: [], articleUrl: URL
+    });
+    assert.equal(entries.length, 0);
+    assert.equal(skipped.filter((s) => /already published/.test(s.reason)).length, 3);
+});
+
+test('run without a scored aggregate: modules publish, aggregate is a counted skip', async () => {
+    const run = makeRun({ aggregate: null });
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [run], predictions: [], resolutions: [], articleUrl: URL
+    });
+    assert.deepEqual(entries.map((e) => e.event.kind), [30056, 30056]);
+    assert.ok(skipped.some((s) => /no scored aggregate/.test(s.reason)));
+});
+
+test('claim back-reference (RQ6): promoted prediction carries the 30040 coordinate at its PUBLISHED address', async () => {
+    const pred = makePrediction({
+        claim_ref: { claim_id: 'claim_1234567890abcdef', pred_d: `pred:${sha16(`${HASH}|rates will fall by december.`)}` }
+    });
+    // The claim was published under a DIFFERENT key than today's
+    // signing key — the back-reference must use the claim's actual
+    // address, not the current signer.
+    const { entries } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [], predictions: [pred], resolutions: [],
+        claimPubkeys: { claim_1234567890abcdef: OTHER_PK },
+        articleUrl: URL
+    });
+    assert.equal(entries.length, 1);
+    const claimTag = tagsNamed(entries[0].event, 'a').find((t) => t[1].startsWith('30040:'));
+    assert.deepEqual(claimTag, ['a', `30040:${OTHER_PK}:claim_1234567890abcdef`, '', 'claim']);
+});
+
+test('promoted prediction DEFERS when its claim has no published address — and drags its resolution with it', async () => {
+    const pred = makePrediction({
+        claim_ref: { claim_id: 'claim_1234567890abcdef', pred_d: `pred:${sha16(`${HASH}|rates will fall by december.`)}` }
+    });
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [], predictions: [pred], resolutions: [makeResolution()],
+        claimPubkeys: {},     // the claim failed (or never published) this batch
+        articleUrl: URL
+    });
+    assert.equal(entries.length, 0, 'neither the 30058 nor its 30059 publishes');
+    assert.ok(skipped.some((s) => /no published address yet/.test(s.reason)));
+    assert.ok(skipped.some((s) => /its prediction deferred this batch/.test(s.reason)));
+});
+
+test('unpromoted prediction carries NO 30040 reference', async () => {
+    const { entries } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [], predictions: [makePrediction()], resolutions: [], articleUrl: URL
+    });
+    assert.equal(tagsNamed(entries[0].event, 'a').filter((t) => t[1].startsWith('30040:')).length, 0);
+});
+
+test('stale-identity resolution is refused; remote-prediction and own-coordinate resolutions publish', async () => {
+    // Same d as the local prediction, foreign pubkey: OUR prediction
+    // filed under an older signing identity — that address will never
+    // exist, refuse it.
+    const staleCoord = `30058:${OTHER_PK}:pred:${sha16(`${HASH}|rates will fall by december.`)}`;
+    const stale = makeResolution({
+        id: `res_${sha16(staleCoord)}`,
+        prediction_coord: staleCoord
+    });
+    // Foreign pubkey AND no local prediction counterpart: someone
+    // else's published prediction, resolved by this user — a designed
+    // workflow; the coordinate exists on relays. Publishes, anchored
+    // to the prediction's own article hash.
+    const remoteCoord = `30058:${OTHER_PK}:pred:${'0'.repeat(16)}`;
+    const remoteHash = 'b'.repeat(64);
+    const remote = makeResolution({
+        id: `res_${sha16(remoteCoord)}`,
+        prediction_coord: remoteCoord,
+        article_hash: remoteHash
+    });
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [], predictions: [makePrediction()],
+        resolutions: [stale, remote, makeResolution()],
+        articleUrl: URL
+    });
+    const resolutionEntries = entries.filter((e) => e.label === 'resolution');
+    assert.equal(resolutionEntries.length, 2, 'remote + own publish; stale-identity is refused');
+    assert.deepEqual(firstTag(resolutionEntries[0].event, 'a'),
+        ['a', remoteCoord, '', 'prediction']);
+    assert.deepEqual(firstTag(resolutionEntries[0].event, 'x'), ['x', remoteHash],
+        'remote-prediction resolution anchors to ITS article, not the batch article');
+    assert.deepEqual(firstTag(resolutionEntries[1].event, 'a'),
+        ['a', OWN_PRED_COORD, '', 'prediction']);
+    assert.ok(skipped.some((s) => /different pubkey/.test(s.reason)));
+});
+
+test('one malformed record never blocks the batch — counted as a refused build', async () => {
+    const broken = makeResolution({ evidence: [] });   // 30059s are evidence-bound; the builder throws
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [makeRun()], predictions: [makePrediction()],
+        resolutions: [broken],
+        articleUrl: URL
+    });
+    assert.deepEqual(entries.map((e) => e.event.kind), [30056, 30056, 30057, 30058],
+        'everything else still publishes');
+    assert.ok(skipped.some((s) => /build refused/.test(s.reason)));
+});
+
+test('every event anchors to its OWN record\'s hash, not the publish-time hash', async () => {
+    const oldHash = 'c'.repeat(64);
+    const run = makeRun({ articleHash: oldHash });
+    run.moduleResults = [run.moduleResults[0]];
+    const pred = makePrediction({ articleHash: oldHash });
+    const { entries } = await assembleAuditBatch({
+        articleHash: HASH,    // the CURRENT capture hash — records predate it
+        userPubkey: USER_PK,
+        runs: [run], predictions: [pred], resolutions: [], articleUrl: URL
+    });
+    for (const e of entries) {
+        assert.deepEqual(firstTag(e.event, 'x'), ['x', oldHash],
+            `${e.label}: anchored to the audited vintage`);
+    }
+});
+
+test('30058 module-version comes from the record; the published d matches the entry coord', async () => {
+    const pred = makePrediction({ module_version: '1.4' });
+    const { entries } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [], predictions: [pred], resolutions: [], articleUrl: URL
+    });
+    assert.deepEqual(firstTag(entries[0].event, 'module-version'), ['module-version', '1.4']);
+    // The event's actual d (derived from the TEXT by the builder) must
+    // agree with the coord the marks/resolutions key on (derived from
+    // the record id) — the two derivations share their sha16 input.
+    const wireD = firstTag(entries[0].event, 'd')[1];
+    assert.equal(`30058:${USER_PK}:${wireD}`, entries[0].coord);
+});
+
+test('articleCoord and relayHint thread through to the events when supplied', async () => {
+    const coord30023 = `30023:${USER_PK}:${'7'.repeat(16)}`;
+    const { entries } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [makeRun()], predictions: [makePrediction()], resolutions: [],
+        articleUrl: URL, articleCoord: coord30023, relayHint: 'wss://relay.example'
+    });
+    for (const e of entries) {
+        const articleTag = tagsNamed(e.event, 'a').find((t) => t[1] === coord30023);
+        assert.ok(articleTag, `${e.label}: carries the 30023 join`);
+        assert.equal(articleTag[2], 'wss://relay.example');
+    }
+});
+
+test('events carry the article hash and never a stance — the audit/assessment firewall holds', async () => {
+    const { entries } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [makeRun()],
+        predictions: [makePrediction()],
+        resolutions: [makeResolution()],
+        articleUrl: URL
+    });
+    for (const e of entries) {
+        assert.deepEqual(firstTag(e.event, 'x'), ['x', HASH], `${e.label}: x = article hash`);
+        for (const banned of ['stance', 'rating-value', 'L', 'l']) {
+            assert.equal(firstTag(e.event, banned), undefined,
+                `${e.label}: audit kinds never carry '${banned}'`);
+        }
+    }
+});
+
+test('empty ledger: empty batch, nothing throws', async () => {
+    const { entries, skipped } = await assembleAuditBatch({
+        articleHash: HASH, userPubkey: USER_PK,
+        runs: [], predictions: [], resolutions: [], articleUrl: URL
+    });
+    assert.deepEqual(entries, []);
+    assert.deepEqual(skipped, []);
+});

--- a/tests/portal-reconcile.test.mjs
+++ b/tests/portal-reconcile.test.mjs
@@ -214,3 +214,139 @@ test('loadLocalLedger: link with a local-id endpoint gets no addr (id-only match
     assert.deepEqual(link.addrs, []);
     assert.equal(link.publishedEventId, EV('6'));
 });
+
+// ------------------------------------------------------------------
+// Audit kinds (13.8) — the publish ledger added for 30056–30059
+// ------------------------------------------------------------------
+
+const AUDIT_HASH = 'd'.repeat(64);
+const RUN_AT = '2026-06-11T20:14:05Z';
+const AUDITOR = { kind: 'model', id: 'anthropic/claude-sonnet-4-6' };
+const sha16 = async (s) => (await Crypto.sha256(String(s))).slice(0, 16);
+
+test('loadLocalLedger: audit addrs are recomputable from the records', async () => {
+    const { AuditRunModel, PredictionModel, ResolutionModel } =
+        await import('../src/shared/audit/audit-model.js');
+
+    const run = await AuditRunModel.create({
+        articleHash: AUDIT_HASH, auditor: AUDITOR, runAt: RUN_AT, source: 'cli-import',
+        moduleResults: [
+            { module: 'internal_coherence', module_version: '1.0', run_at: RUN_AT, failed: false },
+            { module: 'omission', module_version: '1.0', run_at: RUN_AT, failed: false }
+        ],
+        aggregate: { final_score: 60 }
+    });
+    // Publish marks: one module + the aggregate. The unmarked module
+    // must yield NO ledger entry — never published, nothing to confirm.
+    await AuditRunModel.markEventPublished(run.id, 'mod:internal_coherence', EV('a'));
+    await AuditRunModel.markEventPublished(run.id, 'agg', EV('b'));
+
+    const pred = await PredictionModel.create({
+        articleHash: AUDIT_HASH, text: 'Rates Will  Fall.',
+        criteria: 'c', evidence_quote: 'q', tractability: 'publicly_resolvable'
+    });
+    await PredictionModel.markPublished(pred.id, EV('c'));
+
+    const predCoord = `30058:${PK_A}:pred:${pred.id.slice('pred_'.length)}`;
+    const res = await ResolutionModel.create({
+        predictionCoord: predCoord, outcome: 'true', auditor: { kind: 'human', id: PK_A }
+    });
+    await ResolutionModel.markPublished(res.id, EV('d'));
+
+    const ledger = await loadLocalLedger({ pubkeys: [PK_A] });
+    const audits = ledger.filter((e) => e.source === 'audit');
+    assert.equal(audits.length, 2, 'one entry per PUBLISHED run event — the unmarked module stays off the ledger');
+
+    const modD = 'mod:' + (await sha16(`${AUDIT_HASH}|internal_coherence|1.0|${RUN_AT}`));
+    const aggD = 'agg:' + (await sha16(`${AUDIT_HASH}|${AUDITOR.id}|${RUN_AT}`));
+    assert.deepEqual(audits.find((e) => e.localId.endsWith('mod:internal_coherence')).addrs,
+        [`30056:${PK_A}:${modD}`]);
+    assert.deepEqual(audits.find((e) => e.localId.endsWith('/agg')).addrs,
+        [`30057:${PK_A}:${aggD}`]);
+
+    // Prediction: the local id shares its sha16 with the wire d.
+    const predEntry = ledger.find((e) => e.source === 'prediction');
+    assert.deepEqual(predEntry.addrs, [`30058:${PK_A}:pred:${pred.id.slice('pred_'.length)}`]);
+    assert.equal(predEntry.publishedEventId, EV('c'));
+
+    // Resolution: res:<sha16(coord)> — the id's own derivation.
+    const resEntry = ledger.find((e) => e.source === 'resolution');
+    assert.deepEqual(resEntry.addrs, [`30059:${PK_A}:res:${res.id.slice('res_'.length)}`]);
+});
+
+test('countLocalOnly: audit buckets count never-published records only', async () => {
+    const { AuditRunModel, PredictionModel, ResolutionModel } =
+        await import('../src/shared/audit/audit-model.js');
+
+    // Self-contained: create BOTH a marked and an unmarked run here,
+    // so the partial-run-exclusion assertion holds even when this
+    // test runs in isolation (the shared fake-indexeddb DB makes the
+    // prior test's records an order-dependence hazard otherwise).
+    const marked = await AuditRunModel.create({
+        articleHash: AUDIT_HASH, auditor: AUDITOR, runAt: '2026-06-12T02:00:00Z',
+        source: 'cli-import',
+        moduleResults: [{ module: 'omission', module_version: '1.0', run_at: '2026-06-12T02:00:00Z', failed: false }],
+        aggregate: null
+    });
+    await AuditRunModel.markEventPublished(marked.id, 'mod:omission', EV('e'));
+    await AuditRunModel.create({
+        articleHash: AUDIT_HASH, auditor: AUDITOR, runAt: '2026-06-12T01:00:00Z',
+        source: 'cli-import',
+        moduleResults: [{ module: 'omission', module_version: '1.0', run_at: '2026-06-12T01:00:00Z', failed: false }],
+        aggregate: null
+    });
+    await PredictionModel.create({
+        articleHash: AUDIT_HASH, text: 'Another, unpublished prediction.',
+        criteria: 'c', evidence_quote: 'q'
+    });
+    await ResolutionModel.create({
+        predictionCoord: `30058:${PK_B}:pred:${'1'.repeat(16)}`, outcome: 'false'
+    });
+
+    const counts = await countLocalOnly();
+    assert.equal(counts.auditRun, 1, 'the marked run is not local-only; the unmarked one is');
+    assert.equal(counts.prediction, 1);
+    assert.equal(counts.resolution, 1);
+    assert.equal(counts.total >= 3, true);
+});
+
+test('reconcile: audit kinds are ledgered — unledgered ones surface as remote-only', () => {
+    const ledger = [
+        { source: 'audit', localId: 'audit_x/agg', label: 'agg', publishedEventId: EV('1'),
+          addrs: [`30057:${PK_A}:agg:${'2'.repeat(16)}`] }
+    ];
+    const items = [
+        item(EV('9'), 30057, PK_A, { d: 'agg:' + '2'.repeat(16) }),  // republished — addr match
+        item(EV('8'), 30058, PK_A, { d: 'pred:' + '3'.repeat(16) }), // remote-only: ledgered kind, no record
+        item(EV('6'), 30056, PK_A, { d: 'mod:' + '5'.repeat(16) }),  // remote-only: ledgered kind, no record
+        item(EV('5'), 30059, PK_A, { d: 'res:' + '6'.repeat(16) }),  // remote-only: ledgered kind, no record
+        item(EV('7'), 30061, PK_A, { d: 'dispute:' + '4'.repeat(16) }), // 30061 has no publish path — no-ledger
+        item(EV('4'), 30060, PK_A, { d: 'dossier:' + '7'.repeat(16) })  // 30060 deferred — no-ledger by design
+    ];
+    const r = reconcile(ledger, items);
+    assert.equal(r.statusByEventId[EV('9')], 'confirmed');
+    assert.equal(r.statusByEventId[EV('8')], 'remote-only');
+    assert.equal(r.statusByEventId[EV('6')], 'remote-only');
+    assert.equal(r.statusByEventId[EV('5')], 'remote-only');
+    assert.equal(r.statusByEventId[EV('7')], 'no-ledger');
+    assert.equal(r.statusByEventId[EV('4')], 'no-ledger');
+    assert.deepEqual(r.summary, { ledgerPublished: 1, confirmed: 1, missing: 0, remoteOnly: 3 });
+});
+
+test('loadLocalLedger: the 30056 address derives from findings.version, not the wrapper field', async () => {
+    const { AuditRunModel } = await import('../src/shared/audit/audit-model.js');
+    const run = await AuditRunModel.create({
+        articleHash: 'e'.repeat(64), auditor: AUDITOR, runAt: RUN_AT, source: 'cli-import',
+        moduleResults: [{
+            module: 'internal_coherence', module_version: '1.0', run_at: RUN_AT,
+            findings: { module: 'internal_coherence', version: '1.1' }, failed: false
+        }],
+        aggregate: null
+    });
+    await AuditRunModel.markEventPublished(run.id, 'mod:internal_coherence', EV('f'));
+    const ledger = await loadLocalLedger({ pubkeys: [PK_A] });
+    const entry = ledger.find((e) => e.source === 'audit' && e.localId === `${run.id}/mod:internal_coherence`);
+    const d = 'mod:' + (await sha16(`${'e'.repeat(64)}|internal_coherence|1.1|${RUN_AT}`));
+    assert.deepEqual(entry.addrs, [`30056:${PK_A}:${d}`],
+        'the builder derives the wire d from findings.version — the ledger must recompute the same way');
+});


### PR DESCRIPTION
Eighth slice of Phase 13 (#58, design #61). Stacked on #68 (13.7) — review only the top commit.

## What this adds

The reader's Publish flow gains a **flag-gated** (`epistemicAuditing`, default off) ordered audit batch: the published article's module results (30056) → aggregate (30057) → prediction ledger entries (30058) → resolutions (30059), each with a per-event ledger mark so a partially-published batch **resumes** instead of duplicating. Options ▸ Advanced gains the toggle, with a per-article-scope + public-visibility disclosure (a published low score is a public, attributed, disputable record). The portal's reconciliation panel covers the new kinds: a published audit that vanishes from relays surfaces as `missing`, an unledgered own-authored one as `remote-only`; 30060/30061 stay `no-ledger` (30060 snapshot publish deferred — the portal stays read-only, per the design's optional clause).

## Ordering is a wire property

The adversarial review (6 finder lenses → per-finding adversarial verifiers; **30 confirmed, 10 refuted**) centered on one theme: emitting events in order is not the same as the order *holding under partial failure*. As merged:

- An **aggregate defers** when any of its run's module events failed this batch; a **resolution defers** when its prediction failed or deferred.
- A **promoted 30058 defers** until its claim has a *published address*, and references that address (`publishedPubkey`) — never the current signing key's. A claim that failed this batch and one never published collapse into the same check, because `claimPubkeys` is read from the claim records after the claims block runs.
- **30056 coordinates derive from `findings.version`** (the builder's d-preimage) at every derivation site; import now fails a module whose wrapper `module_version` diverges from it (the score/confidence trust boundary, applied to the one field that feeds a wire address) and adopts `findings.version` when the wrapper is absent.
- **Per-record hash anchoring**: records publish against the vintage they audited, and the reader gathers ledger records across every hash the article has carried (current + archive + priorVersions) — the publish-time restamp can no longer strand a resume, and an edited-body publish no longer silently drops the batch.
- **Resolution identity rule** (now in the design note): a coordinate matching a local prediction under a different pubkey is refused (that address will never exist — re-file under the signing identity); a coordinate with no local counterpart is someone else's published prediction and publishes verbatim, anchored to the *prediction's* article via the new `article_hash` field the portal Resolve… form stamps (and backfills on revision). The first cut refused all foreign coordinates, which broke the resolver-≠-predictor workflow 13.7 promised.
- **Per-entry build isolation**: one malformed record is a counted skip with the builder's reason, never a blocked batch; every outcome (ok/fail/skipped) reaches the publish summary and console breakdown. The end-of-loop audit toast was deleted as dead — the single-slot summary toast replaced it in the same tick.
- Import validates `module_contributions` rows at the door (no fabricated zero weights on the wire); prediction records persist their extraction methodology version, so the published 30058 states the version that actually produced it.

## Known gaps (decided, documented in JOURNAL)

- `xray:flags:reload` is documented but has no sender/listener anywhere — benign today (the reader re-loads flags before the gate); left for a flags-bus slice.
- The reader's defer-discipline loop is DOM-bound and untested; the property contract it consumes is pinned in the batch tests, and SMOKE_TEST coverage lands in 13.9.
- Resolutions of remote predictions about *other* articles publish when that article is next published, not from the portal.

## Tests

835 pass (22 new): batch ordering + marks, resume (module/agg/prediction), claim deferral + published-address back-refs, stale-identity vs remote-prediction resolutions, per-record hash anchoring, build isolation, articleCoord/relayHint threading, 30058 d/coord agreement, firewall (no stance/rating-value/L/l); reconcile addr derivations (findings-version pinned), LEDGERED_KINDS pins incl. 30060 no-ledger, self-contained countLocalOnly; import version-divergence/adoption, contribution-row rejection, prediction version persistence.

`npm run build` ✓ · `npm test` 835/835 ✓ · `web-ext lint` 0 errors ✓

Draft for smoke-testing per the house cadence — the end-to-end walk (import → toggle on → publish → portal reconcile) wants a live relay before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)