### PR TITLE
Phase 14 — forensic findings (behavioral-pattern layer): 14.1–14.4 + 14.5 kickoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 14.3 — forensic wire format (kind `30062`).** New
+  `buildBehavioralFindingEvent` (kind 30062 BehavioralFinding) +
+  `parseBehavioralFindingEvent` + a kind-1985 maneuver mirror, behind a
+  new `forensicPublishing` flag (default off). The directional
+  `revision/*` story-change values (`narrative-patch`,
+  `recharacterizes`, `walks-back`) join kind 30055. ⚠️ Wire-format
+  change: a new event kind and three new 30055 relationship values, both
+  specified in `docs/NIP_DRAFT.md` §30062/§30055. The audit/assessment
+  firewall holds by construction — a finding never carries `stance`,
+  `rating-value`, `score`, or the `xray/assessment` namespace.
+
 - **Phase 13.9 — hardening.** `docs/SMOKE_TEST.md` gains §Phase 13:
   the 24-step manual acceptance walk for the audit pipeline (import
   refusal cases, the display-rule checks, publish resume, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Sections per release: **Added** (new features), **Changed**
   firewall holds by construction — a finding never carries `stance`,
   `rating-value`, `score`, or the `xray/assessment` namespace.
 
+- **Phase 14.3b — forensic publish wiring.** The reader's Publish flow
+  gains a flag-gated (`forensicPublishing`, default off) forensic batch:
+  behavioral findings (30062) → their kind-1985 maneuver mirrors → the
+  `revision/*` story-change edges (30055), each marked published in the
+  local ledger so a relay hiccup is resumable. A finding publishes
+  against a resolved subject pubkey (a tagged entity's keypair or an
+  external pubkey); subjects known only by label/handle wait for entity
+  linking. The `revision/*` edges moved out of the `assessmentPublishing`
+  link batch into this one.
+
 - **Phase 13.9 — hardening.** `docs/SMOKE_TEST.md` gains §Phase 13:
   the 24-step manual acceptance walk for the audit pipeline (import
   refusal cases, the display-rule checks, publish resume, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ Sections per release: **Added** (new features), **Changed**
   linking. The `revision/*` edges moved out of the `assessmentPublishing`
   link batch into this one.
 
+- **Phase 14.4 — forensic portal lenses.** The "My Archive" portal reads
+  behavioral findings: kind `30062` joins the corpus query + a "Findings"
+  Library facet + an inspector section (maneuver + evidence chain +
+  counter-read). The subject (entity) and case views gain a
+  **forensic-findings block** that renders the same findings through four
+  report lenses — **evidentiary / executive / survivor / editor** — never
+  averaged or scored. `30062` joins the reconciliation ledger (the wire
+  d-tag is recorded at publish so the coordinate rebuilds).
+
 - **Phase 13.9 — hardening.** `docs/SMOKE_TEST.md` gains §Phase 13:
   the 24-step manual acceptance walk for the audit pipeline (import
   refusal cases, the display-rule checks, publish resume, the

--- a/docs/CRIMINOLOGY_DESIGN.md
+++ b/docs/CRIMINOLOGY_DESIGN.md
@@ -1,0 +1,379 @@
+# Forensic findings — behavioral pattern analysis (Phase 13)
+
+**Status:** design **agreed 2026-06-14**. Companion to — and deliberately
+*not* a fork of — the Phase 11 assessment layer
+([`ASSESSMENTS_DESIGN.md`](ASSESSMENTS_DESIGN.md)). Where an assessment
+judges whether a *claim* is true, a **forensic finding** names a
+*behavioral maneuver* a subject performs around the truth — an evasion, a
+defense, a self-serving revision — and binds it to evidence, **without
+rendering a verdict on the subject's honesty or intent.**
+
+## What this is, and why it's separate from assessments
+
+X-Ray already grades claims: an assessment (kind `30054`) carries a stance
+(−2..+2) and typed truth/fallacy labels anchored to the offending span.
+That answers *"is the claim true?"*. It does **not** answer *"what is this
+person doing to the conversation?"* — narrowing an opponent's position,
+patching a damaged claim with a new story, redefining a word to dodge the
+evidence, changing their account once it's cornered.
+
+Phase 13 adds the **behavior layer**. The two compose:
+
+> *Claim:* "the Book of Abraham is a translation." → *Assessment (30054):*
+> `unsupported`, stance −1. → *Forensic findings (30056):*
+> `defense/definitional-retreat` anchored to the word *translation*, plus a
+> **diachronic revision** edge showing the word's meaning shifted *after*
+> the Egyptology evidence landed — to preserve the original conclusion.
+
+The framing is borrowed, with attribution, from Dawn McCarty's "forensic
+criminology" segment on *Mormonism Live* (2026-06-10,
+[`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)) — and her
+cybersecurity-flavored vocabulary (narrative patching, semantic inversion,
+cognitive containment, epistemological fog, systemic overextension, trust-
+credential spoofing) is reduced here to its **criminology / thought-reform
+canon** so the taxonomy is citable rather than idiolectic
+([Taxonomy](#maneuver-taxonomy-seeded-from-the-canon)).
+
+It is a **separate artifact** from an assessment because the unit of
+analysis is different in three load-bearing ways:
+
+1. **The subject is a person-in-a-role over time, not a claim.** A finding
+   accrues to an identity (Phase 9 identity layer) playing a declared
+   **role** (apologist / critic / institution / witness / survivor). The
+   same engine must profile *either side* — bias-symmetry is a hard
+   requirement, not a nicety.
+2. **There is no stance and no score.** A finding is a typed, evidence-
+   anchored *observation of structure*. It deliberately carries no numeric
+   confidence (see [the no-verdict rule](#methodology-the-six-rules)).
+3. **Maneuvers are often sequences, not points.** Grooming is *build
+   vulnerability → establish trust → redefine boundaries → apply pressure*;
+   a narrative patch is *damage → cover story → containment*. A single
+   label can't hold an ordered evidence chain; a finding's `anchors[]` can.
+
+## Decisions at a glance
+
+| Question | Decision |
+| --- | --- |
+| Artifact | **New kind `30056` (BehavioralFinding)** — addressable, one per (author, subject, maneuver, anchor-hash); targets a subject by `p`, carries an ordered evidence chain, a maneuver label under NIP-32-style `L`/`l` `xray/forensic` tags, with a **kind-1985 mirror** as the ecosystem-aggregation path. Parallels 30054, *not* an extension of it. |
+| No score | A finding has **no stance, no confidence number.** Instead a bounded **`basis`** enum (`quoted` / `paraphrased` / `behavioral-cue` / `structural-inference`) records *how we know* — a real, checkable statement, not a subjective 0–100. |
+| Falsifiability | A `counter_note` (the exonerating / alternative read) is **required** to save any subject-implicating finding. Each maneuver ships with definition + **indicators** + **counter-indicators**. |
+| Subject + role | Reuses the **Phase 9 identity layer**; a finding references an identity + a `role` from a fixed enum. No new person/account object. |
+| Diachronic story-change | **Extend kind `30055`** with directional `revision/*` relationship values (`narrative-patch`, `recharacterizes`, `walks-back`) linking statement-then → statement-now by the same subject. Additive to a shipped kind; a 30056 finding may *characterize* such an edge. |
+| Taxonomy | New **`src/shared/forensic-taxonomy.js`**, namespace **`xray/forensic`**, six maneuver families seeded from the canon (Sykes & Matza, Freyd/DARVO, Lifton, Popper/Lakatos/agnotology, Finkelhor/Craven, statement analysis). **Reuses** existing `fallacy/*` and `consistency/*` labels where they already coincide. |
+| Local-first | New `behavioral_findings` storage key; the existing `evidence_links` gains the `revision/*` values. Local capture always on; **publishing flag-gated** (`forensicPublishing`, default off). |
+| Report lenses | Dawn's **evidentiary / executive / survivor / editor** views are *render modes over the same findings* in the portal, not different data. |
+| LLM-ready | `suggested_by` (`'user'` \| `'llm:<model>'`) on every finding — her engine is an LLM, so findings are natively `llm:<model>`, human-confirmed, with the anchor + counter-note discipline enforced. |
+| Non-goals (v1) | Truth verdicts on subjects, intent attribution, micro-expression *scoring*, aggregating others' findings (publish-*ready* only), automated detection shipping on by default. |
+
+## Methodology — the six rules
+
+These come straight from the source method and are the spine of the design;
+the taxonomy, the model validation, and the UI all enforce them.
+
+1. **Structure, not intent.** A finding describes the *maneuver*, never the
+   subject's honesty. The method's own words: *"without me saying tell me if
+   they're lying — we don't want to say anything like that"* and *"I don't
+   need to prove that Jacob intends manipulation; the structure functions by
+   reducing the alternative."* The model has **no `lying` / `dishonest` /
+   intent field**, by construction. This is what keeps it bounded in what's
+   real.
+2. **Evidence-bound** ("source-fed, target-fed, evidence-sourced"). A
+   finding **cannot be saved with zero anchors.** Each anchor is a selector
+   into the captured source + the quoted span (+ optional media timestamp).
+3. **Baseline → deviation.** A finding may stand alone *or* reference an
+   established **baseline** for the subject and be flagged as a deviation
+   from it (the signal is the change, not an absolute reading).
+4. **Role-typed and symmetric.** Every finding fixes a subject + role and
+   must be runnable against critics as readily as apologists. The taxonomy
+   carries no side; the acceptance demo profiles both interlocutors.
+5. **Sequences are first-class.** `anchors[]` is ordered; `n > 1` means a
+   multi-step maneuver (the grooming sequence, patch-then-contain).
+6. **Falsifiability discipline.** `counter_note` (required) records the
+   alternative reading; each maneuver definition pairs **indicators** with
+   **counter-indicators** so "what would make this *not* this" is always on
+   the page.
+
+## Subject, role, and baseline (the identity rules)
+
+A finding points at a **subject**, resolved through the Phase 9 identity
+layer (captured commenters/authors as dedup-able identities; cross-platform
+accounts collapsible to one person). Reusing that layer means a subject's
+findings aggregate across captures and platforms for free.
+
+```
+subject_ref {
+  identity_id?     // local identity id (canonical for tracked subjects)
+  pubkey?          // entity/person pubkey when one exists (wire join key)
+  account?         // platform-account handle when no identity is resolved yet
+  label            // display snapshot ("Jacob Hansen") — survives relay churn
+}
+role               // apologist | critic | institution | witness | survivor | other
+```
+
+- **Role enum** lives in `forensic-taxonomy.js` (exhaustive-enum test pins
+  it), wire value lowercased. `institution` covers the "no one coordinates
+  it, yet a unified front emerges" case — findings can target an org pubkey.
+- **Baseline.** A lightweight `forensic_baselines` note per (subject, source)
+  records the subject's established register ("held an even tone across 3
+  sessions; fact-anchored"). A deviation finding sets `baseline_ref`. The
+  baseline is descriptive prose + optional anchors, never a score.
+
+## Data model (local-first)
+
+### BehavioralFinding
+
+Stored under a new `chrome.storage.local` key **`behavioral_findings`** as a
+single id→record map — same JSON-serialized Storage conventions as
+`claim_assessments`, no keypair-registry involvement.
+
+```
+BehavioralFinding {
+  id              // find_<sha256(canonical)[:16]>  — deterministic, idempotent
+                  //   canonical = subjectRef | maneuver | anchorsHash
+  subject_ref     // { identity_id?, pubkey?, account?, label } (above)
+  role            // role enum
+  maneuver        // taxonomy value, e.g. 'defense/ad-hoc-patch',
+                  //   'neutralization/condemn-condemners'
+  anchors: [ {    // ORDERED; >= 1 required; n>1 = sequence
+    selector        // selector array from metadata/anchor-capture.buildSelectors
+    quote           // the offending/illustrative span (export-survivable)
+    source_ref      // { url, url_raw, title?, coord?, event_id? } — where it lives
+    timestamp?      // media offset (seconds) for A/V sources
+    step_note?      // short per-step note (sequence steps)
+  } ]
+  baseline_ref?   // id of a forensic_baselines note this deviates from
+  note            // structural rationale, markdown (the "what the structure does")
+  counter_note    // REQUIRED — the exonerating / alternative reading
+  basis           // 'quoted' | 'paraphrased' | 'behavioral-cue' | 'structural-inference'
+  related_rel?    // optional id of a 30055 revision edge this characterizes
+  suggested_by    // 'user' | 'llm:<model>'  (default 'user')
+  created, updated, publishedAt, publishedEventId, publishedPubkey
+}
+```
+
+- **Validation:** ≥ 1 anchor; non-empty `counter_note`; `maneuver` valid
+  against the taxonomy (standard or custom token grammar, same rails as
+  assessment labels); `basis` in the enum; `role` in the enum; `suggested_by`
+  per `isValidSuggestedBy`. No stance, no score, no intent field exists to
+  validate. Clone the `assessment-model.js` idempotency/markPublished
+  patterns (deterministic id, `markPublished` doesn't bump `updated`,
+  immutable refs except coord/pubkey backfill).
+- **Module:** `src/shared/forensic-model.js`, following `AssessmentModel`.
+
+### Diachronic revision edge (extends `evidence-linker.js` / kind 30055)
+
+A self-serving story-change is a *link between two of the same subject's
+statements over time*. Rather than a new kind, **extend the existing typed-
+link substrate** with three directional values:
+
+- `narrative-patch` — B is a new explanation added after A was damaged, so
+  A's conclusion survives ("the problem isn't solved, it's covered by
+  another story").
+- `recharacterizes` — B redefines a key term from A to dodge evidence
+  (translation → "revelation/inspiration"); the diachronic face of
+  `defense/definitional-retreat`.
+- `walks-back` — B retreats from / softens A once A was cornered.
+
+All three are **directional** (source = earlier statement, target = later),
+joining the existing `contradicts / supports / updates / duplicates`. The
+neutral edge says *"B revises A"*; an optional `30056` finding
+(`related_rel`) says *"this revision instantiates maneuver M by subject S,
+here is the evidence, here is the counter-read"* — keeping neutral-link and
+behavioral-characterization cleanly separated, per Rule 1.
+
+## Maneuver taxonomy (seeded from the canon)
+
+Canonical list in **`src/shared/forensic-taxonomy.js`**, namespace
+**`xray/forensic`**, grouped for the picker, exported flat, pinned by the
+exhaustive-enum test idiom. Each entry carries: canonical name, **source
+citation**, **Dawn-alias**, one-line definition, **indicators**, and
+**counter-indicators**. The custom-label escape hatch and token grammar are
+identical to the assessment taxonomy.
+
+| Family | Canon source | Dawn's term(s) it absorbs |
+| --- | --- | --- |
+| `neutralization/*` | **Sykes & Matza 1957** (+ Klockars' ledger, Minor's extensions) | "attack the questioner" = condemn-condemners |
+| `darvo/*` | **Freyd 1997** | institutional "attack," victim-flip, authority restoration |
+| `thought-reform/*` | **Lifton 1961** (8 criteria) | semantic inversion ≈ loading-the-language; cognitive containment ≈ milieu-control + dispensing-of-existence; credential armor ≈ sacred-science |
+| `defense/*` | **Popper / Lakatos / Proctor (agnotology)** | narrative patching ≈ ad-hoc/immunizing; systemic overextension ≈ degenerating program; epistemological fog ≈ manufactured doubt; framing; presentism |
+| `grooming/*` (ordered) | **Finkelhor preconditions / Craven et al. 2006** | the "behavioral sequence" |
+| `revision/*` (30055 edges) | **statement analysis / SCAN** + existing `consistency/*` | narrative patch over time; recharacterize term |
+
+Member values (v1 seeds all six families):
+
+- **`neutralization/`** `deny-responsibility`, `deny-injury`, `deny-victim`,
+  `condemn-condemners`, `higher-loyalties`, `ledger`, `necessity`,
+  `normalcy`, `deny-negative-intent`.
+- **`darvo/`** `deny`, `attack`, `reverse-victim-offender`.
+- **`thought-reform/`** `milieu-control`, `loading-the-language`,
+  `sacred-science`, `doctrine-over-person`, `dispensing-of-existence`,
+  `demand-for-purity`, `thought-terminating-cliche`.
+- **`defense/`** `ad-hoc-patch`, `immunizing-stratagem`, `manufactured-doubt`,
+  `frame-control`, `definitional-retreat`, `presentism`, `usefulness-pivot`
+  (truth→utility shift), `credibility-armor`.
+- **`grooming/`** `build-vulnerability`, `establish-trust`,
+  `redefine-boundaries`, `apply-pressure`.
+- **`revision/`** (relationship values on 30055, above) `narrative-patch`,
+  `recharacterizes`, `walks-back`.
+
+**Reuse, don't duplicate.** Dawn's "reduction challenge / semantic narrowing"
+*is* the existing `fallacy/strawman`; "false dilemma framing" *is*
+`fallacy/false-dilemma`; "moved goalposts," "flip-flop," and "contradicts
+prior statement" are the existing `consistency/*` labels. A finding may carry
+one of those existing values directly; Phase 13 only *adds* the behavioral /
+institutional families that have no home in the assessment taxonomy.
+
+## Wire format (publish-ready, flag-gated)
+
+Same conventions as 30054/30055: deterministic recomputable `d`, NIP-73
+`i`/`k` anchoring where a URL exists, NIP-32 `L`/`l` + a kind-1985 mirror as
+the aggregation path, multi-letter tags (`role`, `maneuver-step`, `basis`,
+`suggested-by`) **not** relay-indexed (filtering is client-side on
+`#p`/`#l`/`#a` + `kinds`).
+
+### Kind `30056` — BehavioralFinding (new; addressable)
+
+```jsonc
+{
+  "kind": 30056,
+  "tags": [
+    ["d", "find:<sha256(subjectRef|maneuver|anchorsHash)[:16]>"],
+    ["p", "<subject-pubkey>", "", "subject"],          // the profiled subject
+    ["L", "xray/forensic"],
+    ["l", "defense/ad-hoc-patch", "xray/forensic"],    // the maneuver
+    ["role", "apologist"],
+    ["r", "<source-url-verbatim>"],                    // per anchor source
+    ["i", "<normalized-url>"], ["k", "web"],           // NIP-73
+    ["a", "30055:<author>:<rel-d>"],                   // optional: characterized revision edge
+    ["maneuver-step", "0", "<selector-json>", "<ts?>"],// ordered; one per anchor
+    ["maneuver-step", "1", "<selector-json>", "<ts?>"],
+    ["basis", "quoted"],
+    ["suggested-by", "user"],
+    ["client", "xray"]
+  ],
+  "content": "<markdown: note (structure) + counter_note (alternative read)>"
+}
+```
+
+- **Subject by `p` with a `subject` role-marker** (the `['p', pk, '', role]`
+  idiom), so the side panel / portal `{"#p":[subject]}` query pulls a
+  subject's claims, assessments, *and* findings in one filter.
+- **`d` is recomputable** from subjectRef + maneuver + ordered anchors.
+- **Selectors ride in `maneuver-step` tags** (ordered), not content —
+  content is human-readable markdown carrying `note` then `counter_note`
+  under stable headings so a parser can split them.
+- **NIP-32 honesty:** identical posture to 30054 — `l` on a non-1985 kind is
+  formally a self-label, so the NIP draft *defines* that here `l` describes
+  the `p`-referenced subject's maneuver, and the **kind-1985 mirror is the
+  designated aggregation path** (same `L`/`l`, `p`-targeted, behind the same
+  flag). One caveat the draft must call out loudly: unlike the assessment
+  mirror (which avoids labeling the claim author), a forensic mirror **does**
+  put a behavioral label on a person's pubkey — the NIP text must frame these
+  as *structural observations with required counter-reads*, never verdicts,
+  and recommend consumers surface the `counter_note`.
+- **Builder:** `buildBehavioralFindingEvent` in `metadata/builders.js`
+  (`{event, body, dTag}` contract); `parseBehavioralFindingEvent` is new
+  consumer code with first-ever wire tests.
+
+### Kind `30055` — three additive `revision/*` relationship values
+
+No structural change: `narrative-patch`, `recharacterizes`, `walks-back`
+join the `relationship` enum (directional). Additive and safe — old
+consumers ignore unknown relationship values, and the `d` hash already
+includes the relationship string so identity never collides. NIP draft §30055
+gains the three values + a note that they express a subject's diachronic
+account-change (and may be paired with a 30056 finding).
+
+### Feature flag
+
+`FLAGS_DEFAULTS` gains **`forensicPublishing: false`** — gates the publish
+paths for `30056`, the `revision/*` 30055 emission, and the 1985 mirror.
+Local capture / baselines / rollups / export are *not* gated. The SW already
+accepts incoming events of every kind, unchanged.
+
+## UI surfaces
+
+No new service-worker messages (`xray:relay:query` / `xray:relay:publish`
+already pass arbitrary filters / pre-signed events). `behavioral_findings`
+and `forensic_baselines` join the side panel's `chrome.storage.onChanged`
+whitelist.
+
+- **Finding modal** (reuse the `assess-modal.js` pattern): subject + role
+  picker, grouped maneuver picker (+ custom), the **ordered** span-anchor
+  capture (the modal-minimize "mark the span" interaction, repeated per
+  step), `note` + required `counter_note` textareas, `basis` selector. Saving
+  without an anchor or counter-note is blocked at the model.
+- **Findings bar** in the reader, alongside the claims bar: per-subject
+  maneuver badges with the evidence chain expandable; a "mark baseline"
+  affordance.
+- **Cross-statement revision link** reuses the cross-source link modal with
+  the three new `revision/*` types and an optional "characterize this
+  revision" step that opens the finding modal pre-bound to the edge.
+- **Portal (Phase 12) report lenses.** A subject/case view renders the same
+  findings as Dawn's four lenses — **evidentiary** (full chains + counter-
+  notes + sources), **executive** (summary roll-up), **survivor**
+  (validation-oriented), **editor** (prose draft) — hung on the existing
+  entity-spokes / case-dashboard / inspector surfaces. A new
+  `parseBehavioralFindingEvent` feeds the corpus query (kinds list gains
+  `30056`).
+
+## Slice plan (one concern per PR; `claude/phase-13-*`)
+
+- **13.1 — Foundation (local-only, no wire).** `forensic-taxonomy.js` (six
+  families + role enum + basis enum + the indicators/counter-indicators
+  table), `forensic-model.js` + `behavioral_findings` store, baseline note
+  store, validation + idempotency + exhaustive-enum tests. `evidence-linker.js`
+  gains the three `revision/*` values. No UI, no wire.
+- **13.2 — Capture UI.** Finding modal (subject+role, ordered anchors,
+  note/counter-note, basis), findings bar, baseline marking, revision-link
+  flow. Draft PR for smoke-test.
+- **13.3 — Wire builders + NIP draft.** `buildBehavioralFindingEvent`
+  (30056) + `parseBehavioralFindingEvent` (+ first wire tests), 30055
+  `revision/*` emission, `forensicPublishing` flag, NIP_DRAFT.md §30056 +
+  §30055 update + the "structural-observation, not verdict" framing,
+  CHANGELOG + JOURNAL callouts.
+- **13.4 — Portal report lenses.** `parseBehavioralFindingEvent` in the
+  portal corpus query; subject/case lens views (evidentiary / executive /
+  survivor / editor); reconciliation.
+- **13.5 — LLM assist (flag-gated).** A `suggested_by: llm:<model>` pass that
+  proposes findings for human confirmation, enforcing the anchor +
+  counter-note + basis discipline before a draft is acceptable.
+
+## Acceptance demo
+
+The source video is itself the first driving case: capture the Jacob Hansen
+↔ Bill Reel and Jacob Hansen ↔ Alex O'Connor conversations and the Robert
+Gurr debate → mark each subject + role → tag findings with evidence chains
+(`defense/usefulness-pivot` on the truth→useful shift; `defense/definitional-
+retreat` + a `recharacterizes` revision edge on *translation*;
+`grooming/*` sequence on the presentism defense) → **profile Bill too**
+(symmetry check) → open the subject lens: maneuvers, evidence chains,
+counter-notes, and the diachronic revision edges all visible across the
+four report lenses. Reuse the Phase 11 cases (LDS Church v. Dehlin; Bricks &
+Minifigs) as secondary runs.
+
+## Known limitations (accepted for v1)
+
+- **`behavioral-cue` basis is the weakest leg.** Micro-expression / body-
+  language reads are retained per the maintainer's "keep everything" call,
+  but the taxonomy entry for any cue-based finding must pair it with strong
+  counter-indicators, and the NIP framing flags `basis: behavioral-cue` as
+  the lowest-evidentiary tier. It is never aggregated into a "score" because
+  there is no score.
+- **Subject pubkeys are per-install** (same as entity keys) — cross-*user*
+  aggregation of findings about a subject only works between users sharing
+  entity keys (entity-sync). The aggregation phase owns this.
+- **A forensic label on a person's pubkey is reputationally heavier than a
+  claim label.** Mitigated by the required counter-note, the no-intent
+  construction, and the mirror framing — but called out so a future reader
+  doesn't quietly drop the counter-note requirement.
+- **Repeated-short-phrase anchors** resolve to first occurrence (the
+  standing 10.3 limitation) — applies to maneuver-step anchors identically.
+
+## Questions decided 2026-06-14
+
+1. **Separate `30056` finding** (vs. extending 30054) — ✅ confirmed.
+2. **Ship all six maneuver families** in the v1 seed — ✅ confirmed.
+3. **Keep the full `basis` enum** including `behavioral-cue`; no numeric
+   score — ✅ confirmed.
+4. **Land this design doc + roadmap entry now, draft PR** — ✅ confirmed.

--- a/docs/CRIMINOLOGY_DESIGN.md
+++ b/docs/CRIMINOLOGY_DESIGN.md
@@ -1,4 +1,4 @@
-# Forensic findings — behavioral pattern analysis (Phase 13)
+# Forensic findings — behavioral pattern analysis (Phase 14)
 
 **Status:** design **agreed 2026-06-14**. Companion to — and deliberately
 *not* a fork of — the Phase 11 assessment layer
@@ -7,6 +7,15 @@ judges whether a *claim* is true, a **forensic finding** names a
 *behavioral maneuver* a subject performs around the truth — an evasion, a
 defense, a self-serving revision — and binds it to evidence, **without
 rendering a verdict on the subject's honesty or intent.**
+
+**Builds on Phase 13 (the epistemic audit; `docs/EPISTEMIC_AUDIT_KICKOFF.md`).**
+Phase 14 is a *separate* feature that sits on top of the epistemic-audit
+layer, which must merge to `main` first. The two are kept wire-disjoint on
+purpose: the audit owns kinds **`30056–30061`** and the `epistemicAuditing`
+flag, so this phase takes **`30062`** for its `BehavioralFinding` and the
+distinct `forensicPublishing` flag. (It reuses Phase 11's kind `30055` for
+the `revision/*` edges and kind `30054`/`1985` idioms — those are the
+assessment layer, not the audit's.)
 
 ## What this is, and why it's separate from assessments
 
@@ -17,10 +26,10 @@ person doing to the conversation?"* — narrowing an opponent's position,
 patching a damaged claim with a new story, redefining a word to dodge the
 evidence, changing their account once it's cornered.
 
-Phase 13 adds the **behavior layer**. The two compose:
+Phase 14 adds the **behavior layer**. The two compose:
 
 > *Claim:* "the Book of Abraham is a translation." → *Assessment (30054):*
-> `unsupported`, stance −1. → *Forensic findings (30056):*
+> `unsupported`, stance −1. → *Forensic findings (30062):*
 > `defense/definitional-retreat` anchored to the word *translation*, plus a
 > **diachronic revision** edge showing the word's meaning shifted *after*
 > the Egyptology evidence landed — to preserve the original conclusion.
@@ -54,11 +63,11 @@ analysis is different in three load-bearing ways:
 
 | Question | Decision |
 | --- | --- |
-| Artifact | **New kind `30056` (BehavioralFinding)** — addressable, one per (author, subject, maneuver, anchor-hash); targets a subject by `p`, carries an ordered evidence chain, a maneuver label under NIP-32-style `L`/`l` `xray/forensic` tags, with a **kind-1985 mirror** as the ecosystem-aggregation path. Parallels 30054, *not* an extension of it. |
+| Artifact | **New kind `30062` (BehavioralFinding)** — addressable, one per (author, subject, maneuver, anchor-hash); targets a subject by `p`, carries an ordered evidence chain, a maneuver label under NIP-32-style `L`/`l` `xray/forensic` tags, with a **kind-1985 mirror** as the ecosystem-aggregation path. Parallels 30054, *not* an extension of it. |
 | No score | A finding has **no stance, no confidence number.** Instead a bounded **`basis`** enum (`quoted` / `paraphrased` / `behavioral-cue` / `structural-inference`) records *how we know* — a real, checkable statement, not a subjective 0–100. |
 | Falsifiability | A `counter_note` (the exonerating / alternative read) is **required** to save any subject-implicating finding. Each maneuver ships with definition + **indicators** + **counter-indicators**. |
 | Subject + role | Reuses the **Phase 9 identity layer**; a finding references an identity + a `role` from a fixed enum. No new person/account object. |
-| Diachronic story-change | **Extend kind `30055`** with directional `revision/*` relationship values (`narrative-patch`, `recharacterizes`, `walks-back`) linking statement-then → statement-now by the same subject. Additive to a shipped kind; a 30056 finding may *characterize* such an edge. |
+| Diachronic story-change | **Extend kind `30055`** with directional `revision/*` relationship values (`narrative-patch`, `recharacterizes`, `walks-back`) linking statement-then → statement-now by the same subject. Additive to a shipped kind; a 30062 finding may *characterize* such an edge. |
 | Taxonomy | New **`src/shared/forensic-taxonomy.js`**, namespace **`xray/forensic`**, six maneuver families seeded from the canon (Sykes & Matza, Freyd/DARVO, Lifton, Popper/Lakatos/agnotology, Finkelhor/Craven, statement analysis). **Reuses** existing `fallacy/*` and `consistency/*` labels where they already coincide. |
 | Local-first | New `behavioral_findings` storage key; the existing `evidence_links` gains the `revision/*` values. Local capture always on; **publishing flag-gated** (`forensicPublishing`, default off). |
 | Report lenses | Dawn's **evidentiary / executive / survivor / editor** views are *render modes over the same findings* in the portal, not different data. |
@@ -176,7 +185,7 @@ link substrate** with three directional values:
 
 All three are **directional** (source = earlier statement, target = later),
 joining the existing `contradicts / supports / updates / duplicates`. The
-neutral edge says *"B revises A"*; an optional `30056` finding
+neutral edge says *"B revises A"*; an optional `30062` finding
 (`related_rel`) says *"this revision instantiates maneuver M by subject S,
 here is the evidence, here is the counter-read"* — keeping neutral-link and
 behavioral-characterization cleanly separated, per Rule 1.
@@ -220,7 +229,7 @@ Member values (v1 seeds all six families):
 *is* the existing `fallacy/strawman`; "false dilemma framing" *is*
 `fallacy/false-dilemma`; "moved goalposts," "flip-flop," and "contradicts
 prior statement" are the existing `consistency/*` labels. A finding may carry
-one of those existing values directly; Phase 13 only *adds* the behavioral /
+one of those existing values directly; Phase 14 only *adds* the behavioral /
 institutional families that have no home in the assessment taxonomy.
 
 ## Wire format (publish-ready, flag-gated)
@@ -231,11 +240,11 @@ the aggregation path, multi-letter tags (`role`, `maneuver-step`, `basis`,
 `suggested-by`) **not** relay-indexed (filtering is client-side on
 `#p`/`#l`/`#a` + `kinds`).
 
-### Kind `30056` — BehavioralFinding (new; addressable)
+### Kind `30062` — BehavioralFinding (new; addressable)
 
 ```jsonc
 {
-  "kind": 30056,
+  "kind": 30062,
   "tags": [
     ["d", "find:<sha256(subjectRef|maneuver|anchorsHash)[:16]>"],
     ["p", "<subject-pubkey>", "", "subject"],          // the profiled subject
@@ -282,12 +291,12 @@ join the `relationship` enum (directional). Additive and safe — old
 consumers ignore unknown relationship values, and the `d` hash already
 includes the relationship string so identity never collides. NIP draft §30055
 gains the three values + a note that they express a subject's diachronic
-account-change (and may be paired with a 30056 finding).
+account-change (and may be paired with a 30062 finding).
 
 ### Feature flag
 
 `FLAGS_DEFAULTS` gains **`forensicPublishing: false`** — gates the publish
-paths for `30056`, the `revision/*` 30055 emission, and the 1985 mirror.
+paths for `30062`, the `revision/*` 30055 emission, and the 1985 mirror.
 Local capture / baselines / rollups / export are *not* gated. The SW already
 accepts incoming events of every kind, unchanged.
 
@@ -315,27 +324,27 @@ whitelist.
   (validation-oriented), **editor** (prose draft) — hung on the existing
   entity-spokes / case-dashboard / inspector surfaces. A new
   `parseBehavioralFindingEvent` feeds the corpus query (kinds list gains
-  `30056`).
+  `30062`).
 
 ## Slice plan (one concern per PR; `claude/phase-13-*`)
 
-- **13.1 — Foundation (local-only, no wire).** `forensic-taxonomy.js` (six
+- **14.1 — Foundation (local-only, no wire).** `forensic-taxonomy.js` (six
   families + role enum + basis enum + the indicators/counter-indicators
   table), `forensic-model.js` + `behavioral_findings` store, baseline note
   store, validation + idempotency + exhaustive-enum tests. `evidence-linker.js`
   gains the three `revision/*` values. No UI, no wire.
-- **13.2 — Capture UI.** Finding modal (subject+role, ordered anchors,
+- **14.2 — Capture UI.** Finding modal (subject+role, ordered anchors,
   note/counter-note, basis), findings bar, baseline marking, revision-link
   flow. Draft PR for smoke-test.
-- **13.3 — Wire builders + NIP draft.** `buildBehavioralFindingEvent`
-  (30056) + `parseBehavioralFindingEvent` (+ first wire tests), 30055
-  `revision/*` emission, `forensicPublishing` flag, NIP_DRAFT.md §30056 +
+- **14.3 — Wire builders + NIP draft.** `buildBehavioralFindingEvent`
+  (30062) + `parseBehavioralFindingEvent` (+ first wire tests), 30055
+  `revision/*` emission, `forensicPublishing` flag, NIP_DRAFT.md §30062 +
   §30055 update + the "structural-observation, not verdict" framing,
   CHANGELOG + JOURNAL callouts.
-- **13.4 — Portal report lenses.** `parseBehavioralFindingEvent` in the
+- **14.4 — Portal report lenses.** `parseBehavioralFindingEvent` in the
   portal corpus query; subject/case lens views (evidentiary / executive /
   survivor / editor); reconciliation.
-- **13.5 — LLM assist (flag-gated).** A `suggested_by: llm:<model>` pass that
+- **14.5 — LLM assist (flag-gated).** A `suggested_by: llm:<model>` pass that
   proposes findings for human confirmation, enforcing the anchor +
   counter-note + basis discipline before a draft is acceptable.
 
@@ -372,7 +381,7 @@ Minifigs) as secondary runs.
 
 ## Questions decided 2026-06-14
 
-1. **Separate `30056` finding** (vs. extending 30054) — ✅ confirmed.
+1. **Separate `30062` finding** (vs. extending 30054) — ✅ confirmed.
 2. **Ship all six maneuver families** in the v1 seed — ✅ confirmed.
 3. **Keep the full `basis` enum** including `behavioral-cue`; no numeric
    score — ✅ confirmed.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,46 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-14 — Phase 13: a behavior layer that deliberately renders no verdict
+
+**Tags:** design
+
+Phase 13 (forensic findings, [`docs/CRIMINOLOGY_DESIGN.md`](CRIMINOLOGY_DESIGN.md))
+adds a layer that names *maneuvers* a subject performs around the truth —
+evasions, immunizing defenses, self-serving revisions — as a companion to the
+Phase 11 assessment layer that grades *claims*. The framing is adapted, with
+attribution, from Dawn McCarty's "forensic criminology" segment on
+*Mormonism Live* ([`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)).
+
+Two design choices are the ones a future reader might second-guess, recorded
+here:
+
+- **No verdict, no score — by construction, not by convention.** The model
+  has *no* `lying` / `intent` / `confidence` field. A finding describes
+  structure ("the move narrows the alternative until the religious authority
+  re-enters as safer ground"), never the subject's honesty, and a
+  `counter_note` (the exonerating read) is *required* to save. This mirrors
+  the source method's own rule ("we don't want to say tell me if they're
+  lying") and the maintainer's "bounded in what's real, no subjectivity"
+  constraint. A bounded `basis` enum (`quoted` / `paraphrased` /
+  `behavioral-cue` / `structural-inference`) replaces a numeric score — it
+  states *how we know*, which is checkable; a 0–100 would not be. If a later
+  contributor is tempted to add a severity number or drop the counter-note,
+  this is the entry that says don't.
+- **Separate kind `30056`, not an extension of the `30054` assessment.** The
+  unit differs in three ways that broke reuse: the subject is a
+  person-in-a-role over time (not a claim), there is no stance, and maneuvers
+  are often ordered *sequences* (grooming; patch-then-contain) needing an
+  evidence chain. Diachronic story-changes do reuse the `30055` link
+  substrate (additive `revision/*` values), and the taxonomy *reuses* the
+  existing `fallacy/*` and `consistency/*` labels where Dawn's vocabulary
+  already coincides — the new families are only the behavioral/institutional
+  ones (neutralization, DARVO, thought-reform, immunizing defense, grooming)
+  that had no home in the truth-label taxonomy.
+
+Design only at this point — no code yet; the taxonomy is meant to be reviewed
+before 13.1 lands.
+
 ## 2026-06-11 — Phase 12.7: what the adversarial review caught (two relay-sync bugs + a read-only breach)
 
 **Tags:** bug, design, pattern

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,16 +19,28 @@ or files, and the "so-what" for future readers.
 
 ---
 
-## 2026-06-14 — Phase 13: a behavior layer that deliberately renders no verdict
+## 2026-06-14 — Phase 14: a behavior layer that deliberately renders no verdict
 
 **Tags:** design
 
-Phase 13 (forensic findings, [`docs/CRIMINOLOGY_DESIGN.md`](CRIMINOLOGY_DESIGN.md))
+Phase 14 (forensic findings, [`docs/CRIMINOLOGY_DESIGN.md`](CRIMINOLOGY_DESIGN.md))
 adds a layer that names *maneuvers* a subject performs around the truth —
 evasions, immunizing defenses, self-serving revisions — as a companion to the
 Phase 11 assessment layer that grades *claims*. The framing is adapted, with
 attribution, from Dawn McCarty's "forensic criminology" segment on
 *Mormonism Live* ([`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)).
+
+**Renumbered 13 → 14 (and re-kinded `30056` → `30062`).** This work was first
+drafted as "Phase 13," but a separate, more-mature **Phase 13 = epistemic
+audit** already existed on its own branch chain (`claude/phase-13-*`,
+kinds `30056–30061`, `epistemicAuditing` flag) — built in parallel and not
+yet merged to `main`. To avoid colliding on both the phase number and the
+`30056` kind, this layer becomes **Phase 14** and takes **`30062`**. The two
+are deliberately distinct features; the criminology layer is meant to build
+*on top of* the epistemic audit, so its development is paused until the
+Phase 13 chain merges, then this branch rebases onto it. The forensic
+`revision/*` edges still ride Phase 11's kind `30055` (the assessment link
+substrate), which is unrelated to the audit's kinds.
 
 Two design choices are the ones a future reader might second-guess, recorded
 here:
@@ -45,7 +57,7 @@ here:
   states *how we know*, which is checkable; a 0–100 would not be. If a later
   contributor is tempted to add a severity number or drop the counter-note,
   this is the entry that says don't.
-- **Separate kind `30056`, not an extension of the `30054` assessment.** The
+- **Separate kind `30062`, not an extension of the `30054` assessment.** The
   unit differs in three ways that broke reuse: the subject is a
   person-in-a-role over time (not a claim), there is no stance, and maneuvers
   are often ordered *sequences* (grooming; patch-then-contain) needing an
@@ -57,7 +69,7 @@ here:
   that had no home in the truth-label taxonomy.
 
 Design only at this point — no code yet; the taxonomy is meant to be reviewed
-before 13.1 lands.
+before 14.1 lands.
 
 ## 2026-06-11 — Phase 12.7: what the adversarial review caught (two relay-sync bugs + a read-only breach)
 

--- a/docs/NIP_DRAFT.md
+++ b/docs/NIP_DRAFT.md
@@ -6,7 +6,7 @@ Web Content Annotations, Fact-Checks, and Topic Trust
 
 `draft` `optional`
 
-This NIP defines fourteen event kinds and two tag extensions that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, and epistemic-audit records (per-module surface-scan results, aggregate article audits, a prediction ledger with resolutions, dossier rollup snapshots, and audit disputes — content-addressed to the exact text scored) — and lets readers query, rank, and surface that metadata in context.
+This NIP defines fifteen event kinds and two tag extensions that together let users publish structured, anchored metadata about web content — atomized claims, annotations, fact-checks, ratings, personal assessments, claim relationships, topic-scoped trust assertions, helpfulness votes, epistemic-audit records (per-module surface-scan results, aggregate article audits, a prediction ledger with resolutions, dossier rollup snapshots, and audit disputes — content-addressed to the exact text scored), and behavioral findings (named maneuvers a subject performs around the truth, evidence-anchored, with no verdict on intent) — and lets readers query, rank, and surface that metadata in context.
 
 It composes with rather than replaces:
 
@@ -329,7 +329,7 @@ Addressable. A typed link between two claims — the cross-source contradiction 
 }
 ```
 
-- `relationship` MUST be one of: `contradicts`, `supports`, `updates`, `duplicates`.
+- `relationship` MUST be one of: `contradicts`, `supports`, `updates`, `duplicates`, or the directional **`revision/*` story-change values** `narrative-patch`, `recharacterizes`, `walks-back` (Phase 14 / kind 30062). The latter three express how the *same subject's* account changed over time — `source` = the earlier statement, `target` = the later — and MAY be characterized by a kind-30062 finding (which references this link by `a` coordinate). They are never symmetric.
 - **`contradicts` and `duplicates` are symmetric**: the two coordinates MUST be sorted lexically — both in the `d` hash and in `a`-tag order — so the same logical link republishes the same `d` regardless of creation direction, and the `source`/`target` markers carry no meaning. **`supports` and `updates` are directional** (source → target) and hash in semantic order.
 - The `d` MUST be recomputable from the two `a` tags + `relationship`. The 4th-position markers on `a`/`e` follow the same role-marker idiom as `p` tags elsewhere in this NIP.
 - `r` tags carry each claim's `r` verbatim, `i` tags the normalized forms (values deduplicated when both claims share a URL); one `k` = `web` accompanies them. Relationship events anchor to the claims (via `a`), not to pages — the URL tags exist for `#r`-join convenience and MAY be omitted when an endpoint's URL is unknown.
@@ -538,6 +538,39 @@ Addressable. A challenge to an audit record — module result, aggregate audit, 
 - **`status` is filer-asserted only** (`open`/`withdrawn`). Upheld/rejected outcomes are NOT wire fields here — they derive from adjudication events (a separate, future kind authored by other pubkeys) and from superseding audits that `e`-tag this dispute with role `resolves-dispute`. A dispute never edits its target; an upheld dispute produces a NEW audit that supersedes the original, and both remain visible.
 - A rejected dispute remains visible too — the record of what was challenged and survived is part of a score's credibility.
 
+## Kind 30062 — BehavioralFinding
+
+Addressable. Names a **maneuver** a subject performs around the truth — an evasion, an immunizing defense, a self-serving revision — and binds it to an ordered evidence chain. It is the companion to kind 30054 (Assessment): where an assessment grades a *claim*, a finding describes a *subject's move*, and **renders no verdict on the subject's honesty or intent.**
+
+```jsonc
+{
+  "kind": 30062,
+  "tags": [
+    ["d", "find:<sha256(subjectPubkey + '|' + maneuver + '|' + anchorsHash).slice(0,16)>"],
+    ["p", "<subject-pubkey>", "", "subject"],
+    ["L", "xray/forensic"],
+    ["l", "defense/ad-hoc-patch", "xray/forensic"],
+    ["role", "apologist"],
+    ["r", "<source-url-verbatim>"], ["i", "<normalized-url>"], ["k", "web"],
+    ["a", "30055:<author>:<rel-d>"],                       // optional: a revision/* edge this characterizes
+    ["maneuver-step", "0", "<quote>", "<selector-json>", "<timestamp?>"],
+    ["maneuver-step", "1", "<quote>", "<selector-json>", "<timestamp?>"],
+    ["basis", "quoted"],
+    ["suggested-by", "user"],
+    ["client", "<client>"]
+  ],
+  "content": "<structural note>\n\n### Counter-read\n\n<the required alternative reading>"
+}
+```
+
+- The subject is referenced by `p` with a `subject` slot-4 marker. A finding publishes against a **resolved subject pubkey**; the local subject reference (a display label or platform handle) never hits the wire.
+- `l` carries the **maneuver** under the `xray/forensic` namespace. Values are drawn from a canon-seeded vocabulary (`neutralization/*`, `darvo/*`, `thought-reform/*`, `defense/*`, `grooming/*`) with the same custom-token escape hatch as kind 30054 labels; a maneuver MAY also reuse a 30054 `fallacy/*` or `consistency/*` value where the move *is* one of those.
+- `maneuver-step` tags are **ordered** `[index, quote, selector-json, timestamp]`; `n > 1` is a multi-step sequence (e.g. a grooming chain). `anchorsHash` = `sha256(JSON of [[quote, selector-json, timestamp], …])`, so the `d` is recomputable from the `maneuver-step` tags alone. Multi-letter tags (`role`, `maneuver-step`, `basis`, `suggested-by`) are not relay-indexed.
+- `basis` is one of `quoted` / `paraphrased` / `behavioral-cue` / `structural-inference` — *how we know*, in place of any numeric score. **There is no score, stance, or confidence on this kind**, by construction.
+- `content` carries the structural `note`, then the **REQUIRED counter-read** under the last `### Counter-read` heading — the alternative/exonerating reading. A finding with no counter-read is malformed.
+- **Firewall:** a behavioral finding is a distinct aggregation signal. It never carries `stance`, `rating-value`, `score`/`confidence`, or the `xray/assessment` namespace; consumers MUST NOT merge findings with assessments (30054), fact-checks (30051), or audits (30056–30061).
+- **NIP-32 mirror + the verdict caveat.** A kind-1985 event MAY mirror the maneuver (`L`/`l` `xray/forensic`, `p` = the subject, `r` = the source URL) as the plain-NIP-32 aggregation path. Unlike the 30054 mirror, this one *does* label a person's pubkey — so consumers SHOULD treat it as a **structural observation, not a verdict**, and SHOULD surface the richer 30062's required counter-read alongside it. The mirror carries no `score` and asserts no intent.
+
 ## Kind 30023 — `responds-to` tag (extension)
 
 A long-form article (kind 30023) MAY declare that it responds to one or more other pieces of content. Each response is a separate `responds-to` tag:
@@ -618,5 +651,5 @@ This NIP does not specify a ranking algorithm. Recommended approaches:
 
 ## Reference implementations
 
-- [x-ray browser extension](https://github.com/bryanmatthewsimonson/xray) — shipping kinds 30040 + 30050 + the `responds-to` and `x` extensions; 30054/30055 builders with publishing flag-gated (Phase 11); 30056–30059 fully implemented — builders, parsers, a flag-gated ordered publish path, and portal read surfaces (Phase 13); 30060/30061 builders + parsers implemented, publish paths deferred (the dossier stays derived; disputes are wire-format-only in v1).
+- [x-ray browser extension](https://github.com/bryanmatthewsimonson/xray) — shipping kinds 30040 + 30050 + the `responds-to` and `x` extensions; 30054/30055 builders with publishing flag-gated (Phase 11); 30056–30059 fully implemented — builders, parsers, a flag-gated ordered publish path, and portal read surfaces (Phase 13); 30060/30061 builders + parsers implemented, publish paths deferred (the dossier stays derived; disputes are wire-format-only in v1); 30062 behavioral-finding builder + parser + the kind-1985 mirror and the `revision/*` 30055 values, publishing flag-gated (Phase 14).
 - *(second client, TBD pre-merge)*

--- a/docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md
+++ b/docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md
@@ -1,0 +1,223 @@
+# Phase 14.5 — LLM-assist (in-extension suggestion engine) — implementation prompt
+
+> This file is the **handoff prompt** for the Claude Code session that
+> implements Phase 14.5. It is self-contained: read it, read the files it
+> points at, then build. Everything in the X-Ray repo's `CLAUDE.md`
+> applies (conventions, build, flags, message bus, Firefox floor).
+
+## Task
+
+Build an **in-extension LLM-assist**: a user-invoked pass that calls the
+**Anthropic Messages API directly from the background service worker** and
+proposes **capture artifacts** from the open article — **entities,
+claims, assessments, claim relationships, and forensic findings** (and,
+secondarily, baselines and `revision/*` edges) — for the user to
+**review and confirm**. Every accepted artifact is created through the
+**existing models** with provenance `suggested_by: 'llm:<model>'`.
+**Nothing auto-saves; nothing auto-publishes.** The whole feature is
+gated by a flag (default off) *and* requires a user-supplied API key (a
+second consent gate), because the article text leaves the device.
+
+This completes Phase 14 (`docs/CRIMINOLOGY_DESIGN.md` slice plan, 14.5).
+The `suggested_by: 'user' | 'llm:<model>'` seam is **already** baked into
+every model and wire builder — so the work is: (1) call the API safely,
+(2) turn its structured output into validated `create()` inputs, (3) a
+review UI that funnels accepts into the existing capture models.
+
+## Read first (load-bearing context)
+
+- **`CLAUDE.md`** — build (`esbuild`, no transpile), 4-space indent, the
+  `xray:*` message bus, `Utils.log`/`Utils.error` (no bare console), the
+  flag pattern, the Firefox `gecko.strict_min_version: 128.0` floor, the
+  "private keys never leave" rule.
+- **`docs/CRIMINOLOGY_DESIGN.md`** — the forensic layer + the **six
+  methodology rules** (no verdict / evidence-bound / baseline / role-
+  symmetric / sequences / falsifiability) and the **LLM-ready** notes.
+- **`docs/ASSESSMENTS_DESIGN.md`** — claims (30040), assessments (30054),
+  relationships (30055).
+- **The models you will feed** (read their `create()` inputs + validators):
+  - `src/shared/entity-model.js` — `EntityModel.create({name, type, …})`,
+    `keypair`, `ENTITY_TYPES`/`ENTITY_ICONS`.
+  - `src/shared/claim-model.js` — `ClaimModel.create({text, source_url,
+    anchor, about, type, suggested_by})`.
+  - `src/shared/assessment-model.js` — `AssessmentModel.create({claim_ref,
+    stance, labels, rationale, suggested_by})`; `src/shared/assessment-taxonomy.js`
+    (`ASSESSMENT_LABEL_GROUPS`, `STANCE_VALUES`, `isValidLabel`,
+    `isValidSuggestedBy`, `CLAIM_RELATIONSHIPS`, `REVISION_RELATIONSHIPS`).
+  - `src/shared/evidence-linker.js` — `EvidenceLinker.create({source_claim_id,
+    target_claim_id, relationship, note, suggested_by})`.
+  - `src/shared/forensic-model.js` — `ForensicModel.create({subject_ref,
+    role, maneuver, anchors, note, counter_note, basis, suggested_by})` +
+    `ForensicBaseline`; `src/shared/forensic-taxonomy.js`
+    (`FORENSIC_MANEUVER_GROUPS`, `MANEUVER_GUIDE`, `ROLES`, `BASIS_VALUES`,
+    `isValidManeuver`/`isValidRole`/`isValidBasis`).
+- **The capture UIs** the review panel should reuse / mirror (do NOT
+  invent parallel save paths): `src/reader/entity-tagger.js`,
+  `src/reader/claim-extractor.js` (`openClaimModal`),
+  `src/shared/assess-modal.js`, `src/shared/forensic-modal.js`,
+  `src/reader/findings-section.js`, and the reader wiring in
+  `src/reader/index.js`.
+- **Anchoring**: `src/shared/metadata/anchor-capture.js`
+  (`captureFromRange`, `buildSelectors`) and how the reader rehydrates a
+  quote to a span (`rehydrateClaimMarks` / `resolveSelectors`). The LLM
+  proposes a **verbatim quote**; you resolve it to a selector against the
+  article body so proposals carry real anchors.
+- **The flag + external-API-key precedent**: `src/shared/metadata/feature-flags.js`
+  (`epistemicAuditing`, `forensicPublishing`), and the Options "Epistemic
+  audits" section (`src/options/options.html` + `src/options/index.js`)
+  with its key/disclosure pattern. NOTE: the audit scorer is a *companion
+  CLI*; **14.5 is in-extension** instead.
+- **The message bus + SW**: `src/background/index.js` (how `xray:*`
+  handlers register; the relay pool lives here because page CSP blocks
+  page-context network — **the LLM call must run here too**).
+- **The `claude-api` skill** in this harness (or current Anthropic docs)
+  for the **current Messages API shape, tool-use, and model IDs** —
+  default to the latest capable Claude model; **do not hard-code an old
+  model id from memory.**
+
+## Branch
+
+Develop on **`claude/x-ray-criminology-framework-t2cegk`** (the Phase 14
+branch / PR #71), as slices **14.5.x**. If PR #71 has already merged to
+`main`, branch from `main` instead. Keep build + `npm test` + `web-ext
+lint --self-hosted` green before every push, and open/refresh a draft PR.
+
+## Architecture
+
+1. **Service-worker LLM client** — `src/shared/llm-client.js`, invoked
+   from `src/background/index.js` via a new message **`xray:llm:suggest`**
+   (request: `{ task, articleText, articleUrl, context }`; response:
+   `{ ok, proposals } | { ok:false, error }`). It:
+   - reads the API key from `chrome.storage.local` (a dedicated secret key,
+     e.g. `xray:llm:key` — NEVER `preferences`, never exported);
+   - reads model + flag from settings;
+   - calls `https://api.anthropic.com/v1/messages` with `fetch`, the
+     `x-api-key`, `anthropic-version`, and **`anthropic-dangerous-direct-browser-access: true`**
+     headers (browser-origin calls need this; see Gotchas);
+   - uses **tool-use / structured output** so the model returns JSON that
+     maps onto the model `create()` inputs (one tool per artifact type, or
+     one tool whose schema is a discriminated union keyed by `kind`);
+   - is the ONLY module that touches the API; everything else consumes
+     validated proposals.
+   - `manifest.json` gains a host permission for `https://api.anthropic.com/*`
+     (and the matching `host_permissions`/`optional_host_permissions`;
+     don't widen beyond the API host).
+
+2. **Settings** — Options → Advanced gains an **"LLM assist"** section:
+   an API-key field (password input; stored under the secret key; a
+   "clear key" affordance), a **model picker** (defaults to the latest
+   capable Claude; populate from the `claude-api` skill), and the
+   **`llmAssist` flag** (default off) with a disclosure that the article
+   text is sent to Anthropic and that suggestions are drafts requiring
+   confirmation. Mirror the `epistemicAuditing` toggle wiring.
+
+3. **The suggestion → confirmation loop** (reader) — a **"✨ Suggest…"**
+   control (in the reader chrome and/or the selection popover) runs a pass
+   for the chosen task(s). Results land in a **review panel** grouped by
+   artifact type. For each proposal the user can **Accept / Edit / Reject**;
+   Accept creates the artifact through the existing model with
+   `suggested_by: 'llm:<model>'`; Edit opens the matching capture modal
+   pre-filled (the user's edits make it `suggested_by: 'user'` only if they
+   change load-bearing content — your call, but record the provenance
+   honestly). **Reject discards.** Publishing stays behind the existing
+   publish flags — suggestion never publishes.
+
+4. **Validation firewall** — every proposal is validated against the SAME
+   model validators that protect manual capture before it can be accepted.
+   A proposal that fails (e.g. a finding with no counter-note, a claim with
+   no text, a bad maneuver/label) is shown as **rejected-with-reason**, not
+   silently dropped and never saved.
+
+## Per-artifact suggestion spec — cover ALL of these
+
+| Task | Proposes | Maps to | Hard requirements the validator enforces |
+| --- | --- | --- | --- |
+| **entities** | people / orgs / places / cases named in the text | `EntityModel.create({name, type})` | `type ∈ ENTITY_TYPES`; dedupe against the existing registry (offer "tag existing" vs "create new") |
+| **claims** | atomized assertions + their about-entities | `ClaimModel.create({text, source_url, anchor, about, type})` | non-empty `text`; a **verbatim quote** resolved to an `anchor`; `about` entities suggested too (link to the entity proposals) |
+| **assessments** | stance + issue labels on a claim | `AssessmentModel.create({claim_ref, stance, labels, rationale})` | `stance ∈ −2..2 \| null`; labels from `ASSESSMENT_LABEL_GROUPS` (or the custom-token grammar); at least one of stance/labels; per-label anchors where possible |
+| **relationships** | contradicts / supports / updates / duplicates between two claims | `EvidenceLinker.create({source_claim_id, target_claim_id, relationship, note})` | `relationship ∈ CLAIM_RELATIONSHIPS`; both endpoints must exist (suggest the linked claims first) |
+| **findings** *(the criminology layer)* | a named **maneuver** a subject performs | `ForensicModel.create({subject_ref, role, maneuver, anchors, note, counter_note, basis})` | **NO verdict / intent** — describe structure only; `maneuver ∈` the canon taxonomy (or custom token); `role ∈ ROLES`; **≥1 evidence anchor with a verbatim quote**; **`counter_note` REQUIRED** (the exonerating read); `basis ∈ BASIS_VALUES`; reject anything missing the counter-note |
+| **revision edges** *(secondary)* | a subject's self-serving story-change between two statements | `EvidenceLinker.create({…, relationship: 'narrative-patch'\|'recharacterizes'\|'walks-back'})` | both statement-claims must exist; directional (earlier → later) |
+| **baselines** *(secondary)* | a subject's established register | `ForensicBaseline.create({subject_ref, note, source_url})` | descriptive note, no score |
+
+The system prompt MUST embed, per task:
+- for **findings**: the `MANEUVER_GUIDE` (definition + indicators +
+  counter-indicators per maneuver) and the six rules — instruct the model
+  to **describe the move, never assert intent or a truth verdict**, to
+  **always provide a counter-read**, and to set `basis` honestly
+  (`quoted` only when the evidence is a verbatim span; `structural-inference`
+  / `behavioral-cue` otherwise);
+- for **assessments**: the label taxonomy + that stance is a personal
+  judgment, not a fact verdict;
+- for all: return **verbatim quotes** (so anchoring works), and emit
+  `suggested_by: 'llm:<model>'`.
+
+## Privacy, security, consent (hard requirements)
+
+- **Off by default** (`llmAssist` flag) AND **no key = no calls** (the
+  second gate). The first run discloses that the article text is sent to
+  Anthropic.
+- The **API key is a secret**: stored under its own `chrome.storage.local`
+  key, never in `preferences`, **never included in entity-export / case
+  bundles**, never logged (`Utils.log`/`error` must not print it), never
+  committed. Add it to whatever "erase all" already clears.
+- **Human-in-the-loop is non-negotiable**: nothing the LLM proposes is
+  saved without an explicit Accept, and nothing is published by this
+  feature (publishing stays behind `assessmentPublishing` /
+  `forensicPublishing`).
+- **Cost/rate**: one pass per explicit user action; no background polling;
+  surface a token/cost estimate if cheap to do. Handle 401/429/5xx with a
+  clear toast, not a crash.
+
+## Slice plan (one concern per PR)
+
+- **14.5.1 — client + settings + manifest.** `llm-client.js` (SW fetch,
+  key/model/flag, tool-use scaffold, error mapping), the `xray:llm:suggest`
+  handler in `background/index.js`, the Options "LLM assist" section
+  (key + model + flag), the `llmAssist` flag, and the
+  `api.anthropic.com` host permission. Verify with a trivial round-trip.
+- **14.5.2 — schema + prompts + anchoring.** The per-task tool schemas,
+  the system prompts (taxonomy + rules embedded), the proposal validators
+  (reuse the model validators), and quote→selector resolution. Pure,
+  heavily unit-tested with a **mocked** client (no live API in CI).
+- **14.5.3 — review UI.** The reader "✨ Suggest…" control + the grouped
+  review panel (Accept/Edit/Reject per proposal) that funnels accepts into
+  the existing models with `suggested_by: 'llm:<model>'`.
+- **14.5.4 — tests + smoke + docs.** Mock-client tests for the full
+  mapping + the no-verdict/counter-note enforcement; `SMOKE_TEST.md`
+  §Phase 14.5; CHANGELOG; ROADMAP 14.5 → done.
+
+## Acceptance criteria
+
+- With the flag on + a key set, "✨ Suggest…" on a captured article
+  returns proposals for **entities, claims, assessments, relationships,
+  and findings**, each reviewable; Accept creates the real artifact
+  (visible in the claims/findings bars) tagged `suggested_by: 'llm:<model>'`.
+- A proposed **finding always carries a counter-note and ≥1 quoted
+  anchor**, or it is shown rejected-with-reason and never saved; no
+  proposal carries a stance/score/intent on a person.
+- Flag **off** or **no key** ⇒ the Suggest control is absent/disabled and
+  **zero** network calls are made.
+- The key never appears in exports/logs; `npm test`, build, and
+  `web-ext lint --self-hosted` are green; Firefox ≥128 behaves identically.
+
+## Gotchas (don't relearn these the hard way)
+
+- **Browser-origin Anthropic calls** need
+  `anthropic-dangerous-direct-browser-access: true` (and CORS is enabled
+  for that header). Run the `fetch` in the **service worker**, not a page
+  with site CSP. If a future API change blocks direct browser access,
+  fall back to documenting a user-run proxy — do not ship a hidden one.
+- **MV3 host permissions**: add `https://api.anthropic.com/*`; keep it
+  narrow. Re-read the flag/key on each SW wake (the SW sleeps).
+- **Anchoring drift**: the model's "verbatim" quote may not be byte-exact;
+  resolve with a tolerant text-find, and if it fails, keep the proposal
+  with the quote but a null selector (the model layer already tolerates a
+  quote-only anchor — except findings, which need the quote non-empty).
+- **Provenance honesty**: don't relabel an LLM proposal as `user` just
+  because it passed through a modal; only the user's substantive edits
+  should change provenance. Keep `isValidSuggestedBy` happy
+  (`llm:<non-blank-model>`).
+- **No new save/publish paths** — reuse `EntityModel` / `ClaimModel` /
+  `AssessmentModel` / `EvidenceLinker` / `ForensicModel`. The wire +
+  reconciliation already understand `suggested_by`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,6 +62,9 @@ Phase 12 ████████████████████  complete 
                                 portal (docs/PORTAL_DESIGN.md). 12.1–12.7
                                 shipped incl. adversarial-review fixes;
                                 §Phase 12 smoke-run pending
+Phase 13 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
+                                behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
+                                13.1–13.5 not yet built
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -914,6 +917,56 @@ Slices (one PR each):
 - ✅ **12.7** Hardening — three-lens adversarial review (20 confirmed
   findings fixed, incl. two relay-sync bugs and a read-only breach;
   JOURNAL 2026-06-11), SMOKE_TEST §Phase 12, docs pass. — #55
+
+---
+
+## Phase 13 — Forensic findings (behavioral-pattern layer) ⏳ design agreed
+
+Where Phase 11 grades whether a *claim* is true, Phase 13 names what a
+*subject* is doing around the truth — an evasion, a defense, a self-serving
+revision — and binds it to evidence, **without a verdict on honesty or
+intent**. A **behavioral finding** (new kind `30056`) targets a subject (the
+Phase 9 identity layer) in a declared **role** (apologist / critic /
+institution / witness / survivor), names a **maneuver** from a taxonomy
+seeded from the criminology / thought-reform canon (Sykes & Matza
+neutralization, Freyd/DARVO, Lifton thought-reform, Popper/Lakatos immunizing
+defenses, Finkelhor/Craven grooming sequence, statement-analysis revision),
+and carries an **ordered evidence chain** plus a **required counter-note**
+(the alternative reading). No stance, no score — a bounded `basis` enum
+(`quoted` / `paraphrased` / `behavioral-cue` / `structural-inference`)
+records *how we know*. Diachronic story-changes extend kind `30055` with
+directional `revision/*` edges (`narrative-patch` / `recharacterizes` /
+`walks-back`). Local-first, publish-ready (flag-gated `forensicPublishing`,
+kind-1985 mirror), LLM-ready (`suggested_by`). The portal renders the same
+findings as Dawn McCarty's four report lenses (evidentiary / executive /
+survivor / editor). Companion to — not a fork of — the assessment layer.
+
+Full design, wire formats, methodology rules, and the canon→vocabulary map:
+[`docs/CRIMINOLOGY_DESIGN.md`](CRIMINOLOGY_DESIGN.md) — design agreed
+2026-06-14.
+
+Slices (one PR each):
+
+- ⏳ **13.1** Foundation — `forensic-taxonomy.js` (six families + role/basis
+  enums + indicators/counter-indicators), `forensic-model.js` +
+  `behavioral_findings` store, baselines, `evidence-linker.js` `revision/*`
+  values; tests. No UI, no wire.
+- ⏳ **13.2** Capture UI — finding modal (subject+role, ordered anchors,
+  note + required counter-note, basis), findings bar, baseline marking,
+  revision-link flow.
+- ⏳ **13.3** Wire builders + NIP draft — `30056`
+  `buildBehavioralFindingEvent` + `parseBehavioralFindingEvent`, 30055
+  `revision/*` emission, `forensicPublishing` flag, §30056/§30055 NIP text
+  with the "structural-observation, not verdict" framing.
+- ⏳ **13.4** Portal report lenses — corpus parser + subject/case lens views
+  (evidentiary / executive / survivor / editor) + reconciliation.
+- ⏳ **13.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal
+  pass enforcing the anchor + counter-note + basis discipline.
+
+Acceptance demo: the source video itself
+([`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)) — profile both
+interlocutors (the symmetry check), with evidence chains, counter-notes, and
+diachronic revision edges visible across the four lenses.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,9 +62,9 @@ Phase 12 ████████████████████  complete 
                                 portal (docs/PORTAL_DESIGN.md). 12.1–12.7
                                 shipped incl. adversarial-review fixes;
                                 §Phase 12 smoke-run pending
-Phase 13 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
+Phase 14 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
                                 behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
-                                13.1–13.5 not yet built
+                                14.1–14.5 not yet built
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -920,12 +920,19 @@ Slices (one PR each):
 
 ---
 
-## Phase 13 — Forensic findings (behavioral-pattern layer) ⏳ design agreed
+## Phase 14 — Forensic findings (behavioral-pattern layer) ⏳ design agreed
 
-Where Phase 11 grades whether a *claim* is true, Phase 13 names what a
+**Builds on Phase 13 (the epistemic audit).** Phase 13 must land on `main`
+first; this layer sits on top of it and is a *distinct* feature. The two use
+**disjoint wire kinds** — the audit owns `30056–30061` (+ `epistemicAuditing`
+flag), so this layer takes **`30062`** for `BehavioralFinding` (+ a separate
+`forensicPublishing` flag). New criminology development is paused until the
+Phase 13 chain merges, at which point this branch rebases onto it.
+
+Where Phase 11 grades whether a *claim* is true, Phase 14 names what a
 *subject* is doing around the truth — an evasion, a defense, a self-serving
 revision — and binds it to evidence, **without a verdict on honesty or
-intent**. A **behavioral finding** (new kind `30056`) targets a subject (the
+intent**. A **behavioral finding** (new kind `30062`) targets a subject (the
 Phase 9 identity layer) in a declared **role** (apologist / critic /
 institution / witness / survivor), names a **maneuver** from a taxonomy
 seeded from the criminology / thought-reform canon (Sykes & Matza
@@ -947,20 +954,20 @@ Full design, wire formats, methodology rules, and the canon→vocabulary map:
 
 Slices (one PR each):
 
-- ⏳ **13.1** Foundation — `forensic-taxonomy.js` (six families + role/basis
+- ⏳ **14.1** Foundation — `forensic-taxonomy.js` (six families + role/basis
   enums + indicators/counter-indicators), `forensic-model.js` +
   `behavioral_findings` store, baselines, `evidence-linker.js` `revision/*`
   values; tests. No UI, no wire.
-- ⏳ **13.2** Capture UI — finding modal (subject+role, ordered anchors,
+- ⏳ **14.2** Capture UI — finding modal (subject+role, ordered anchors,
   note + required counter-note, basis), findings bar, baseline marking,
   revision-link flow.
-- ⏳ **13.3** Wire builders + NIP draft — `30056`
+- ⏳ **14.3** Wire builders + NIP draft — `30062`
   `buildBehavioralFindingEvent` + `parseBehavioralFindingEvent`, 30055
-  `revision/*` emission, `forensicPublishing` flag, §30056/§30055 NIP text
+  `revision/*` emission, `forensicPublishing` flag, §30062/§30055 NIP text
   with the "structural-observation, not verdict" framing.
-- ⏳ **13.4** Portal report lenses — corpus parser + subject/case lens views
+- ⏳ **14.4** Portal report lenses — corpus parser + subject/case lens views
   (evidentiary / executive / survivor / editor) + reconciliation.
-- ⏳ **13.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal
+- ⏳ **14.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal
   pass enforcing the anchor + counter-note + basis discipline.
 
 Acceptance demo: the source video itself

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1127,6 +1127,12 @@ Slices (one PR each):
   kind-1985 maneuver mirror, 30055 `revision/*` emission, the
   `forensicPublishing` flag, §30062/§30055 NIP text with the
   "structural-observation, not verdict" framing + firewall clause.
+- ✅ **14.3b** Publish wiring — `forensic-publish.js` selectors
+  (subject-pubkey resolution via the entity registry, staleness/mirror
+  gates) + a flag-gated reader publish batch (findings → mirrors →
+  revision edges), folded into the publish-summary. Revision edges leave
+  the `assessmentPublishing` link batch (they publish under
+  `forensicPublishing`).
 - ⏳ **14.4** Portal report lenses — corpus parser + subject/case lens views
   (evidentiary / executive / survivor / editor) + reconciliation.
 - ⏳ **14.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1139,8 +1139,13 @@ Slices (one PR each):
   / survivor / editor) over the same findings, never averaged; `30062`
   joins `LEDGERED_KINDS` for reconciliation (the wire d-tag recorded at
   publish).
-- ⏳ **14.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal
-  pass enforcing the anchor + counter-note + basis discipline.
+- ⏳ **14.5** LLM assist (flag-gated, **in-extension Anthropic call**) — a
+  user-invoked pass that proposes **all** capture artifacts (entities,
+  claims, assessments, relationships, findings — and baselines / revision
+  edges) for human review, created with `suggested_by: llm:<model>`;
+  enforces the anchor + counter-note + basis discipline; nothing
+  auto-saves or auto-publishes. Implementation prompt:
+  [`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`](PHASE_14_5_LLM_ASSIST_KICKOFF.md).
 
 Acceptance demo: the source video itself
 ([`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)) — profile both

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,7 +73,7 @@ Phase 13 ███████████░░░░░░░░░  in progre
                                 pending smoke-test
 Phase 14 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
                                 behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
-                                builds on Phase 13; 14.1–14.3 built, 14.4–14.5 pending
+                                builds on Phase 13; 14.1–14.4 built, 14.5 pending
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -1133,8 +1133,12 @@ Slices (one PR each):
   revision edges), folded into the publish-summary. Revision edges leave
   the `assessmentPublishing` link batch (they publish under
   `forensicPublishing`).
-- ⏳ **14.4** Portal report lenses — corpus parser + subject/case lens views
-  (evidentiary / executive / survivor / editor) + reconciliation.
+- ✅ **14.4** Portal report lenses — `30062` joins the corpus + Library
+  "Findings" facet + inspector section; a **forensic-findings block** on
+  the subject/case views renders the four lenses (evidentiary / executive
+  / survivor / editor) over the same findings, never averaged; `30062`
+  joins `LEDGERED_KINDS` for reconciliation (the wire d-tag recorded at
+  publish).
 - ⏳ **14.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal
   pass enforcing the anchor + counter-note + basis discipline.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,7 +73,7 @@ Phase 13 ███████████░░░░░░░░░  in progre
                                 pending smoke-test
 Phase 14 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
                                 behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
-                                builds on Phase 13; 14.1–14.2 built, 14.3–14.5 pending
+                                builds on Phase 13; 14.1–14.3 built, 14.4–14.5 pending
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -1122,10 +1122,11 @@ Slices (one PR each):
 - ⏳ **14.2** Capture UI — finding modal (subject+role, ordered anchors,
   note + required counter-note, basis), findings bar, baseline marking,
   revision-link flow.
-- ⏳ **14.3** Wire builders + NIP draft — `30062`
-  `buildBehavioralFindingEvent` + `parseBehavioralFindingEvent`, 30055
-  `revision/*` emission, `forensicPublishing` flag, §30062/§30055 NIP text
-  with the "structural-observation, not verdict" framing.
+- ✅ **14.3** Wire builders + NIP draft — `30062`
+  `buildBehavioralFindingEvent` + `parseBehavioralFindingEvent` + the
+  kind-1985 maneuver mirror, 30055 `revision/*` emission, the
+  `forensicPublishing` flag, §30062/§30055 NIP text with the
+  "structural-observation, not verdict" framing + firewall clause.
 - ⏳ **14.4** Portal report lenses — corpus parser + subject/case lens views
   (evidentiary / executive / survivor / editor) + reconciliation.
 - ⏳ **14.5** LLM assist (flag-gated) — `suggested_by: llm:<model>` proposal

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -564,6 +564,55 @@ everything before 13.13 below must work with the flag off.
 
 ---
 
+## Phase 14 — Forensic findings (behavioral-pattern layer)
+
+The criminology layer (`docs/CRIMINOLOGY_DESIGN.md`): name the
+*maneuvers* a subject performs around the truth, evidence-anchored, with
+**no verdict on intent**. Local-first; publishing stays off until the
+`forensicPublishing` flag is enabled (14.4 portal surfaces not yet
+built). The bar lives in the reader **under the claims bar and the
+Epistemic-audit bar** — three separate, firewalled blocks.
+
+**Capture + name a finding (reader)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.1 | Capture a page with named people making arguments (a debate/op-ed). Below the claims bar, find the **"Forensic findings"** section | ✅ empty-state prompt: "…name a maneuver and bind it to evidence. No verdicts — structure only, with a required counter-read." |
+| 14.2 | Select a person's name in the article → entity tagger → create/tag them as an entity (this becomes a selectable subject) | ✅ entity mark renders |
+| 14.3 | Select an offending span → **+ Finding** | ✅ modal "Name a maneuver" opens; the selected span is pre-filled as **Evidence step 1** |
+| 14.4 | In the modal: pick the **Subject** (your tagged entity) + a **Role** (apologist/critic/…); pick a **Maneuver** from the grouped picker | ✅ the guide block shows the maneuver's **definition + source citation + "Would make it NOT this:"** counter-indicators |
+| 14.5 | Confirm there is **no stance / score / confidence control** anywhere in the modal | ✅ none exists (the whole point) |
+| 14.6 | **+ evidence step** → 📍 → modal minimizes → select a second span → Done | ✅ a Step 2 row appears with the marked span; the badge later shows `·2` |
+| 14.7 | Fill **Basis** (`quoted`/…), an optional **Note**, leave **Counter-note blank**, Save | ✅ **blocked**: "A counter-note is required — give the alternative / exonerating reading." |
+| 14.8 | Clear the maneuver, Save | ✅ blocked: "Pick a maneuver." |
+| 14.9 | Clear all evidence quotes, Save | ✅ blocked: "Add at least one evidence step with a quote." |
+| 14.10 | Fill the counter-note → Save | ✅ a finding row appears: subject label + **maneuver/role/basis badges** + the lead quote |
+| 14.11 | **Set baseline…** → pick the subject → descriptive register note → Save | ✅ toast "Baseline saved" (no score field anywhere) |
+| 14.12 | ✎ edit the finding → change note/basis/role → Save; then 🗑 delete | ✅ edits persist; delete confirms and removes the row |
+| 14.13 | Reload the reader tab on the same URL | ✅ the finding reappears (matched to the article by its evidence-anchor source URL) |
+| 14.14 | DevTools console: `chrome.storage.local.get(['behavioral_findings','forensic_baselines'], console.log)` | ✅ records carry `subject_ref`, `role`, `maneuver`, ordered `anchors[]`, `counter_note`, `basis`, `suggested_by` — and **no** `stance`/`intent`/`confidence`/`lying` field |
+
+**Publish (flag-gated)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.15 | Settings → Advanced → Experimental: confirm **"Publish forensic findings"** is **unchecked** by default (`xray:flags` → `forensicPublishing` absent/false) | ✅ off by default |
+| 14.16 | With the flag **off**, Publish the article | ✅ summary names article/claims/etc. but **no `30062` / forensic-mirror / revision events** |
+| 14.17 | A finding whose subject is **only a label/handle** (not a tagged keyed entity) | ✅ does **not** publish even with the flag on — it waits for entity linking (the subject has no pubkey) |
+| 14.18 | Enable **`forensicPublishing`** → Publish on an article whose finding's subject **is** a tagged entity | ✅ a forensic sub-batch toast; summary lists `N findings` (+ `finding mirrors`) (+ `revision edges` if any); the finding row gains a **🌐** badge |
+| 14.19 | Re-publish with no changes | ✅ findings are **not** re-emitted (only fresh/edited; staleness gate) |
+| 14.20 | Inspect the published **kind-30062** on a relay explorer | ✅ carries `p`=subject (slot-4 `subject`), `l`=maneuver under **`xray/forensic`**, `role`, ordered `maneuver-step` tags, `basis`, and content = note + `### Counter-read`. **The firewall:** no `stance`, no `rating-value`, no `xray/assessment` label |
+| 14.21 | The finding's **kind-1985 mirror** | ✅ present once; `L`/`l` `xray/forensic` + `p`=subject + `r`; no `score`, no intent |
+| 14.22 | (If you created a `revision/*` edge between two published claims) inspect the **kind-30055** | ✅ `relationship` = `narrative-patch`/`recharacterizes`/`walks-back`, directional (source = earlier statement) |
+
+**Firefox**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.23 | Repeat 14.3, 14.7, 14.18 on Firefox ≥128 | ✅ identical behavior |
+
+---
+
 ## Phase 6 — Entity sync
 
 Run on **Device A** (your normal profile) and **Device B** (a

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -605,11 +605,20 @@ Epistemic-audit bar** — three separate, firewalled blocks.
 | 14.21 | The finding's **kind-1985 mirror** | ✅ present once; `L`/`l` `xray/forensic` + `p`=subject + `r`; no `score`, no intent |
 | 14.22 | (If you created a `revision/*` edge between two published claims) inspect the **kind-30055** | ✅ `relationship` = `narrative-patch`/`recharacterizes`/`walks-back`, directional (source = earlier statement) |
 
+**Portal (14.4)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.23 | Open the portal → **Library** → the **Findings** facet | ✅ published findings list with subject + maneuver; click one → inspector shows the maneuver, the evidence chain, and the **counter-read** (no score) |
+| 14.24 | Open the subject's **entity view** (the person you tagged) | ✅ a **Forensic findings** block beside the audit dossier, with a lens selector |
+| 14.25 | Toggle the four lenses — **Evidentiary / Executive / Survivor / Editor** | ✅ same findings, different renders: full evidence + counter-reads / a maneuver tally + one-liners / plain-language with the fair counter-read / a prose draft. **Never a score, never averaged** |
+| 14.26 | Reconciliation line after publishing a finding | ✅ the `30062` counts toward "ledger says N / relays confirm M"; removing the relay + resyncing moves it to **missing** |
+
 **Firefox**
 
 | # | Test | Pass criteria |
 |---|---|---|
-| 14.23 | Repeat 14.3, 14.7, 14.18 on Firefox ≥128 | ✅ identical behavior |
+| 14.27 | Repeat 14.3, 14.7, 14.18, 14.25 on Firefox ≥128 | ✅ identical behavior |
 
 ---
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -579,7 +579,7 @@ Epistemic-audit bar** — three separate, firewalled blocks.
 |---|---|---|
 | 14.1 | Capture a page with named people making arguments (a debate/op-ed). Below the claims bar, find the **"Forensic findings"** section | ✅ empty-state prompt: "…name a maneuver and bind it to evidence. No verdicts — structure only, with a required counter-read." |
 | 14.2 | Select a person's name in the article → entity tagger → create/tag them as an entity (this becomes a selectable subject) | ✅ entity mark renders |
-| 14.3 | Select an offending span → **+ Finding** | ✅ modal "Name a maneuver" opens; the selected span is pre-filled as **Evidence step 1** |
+| 14.3 | Select an offending span → in the tagger popover click **🔎 Mark finding** (or scroll to the Forensic findings section → **+ Finding**) | ✅ modal "Name a maneuver" opens; the selected span is pre-filled as **Evidence step 1** |
 | 14.4 | In the modal: pick the **Subject** (your tagged entity) + a **Role** (apologist/critic/…); pick a **Maneuver** from the grouped picker | ✅ the guide block shows the maneuver's **definition + source citation + "Would make it NOT this:"** counter-indicators |
 | 14.5 | Confirm there is **no stance / score / confidence control** anywhere in the modal | ✅ none exists (the whole point) |
 | 14.6 | **+ evidence step** → 📍 → modal minimizes → select a second span → Done | ✅ a Step 2 row appears with the marked span; the badge later shows `·2` |

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -522,6 +522,8 @@ async function loadAdvanced() {
         isEnabled('assessmentPublishing');
     document.getElementById('pref-epistemic-auditing').checked =
         isEnabled('epistemicAuditing');
+    document.getElementById('pref-forensic-publishing').checked =
+        isEnabled('forensicPublishing');
 
     const overrides = prefs.config_overrides || {};
     document.getElementById('pref-cache-enabled').checked =
@@ -558,6 +560,8 @@ async function saveAdvanced() {
     await setOverride('assessmentPublishing', publishJudgments ? true : null);
     const publishAudits = document.getElementById('pref-epistemic-auditing').checked;
     await setOverride('epistemicAuditing', publishAudits ? true : null);
+    const publishFindings = document.getElementById('pref-forensic-publishing').checked;
+    await setOverride('forensicPublishing', publishFindings ? true : null);
 
     flash(document.getElementById('advanced-status'), 'Saved.');
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -265,6 +265,24 @@
       <input type="file" id="audit-file" accept="application/json" style="display:none" />
 
       <hr />
+      <h3 class="xr-opt__subhead">Forensic findings</h3>
+      <label class="xr-opt__field xr-opt__field--inline">
+        <input type="checkbox" id="pref-forensic-publishing" />
+        <span>Publish forensic findings to relays</span>
+      </label>
+      <p class="xr-opt__hint" style="margin-top:-8px">
+        Off by default. When on, the reader's Publish batch also emits your
+        behavioral findings — kind-30062 (the named maneuver + its evidence
+        chain + a required counter-read), a one-time kind-1985 maneuver
+        mirror, and any <code>revision/*</code> story-change edges
+        (kind-30055) — signed by your publishing identity and
+        <strong>publicly visible to anyone with relay access</strong>. A
+        finding names a <em>structure</em>, not a verdict; it labels the
+        subject's pubkey, so it only publishes for a subject you've tagged
+        as a keyed entity. Local capture always works regardless.
+      </p>
+
+      <hr />
       <h3 class="xr-opt__subhead">Power user</h3>
 
       <label class="xr-opt__field xr-opt__field--inline">

--- a/src/portal/case-view.js
+++ b/src/portal/case-view.js
@@ -11,6 +11,7 @@ import { el, svgEl, clear, truncate } from './dom.js';
 import { kindLabel, TYPE_DEFS } from './library.js';
 import { buildBuckets } from './timeline.js';
 import { renderDossierBlock } from './dossier-block.js';
+import { renderFindingsBlock } from './findings-block.js';
 
 function latestAssessmentByCoord(items) {
     const map = new Map();
@@ -42,7 +43,7 @@ function contradictedCoords(items) {
  *                                      onOpenGraph(pubkey), onOpenItem(item)}
  */
 export function renderCaseView(host, params) {
-    const { items, entityIndex, casePubkey, callbacks, dossier, populationMean } = params;
+    const { items, entityIndex, casePubkey, callbacks, dossier, populationMean, findings = [] } = params;
     clear(host);
 
     const caseEnt = entityIndex[casePubkey];
@@ -89,6 +90,8 @@ export function renderCaseView(host, params) {
     // --- Audit dossier (13.7) — the design assigns the block to
     // entity AND case views; a case is a pubkey-keyed entity.
     renderDossierBlock(host, dossier, populationMean);
+    // --- Forensic findings (14.4) — the four lenses, beside the dossier.
+    renderFindingsBlock(host, findings, { subjectName: caseName || 'this case' });
 
     // --- publish-density strip ---
     const { buckets } = buildBuckets(everything);

--- a/src/portal/corpus.js
+++ b/src/portal/corpus.js
@@ -38,7 +38,8 @@ export const CONTENT_KINDS = [
     10002, // NIP-65 relay list (signed by the xray:user sync key)
     30078, // entity-sync blobs (ciphertext; listed, never decrypted)
     30050, 30051, 30052, 30053, 9803, // dormant metadata kinds (flag-gated writers)
-    30056, 30057, 30058, 30059, 30060, 30061 // Phase 13 audit kinds (publish lands in 13.8; read always)
+    30056, 30057, 30058, 30059, 30060, 30061, // Phase 13 audit kinds (publish lands in 13.8; read always)
+    30062 // Phase 14 behavioral findings (docs/CRIMINOLOGY_DESIGN.md)
 ];
 
 // Mirrors the background service worker's hardcoded fallback

--- a/src/portal/entity-view.js
+++ b/src/portal/entity-view.js
@@ -14,6 +14,7 @@ import { el, svgEl, clear, truncate, shortKey } from './dom.js';
 import { buildEgoGraph, layoutEgoGraph } from './graph.js';
 import { kindLabel } from './library.js';
 import { renderDossierBlock } from './dossier-block.js';
+import { renderFindingsBlock } from './findings-block.js';
 
 const SIZE = 720;
 
@@ -40,7 +41,7 @@ const NODE_RADIUS = {
  *                                        onBack(), onExpand(type)}
  */
 export function renderEntityView(host, params) {
-    const { items, entityIndex, focusPubkey, expandedTypes, callbacks, dossier, populationMean } = params;
+    const { items, entityIndex, focusPubkey, expandedTypes, callbacks, dossier, populationMean, findings = [] } = params;
     clear(host);
 
     const graph = buildEgoGraph(items, { focusPubkey, entityIndex, expandedTypes });
@@ -69,6 +70,8 @@ export function renderEntityView(host, params) {
 
     // --- Audit dossier (13.7) — shared block, also on case views.
     renderDossierBlock(host, dossier, populationMean);
+    // --- Forensic findings (14.4) — the four lenses for this subject.
+    renderFindingsBlock(host, findings, { subjectName: graph.focus.name });
 
     if (graph.nodes.length === 0) {
         host.appendChild(el('p', 'xr-view__empty',

--- a/src/portal/findings-block.js
+++ b/src/portal/findings-block.js
@@ -1,0 +1,132 @@
+// The forensic-findings block (Phase 14.4) — the same findings rendered
+// through Dawn McCarty's four report lenses (evidentiary / executive /
+// survivor / editor). Hung on the entity (subject) view and the case
+// view, beside the audit dossier. No score, no average — the lenses are
+// render MODES over the same evidence-anchored findings, and every
+// finding keeps its required counter-read in view (no verdict).
+
+import { el, truncate } from './dom.js';
+import { MANEUVER_GUIDE } from '../shared/forensic-taxonomy.js';
+import { FINDING_LENSES, maneuverTally, leadQuote, maneuverShort } from './forensic-data.js';
+
+const LENS_LABELS = {
+    evidentiary: 'Evidentiary',
+    executive:   'Executive',
+    survivor:    'Survivor',
+    editor:      'Editor'
+};
+
+export function renderFindingsBlock(host, findings, { subjectName = 'this subject' } = {}) {
+    if (!findings || findings.length === 0) return;
+    const block = el('div', 'xr-view__findings');
+    block.appendChild(el('h3', 'xr-case__heading',
+        `Forensic findings (${findings.length}) — named maneuvers, no verdict`));
+
+    let lens = 'evidentiary';
+    const lensBar = el('div', 'xr-findings-lens');
+    const body = el('div', 'xr-findings-lens__body');
+    const buttons = {};
+    for (const k of FINDING_LENSES) {
+        const b = el('button', 'xr-findings-lens__btn', LENS_LABELS[k]);
+        b.type = 'button';
+        b.title = `${LENS_LABELS[k]} lens`;
+        b.addEventListener('click', () => { lens = k; sync(); });
+        buttons[k] = b;
+        lensBar.appendChild(b);
+    }
+    function sync() {
+        for (const k of FINDING_LENSES) {
+            buttons[k].classList.toggle('xr-findings-lens__btn--active', k === lens);
+        }
+        renderLens(body, lens, findings, subjectName);
+    }
+    block.appendChild(lensBar);
+    block.appendChild(body);
+    sync();
+    host.appendChild(block);
+}
+
+function renderLens(body, lens, findings, subjectName) {
+    body.textContent = '';
+    if (lens === 'executive') return renderExecutive(body, findings);
+    if (lens === 'survivor')  return renderSurvivor(body, findings);
+    if (lens === 'editor')    return renderEditor(body, findings, subjectName);
+    return renderEvidentiary(body, findings);
+}
+
+function definition(maneuver) {
+    const g = MANEUVER_GUIDE[maneuver];
+    return g ? g.definition : '';
+}
+
+// Evidentiary — the full record: every finding, every anchor quote, the
+// counter-read, for the file.
+function renderEvidentiary(body, findings) {
+    for (const f of findings) {
+        const row = el('div', 'xr-finding-row');
+        row.appendChild(el('div', 'xr-finding-row__head',
+            `${f.maneuver} · ${f.role || 'subject'} · basis ${f.basis || '—'}`));
+        for (const a of f.anchors || []) {
+            if (!a.quote) continue;
+            row.appendChild(el('blockquote', 'xr-finding-row__quote', a.quote));
+        }
+        if (f.note) row.appendChild(el('div', 'xr-finding-row__note', f.note));
+        row.appendChild(el('div', 'xr-finding-row__counter', `Counter-read: ${f.counterNote || '—'}`));
+        body.appendChild(row);
+    }
+}
+
+// Executive — the rollup: a maneuver tally + one compact line per finding.
+function renderExecutive(body, findings) {
+    const chips = el('div', 'xr-finding-tally');
+    for (const t of maneuverTally(findings)) {
+        chips.appendChild(el('span', 'xr-badge', `${t.count}× ${maneuverShort(t.maneuver)}`));
+    }
+    body.appendChild(chips);
+    for (const f of findings) {
+        body.appendChild(el('div', 'xr-finding-line',
+            `${maneuverShort(f.maneuver)} — “${truncate(leadQuote(f), 90)}”`));
+    }
+}
+
+// Survivor — plain language, validation-oriented: the pattern was named
+// with evidence AND a fair counter-read (real, but bounded).
+function renderSurvivor(body, findings) {
+    body.appendChild(el('p', 'xr-finding-lens-intro',
+        'Each pattern was named with evidence and a fair counter-read — the move is real, and bounded.'));
+    for (const f of findings) {
+        const row = el('div', 'xr-finding-row');
+        const d = definition(f.maneuver);
+        row.appendChild(el('div', 'xr-finding-row__head', `${maneuverShort(f.maneuver)}${d ? ` — ${d}` : ''}`));
+        const q = leadQuote(f);
+        if (q) row.appendChild(el('blockquote', 'xr-finding-row__quote', `“${q}”`));
+        row.appendChild(el('div', 'xr-finding-row__counter', `The fair counter-read: ${f.counterNote || '—'}`));
+        body.appendChild(row);
+    }
+}
+
+// Editor — a prose draft an editor could lift into an article. Every
+// sentence is anchored to the evidence above; nothing asserts intent.
+function renderEditor(body, findings, subjectName) {
+    const parts = [];
+    const tally = maneuverTally(findings);
+    if (tally.length) {
+        parts.push(`Across this material, ${subjectName} reached for the same moves — `
+            + tally.map((t) => `${maneuverShort(t.maneuver)} (${t.count}×)`).join(', ') + '.');
+    }
+    for (const f of findings.slice(0, 6)) {
+        const q = leadQuote(f);
+        parts.push(`When pressed, ${subjectName} ${describe(f.maneuver)}${q ? ` — “${truncate(q, 120)}.”` : '.'} `
+            + `In fairness: ${f.counterNote || 'an alternative reading is possible.'}`);
+    }
+    body.appendChild(el('pre', 'xr-finding-editor', parts.join('\n\n')));
+    body.appendChild(el('div', 'xr-finding-row__note xr-view__dossier-line--dim',
+        'A draft for an editor — every sentence is anchored to the evidence above; nothing asserts intent.'));
+}
+
+function describe(maneuver) {
+    const g = MANEUVER_GUIDE[maneuver];
+    return g
+        ? g.definition.charAt(0).toLowerCase() + g.definition.slice(1).replace(/\.$/, '')
+        : `used ${maneuverShort(maneuver)}`;
+}

--- a/src/portal/forensic-data.js
+++ b/src/portal/forensic-data.js
@@ -1,0 +1,43 @@
+// Portal forensic-findings data (Phase 14.4, docs/CRIMINOLOGY_DESIGN.md).
+//
+// Pure joins + summaries from the corpus to the findings-about-a-subject
+// lens views. No DOM, no chrome.* — index.js owns the view, this owns
+// the shape. Findings are NEVER averaged or scored (there is no score);
+// the lenses are render modes over the same evidence-anchored records.
+
+export const FINDING_LENSES = ['evidentiary', 'executive', 'survivor', 'editor'];
+
+/** Findings about one subject pubkey, newest first. */
+export function findingsForEntity(items, pubkey) {
+    if (!pubkey) return [];
+    return (items || [])
+        .filter((it) => it && it.kind === 30062 && it.parsedFinding
+            && it.parsedFinding.subjectPubkey === pubkey)
+        .map((it) => ({
+            ...it.parsedFinding,
+            created_at: it.created_at || 0,
+            eventId:    it.event && it.event.id,
+            relayCount: (it.relays || []).length
+        }))
+        .sort((a, b) => (b.created_at || 0) - (a.created_at || 0));
+}
+
+/** Maneuver tally, most frequent first (the executive rollup). */
+export function maneuverTally(findings) {
+    const counts = new Map();
+    for (const f of findings || []) counts.set(f.maneuver, (counts.get(f.maneuver) || 0) + 1);
+    return [...counts.entries()]
+        .map(([maneuver, count]) => ({ maneuver, count }))
+        .sort((a, b) => b.count - a.count || String(a.maneuver).localeCompare(String(b.maneuver)));
+}
+
+/** The lead evidence quote for a finding (its first anchor's quote). */
+export function leadQuote(finding) {
+    const a = ((finding && finding.anchors) || [])[0];
+    return (a && a.quote) || '';
+}
+
+/** Short, human label for a maneuver value (drop the `family/` prefix). */
+export function maneuverShort(maneuver) {
+    return String(maneuver || '').split('/').pop() || String(maneuver || '');
+}

--- a/src/portal/index.css
+++ b/src/portal/index.css
@@ -704,6 +704,39 @@ button.xr-badge--case { cursor: pointer; background: transparent; }
 .xr-view__dossier-line--dim { color: var(--xr-text-dim); }
 .xr-view__dossier-modules { display: flex; gap: 6px; flex-wrap: wrap; }
 
+/* Forensic findings block (14.4) — the four lenses. */
+.xr-view__findings {
+  margin: 10px 0;
+  padding: 10px 14px;
+  border: 1px solid var(--xr-border, #333);
+  border-left: 3px solid var(--xr-warning, #fbbf24);
+  border-radius: 6px;
+  background: var(--xr-surface);
+  font-size: 12px;
+}
+.xr-findings-lens { display: flex; gap: 4px; margin: 8px 0; flex-wrap: wrap; }
+.xr-findings-lens__btn {
+  padding: 3px 10px; border-radius: 999px; font-size: 11.5px; cursor: pointer;
+  background: var(--xr-surface-2, #2e2e2e); color: var(--xr-text); border: 1px solid var(--xr-border, #333);
+}
+.xr-findings-lens__btn--active {
+  border-color: var(--xr-warning, #fbbf24);
+  background: color-mix(in srgb, var(--xr-warning, #fbbf24) 20%, transparent);
+}
+.xr-findings-lens__body { display: flex; flex-direction: column; gap: 8px; }
+.xr-finding-lens-intro { color: var(--xr-text-dim); margin: 0; }
+.xr-finding-row { display: flex; flex-direction: column; gap: 4px; padding-bottom: 6px; border-bottom: 1px solid var(--xr-border, #333); }
+.xr-finding-row__head { font-weight: 600; }
+.xr-finding-row__quote { margin: 0; padding-left: 10px; border-left: 2px solid var(--xr-border, #333); color: var(--xr-text-dim); font-style: italic; }
+.xr-finding-row__note { color: var(--xr-text); }
+.xr-finding-row__counter { color: var(--xr-warning, #fbbf24); }
+.xr-finding-tally { display: flex; gap: 6px; flex-wrap: wrap; }
+.xr-finding-line { color: var(--xr-text-dim); }
+.xr-finding-editor { white-space: pre-wrap; font: inherit; margin: 0; color: var(--xr-text); }
+.xr-inspector__finding { margin-top: 12px; }
+.xr-inspector__sub { margin: 8px 0 4px; font-size: 12px; color: var(--xr-text-dim); }
+.xr-inspector__finding-anchor { display: flex; gap: 8px; font-size: 12px; }
+
 /* Resolve… modal. */
 .xr-resolve {
   position: fixed;

--- a/src/portal/index.js
+++ b/src/portal/index.js
@@ -25,6 +25,7 @@ import { buildBuckets, brushRange } from './timeline.js';
 import { el, svgEl, clear, truncate, shortKey } from './dom.js';
 import { renderEntityView } from './entity-view.js';
 import { renderCaseView } from './case-view.js';
+import { findingsForEntity } from './forensic-data.js';
 import { loadLocalLedger, reconcile, countLocalOnly } from './reconcile.js';
 import { renderInspector } from './inspector.js';
 import {
@@ -655,6 +656,7 @@ function render() {
             dossier: state.auditIndex
                 ? computeEntityDossier(dossierInputsForEntity(state.items, state.auditIndex, state.view.pubkey, state.priorHashesByUrl))
                 : null,
+            findings: findingsForEntity(state.items, state.view.pubkey),
             populationMean: DEFAULT_POPULATION_MEAN,
             callbacks: viewCallbacks
         });
@@ -667,6 +669,7 @@ function render() {
             dossier: state.auditIndex
                 ? computeEntityDossier(dossierInputsForEntity(state.items, state.auditIndex, state.view.pubkey, state.priorHashesByUrl))
                 : null,
+            findings: findingsForEntity(state.items, state.view.pubkey),
             populationMean: DEFAULT_POPULATION_MEAN,
             callbacks: viewCallbacks
         });

--- a/src/portal/inspector.js
+++ b/src/portal/inspector.js
@@ -90,6 +90,34 @@ function renderAuditSection(host, audit) {
     host.appendChild(section);
 }
 
+// Behavioral finding (14.4): the named maneuver + its ordered evidence
+// chain + the REQUIRED counter-read. No score, no verdict — the field
+// table and this section never assert intent.
+function renderFindingSection(host, finding) {
+    const section = el('div', 'xr-inspector__finding');
+    section.appendChild(el('h3', 'xr-case__heading', 'Behavioral finding'));
+    section.appendChild(el('div', 'xr-inspector__mono',
+        `${finding.maneuver} · ${finding.role || 'subject'} · basis ${finding.basis || '—'}`
+        + (finding.subjectPubkey ? ` · subject ${shortKey(finding.subjectPubkey)}` : '')));
+    const anchors = finding.anchors || [];
+    section.appendChild(el('h4', 'xr-inspector__sub',
+        `Evidence (${anchors.length} step${anchors.length === 1 ? '' : 's'})`));
+    anchors.forEach((a, i) => {
+        if (!a.quote) return;
+        const row = el('div', 'xr-inspector__finding-anchor');
+        row.appendChild(el('span', 'xr-inspector__mono', `[${i}]`));
+        row.appendChild(el('span', null, truncate(a.quote, 140)));
+        section.appendChild(row);
+    });
+    if (finding.note) {
+        section.appendChild(el('h4', 'xr-inspector__sub', 'Note'));
+        section.appendChild(el('div', null, finding.note));
+    }
+    section.appendChild(el('h4', 'xr-inspector__sub', 'Counter-read (required)'));
+    section.appendChild(el('div', null, finding.counterNote || '—'));
+    host.appendChild(section);
+}
+
 const STATUS_TEXT = {
     'confirmed':   ['✓ in ledger & on relays', 'xr-badge--agree'],
     'remote-only': ['◌ remote-only — not in this device\'s ledger', 'xr-badge--case'],
@@ -191,6 +219,11 @@ export function renderInspector(host, item, { status = 'no-ledger', onClose, aud
     // 13.7: the audit record for articles, when any run anchors here.
     if (audit && audit.runs && audit.runs.length > 0) {
         renderAuditSection(host, audit);
+    }
+
+    // 14.4: the behavioral finding's maneuver + evidence chain + counter-read.
+    if (item.kind === 30062 && item.parsedFinding) {
+        renderFindingSection(host, item.parsedFinding);
     }
 
     const details = el('details', 'xr-inspector__raw');

--- a/src/portal/library.js
+++ b/src/portal/library.js
@@ -22,6 +22,7 @@ import {
     parsePredictionEntryEvent, parsePredictionResolutionEvent,
     parseDossierSnapshotEvent, parseAuditDisputeEvent
 } from '../shared/audit/builders.js';
+import { parseBehavioralFindingEvent } from '../shared/forensic-model.js';
 
 // Tags written by this extension (current + userscript-era value).
 export const OUR_CLIENT_TAGS = new Set(['xray', 'nostr-article-capture']);
@@ -37,6 +38,7 @@ export const TYPE_DEFS = [
     { key: 'assessment', label: 'Assessments' },
     { key: 'audit',      label: 'Audits' },
     { key: 'prediction', label: 'Predictions' },
+    { key: 'finding',    label: 'Findings' },
     { key: 'link',       label: 'Links' },
     { key: 'entity',     label: 'Entities' },
     { key: 'case',       label: 'Cases' },
@@ -66,7 +68,8 @@ const KIND_LABELS = {
     30058: 'Prediction',
     30059: 'Resolution',
     30060: 'Dossier',
-    30061: 'Dispute'
+    30061: 'Dispute',
+    30062: 'Behavioral finding'
 };
 
 export function kindLabel(kind) {
@@ -301,6 +304,21 @@ function buildItem(record, entityIndex) {
                 extra.auditRole = 'dispute';
                 extra.parsedDispute = dis;
                 haystack.push(dis.targetKind, dis.status);
+            }
+            break;
+        }
+        // ---- Phase 14 behavioral finding (14.4) -------------------
+        case 30062: {
+            const f = parseBehavioralFindingEvent(event);
+            if (f) {
+                typeKey = 'finding';
+                const subj = (f.subjectPubkey && entityIndex[f.subjectPubkey]
+                    && entityIndex[f.subjectPubkey].name)
+                    || (f.subjectPubkey ? `${f.subjectPubkey.slice(0, 10)}…` : '(unknown subject)');
+                title = `Finding — ${f.maneuver}`;
+                sub = `${subj} · ${f.role || 'subject'}`;
+                extra.parsedFinding = f;
+                haystack.push(f.maneuver, f.role, f.subjectPubkey, subj, f.url);
             }
             break;
         }

--- a/src/portal/reconcile.js
+++ b/src/portal/reconcile.js
@@ -25,6 +25,7 @@ import { ClaimModel } from '../shared/claim-model.js';
 import { AssessmentModel } from '../shared/assessment-model.js';
 import { EvidenceLinker } from '../shared/evidence-linker.js';
 import { EntityModel } from '../shared/entity-model.js';
+import { ForensicModel } from '../shared/forensic-model.js';
 import { listArticles } from '../shared/archive-cache.js';
 import { listRuns, listPredictions, listResolutions } from '../shared/audit/audit-cache.js';
 import {
@@ -37,7 +38,7 @@ import { Utils } from '../shared/utils.js';
 
 // 30060 (snapshots) and 30061 (disputes) have no publish path in 13.8
 // — they stay 'no-ledger' below, never an anomaly.
-const LEDGERED_KINDS = new Set([30023, 30040, 30054, 30055, 0, 30056, 30057, 30058, 30059]);
+const LEDGERED_KINDS = new Set([30023, 30040, 30054, 30055, 0, 30056, 30057, 30058, 30059, 30062]);
 
 async function sha16(s) {
     return (await Crypto.sha256(String(s))).slice(0, 16);
@@ -230,6 +231,26 @@ export async function loadLocalLedger({ pubkeys = [] } = {}) {
             });
         }
     } catch (err) { Utils.error('Reconcile: resolution ledger scan failed', err); }
+
+    try {
+        const findings = await ForensicModel.getAll();
+        for (const f of Object.values(findings || {})) {
+            if (!f || !f.publishedAt || !f.publishedEventId) continue;
+            // The wire address rebuilds from the recorded d-tag +
+            // publishing pubkey; without a stored d-tag we still match by
+            // exact event id (the primary path).
+            const addrs = (f.publishedPubkey && f.publishedDTag)
+                ? [`30062:${f.publishedPubkey}:${f.publishedDTag}`] : [];
+            entries.push({
+                source: 'finding',
+                localId: f.id,
+                label: `${f.maneuver} (${(f.subject_ref && f.subject_ref.label) || ''})`.slice(0, 60),
+                publishedAt: f.publishedAt,
+                publishedEventId: f.publishedEventId,
+                addrs
+            });
+        }
+    } catch (err) { Utils.error('Reconcile: finding ledger scan failed', err); }
 
     return entries;
 }

--- a/src/reader/entity-tagger.js
+++ b/src/reader/entity-tagger.js
@@ -32,6 +32,7 @@ let currentSelectionRange = null;
 let currentSelectionText  = '';
 let onTagCallback         = null;
 let onClaimCallback       = null;
+let onFindingCallback     = null;
 let taggerRoot            = null;
 
 /**
@@ -40,16 +41,18 @@ let taggerRoot            = null;
  *
  * @param {{
  *   container: HTMLElement,
- *   onTag:     (ref)  => void,
- *   onClaim?:  (info) => void  // called when the popover's "Add as
- *                              // claim" row is clicked; the reader
- *                              // opens the claim modal from there
+ *   onTag:      (ref)  => void,
+ *   onClaim?:   (info) => void, // the popover's "Add as claim" row
+ *   onFinding?: (info) => void  // the popover's "Mark finding" row —
+ *                               // the reader opens the finding modal
+ *                               // seeded with the selected span
  * }} opts
  */
-export function installEntityTagger({ container, onTag, onClaim }) {
+export function installEntityTagger({ container, onTag, onClaim, onFinding }) {
     if (!container) return () => {};
     onTagCallback = onTag;
     onClaimCallback = onClaim || null;
+    onFindingCallback = onFinding || null;
     taggerRoot = container;
 
     const onMouseUp = (ev) => {
@@ -150,6 +153,9 @@ function openPopover({ x, y, initialText }) {
         <button type="button" class="xr-tagger-popover__claim-btn" title="Open the claim form with this selection">
           📋 Add as claim
         </button>
+        <button type="button" class="xr-tagger-popover__finding-btn" title="Name a behavioral maneuver, anchored to this selection">
+          🔎 Mark finding
+        </button>
       </div>
     `;
 
@@ -227,6 +233,28 @@ function openPopover({ x, y, initialText }) {
             currentSelectionText  = '';
             if (typeof onClaimCallback === 'function') {
                 onClaimCallback({ text, context, anchor });
+            }
+        });
+    }
+
+    // "Mark finding" handoff — same cloned-range capture as the claim
+    // path, handed to the reader so it can open the finding modal with
+    // this span as the seed evidence anchor.
+    const findingBtn = popover.querySelector('.xr-tagger-popover__finding-btn');
+    if (findingBtn) {
+        findingBtn.addEventListener('click', () => {
+            const text = currentSelectionText;
+            const captured = currentSelectionRange
+                ? captureFromRange(currentSelectionRange, taggerRoot)
+                : null;
+            const anchor = captured ? captured.selectors : null;
+            closePopover();
+            const sel = window.getSelection();
+            if (sel) sel.removeAllRanges();
+            currentSelectionRange = null;
+            currentSelectionText  = '';
+            if (typeof onFindingCallback === 'function') {
+                onFindingCallback({ text, anchor });
             }
         });
     }

--- a/src/reader/findings-section.js
+++ b/src/reader/findings-section.js
@@ -1,4 +1,4 @@
-// Reader findings section — Phase 13.2 (docs/CRIMINOLOGY_DESIGN.md).
+// Reader findings section — Phase 14.2 (docs/CRIMINOLOGY_DESIGN.md).
 //
 // Renders the per-article "Forensic findings" bar beneath the claims
 // bar: a header with the capture affordances (+ Finding / Set baseline)

--- a/src/reader/findings-section.js
+++ b/src/reader/findings-section.js
@@ -1,0 +1,59 @@
+// Reader findings section — Phase 13.2 (docs/CRIMINOLOGY_DESIGN.md).
+//
+// Renders the per-article "Forensic findings" bar beneath the claims
+// bar: a header with the capture affordances (+ Finding / Set baseline)
+// and one row per finding (subject + maneuver badges + the lead quote).
+// Pure HTML string, like renderClaimsBar; index.js owns the wiring.
+
+import { renderFindingBadges } from '../shared/forensic-modal.js';
+
+/**
+ * @param {Array<object>} findings  findings whose evidence is on this article
+ * @returns {string} HTML
+ */
+export function renderFindingsBar(findings) {
+    const list = Array.isArray(findings) ? findings : [];
+    const header = `
+      <div class="xr-findings__head">
+        <span class="xr-findings__title">Forensic findings${list.length ? ` (${list.length})` : ''}</span>
+        <span class="xr-findings__gap"></span>
+        <button type="button" class="xr-findings__btn" id="xr-findings-baseline" title="Record a subject's baseline register">Set baseline…</button>
+        <button type="button" class="xr-findings__btn xr-findings__btn--primary" id="xr-findings-add" title="Name a maneuver for the selected span">+ Finding</button>
+      </div>`;
+
+    if (list.length === 0) {
+        return `<div class="xr-findings">${header}
+          <div class="xr-findings__empty">Select a span in the article, then <strong>+ Finding</strong> to name a maneuver and bind it to evidence. No verdicts — structure only, with a required counter-read.</div>
+        </div>`;
+    }
+
+    const rows = list.map((f) => {
+        const lead = (f.anchors && f.anchors[0] && f.anchors[0].quote) || '';
+        const subject = (f.subject_ref && f.subject_ref.label) || '(subject)';
+        return `
+          <div class="xr-findings__item" data-id="${escapeHtml(f.id)}">
+            <div class="xr-findings__item-main">
+              <span class="xr-findings__subject">${escapeHtml(subject)}</span>
+              ${renderFindingBadges(f)}
+              ${lead ? `<blockquote class="xr-findings__quote">${escapeHtml(truncate(lead, 160))}</blockquote>` : ''}
+            </div>
+            <div class="xr-findings__item-actions">
+              <button type="button" class="xr-findings__row-btn" data-action="edit" title="Edit finding">✎</button>
+              <button type="button" class="xr-findings__row-btn" data-action="delete" title="Delete finding">🗑</button>
+            </div>
+          </div>`;
+    }).join('');
+
+    return `<div class="xr-findings">${header}<div class="xr-findings__list">${rows}</div></div>`;
+}
+
+function truncate(s, n) {
+    const str = String(s || '');
+    return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+}
+
+function escapeHtml(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+}

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -1004,7 +1004,8 @@ body {
   border-top: 1px solid var(--xr-border);
 }
 
-.xr-tagger-popover__claim-btn {
+.xr-tagger-popover__claim-btn,
+.xr-tagger-popover__finding-btn {
   width: 100%;
   padding: 8px 12px;
   border: 1px solid var(--xr-border);
@@ -1018,9 +1019,16 @@ body {
   transition: background 120ms ease, border-color 120ms ease;
 }
 
+.xr-tagger-popover__finding-btn { margin-top: 6px; }
+
 .xr-tagger-popover__claim-btn:hover {
   background: color-mix(in srgb, var(--xr-accent) 12%, transparent);
   border-color: color-mix(in srgb, var(--xr-accent) 50%, transparent);
+}
+
+.xr-tagger-popover__finding-btn:hover {
+  background: color-mix(in srgb, var(--xr-warning) 14%, transparent);
+  border-color: color-mix(in srgb, var(--xr-warning) 55%, transparent);
 }
 
 /* ---------------- claim marks in the article body (Phase 5 C2) ---------------- */

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -1428,6 +1428,86 @@ body {
   color: var(--xr-text-dim);
 }
 
+/* Forensic findings bar (Phase 13) — sibling of the claims bar. */
+.xr-findings {
+  max-width: var(--xr-reader-max-w);
+  margin: 0 auto 16px;
+  padding: 16px 24px 20px;
+  background: var(--xr-surface);
+  border: 1px solid var(--xr-border);
+  border-radius: 10px;
+}
+
+.xr-findings__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.xr-findings__title { margin: 0; font-size: 16px; font-weight: 600; }
+.xr-findings__gap { flex: 1; }
+
+.xr-findings__btn {
+  padding: 4px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  background: var(--xr-surface-2);
+  color: var(--xr-text);
+  border: 1px solid var(--xr-border);
+}
+
+.xr-findings__btn--primary {
+  background: var(--xr-primary, #8b5cf6);
+  border-color: var(--xr-primary, #8b5cf6);
+  color: #fff;
+}
+
+.xr-findings__empty {
+  padding: 14px 16px;
+  color: var(--xr-text-dim);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.xr-findings__list { display: flex; flex-direction: column; gap: 10px; }
+
+.xr-findings__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px 14px;
+  border-left: 3px solid var(--xr-warning, #fbbf24);
+  background: var(--xr-surface-2);
+  border-radius: 0 6px 6px 0;
+}
+
+.xr-findings__item-main { flex: 1; min-width: 0; }
+.xr-findings__subject { font-weight: 600; font-size: 14px; }
+
+.xr-findings__quote {
+  margin: 6px 0 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--xr-border);
+  color: var(--xr-text-dim);
+  font-style: italic;
+  font-size: 13px;
+}
+
+.xr-findings__item-actions { display: flex; gap: 4px; flex: none; }
+
+.xr-findings__row-btn {
+  background: none;
+  border: 1px solid var(--xr-border);
+  border-radius: 6px;
+  color: var(--xr-text);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 3px 7px;
+}
+
 .xr-claims__type {
   font-weight: 600;
   color: var(--xr-text);

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -1428,7 +1428,7 @@ body {
   color: var(--xr-text-dim);
 }
 
-/* Forensic findings bar (Phase 13) — sibling of the claims bar. */
+/* Forensic findings bar (Phase 14) — sibling of the claims bar. */
 .xr-findings {
   max-width: var(--xr-reader-max-w);
   margin: 0 auto 16px;

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -43,7 +43,7 @@
        with edit + delete affordances. -->
   <div id="xr-claims-host"></div>
 
-  <!-- Forensic findings bar (Phase 13). Populated by reader/index.js:
+  <!-- Forensic findings bar (Phase 14). Populated by reader/index.js:
        per-subject behavioral maneuvers, evidence-anchored, no verdict. -->
   <div id="xr-findings-host"></div>
 

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -43,6 +43,10 @@
        with edit + delete affordances. -->
   <div id="xr-claims-host"></div>
 
+  <!-- Forensic findings bar (Phase 13). Populated by reader/index.js:
+       per-subject behavioral maneuvers, evidence-anchored, no verdict. -->
+  <div id="xr-findings-host"></div>
+
   <!-- Comments section. Shown only when the article has a postId from
        a platform that supports comment capture (Substack today). The
        inner HTML is populated by reader/index.js. -->

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -2702,7 +2702,7 @@ async function publish() {
                 btn.textContent = `Publishing (${fBase + (++fStep)}/${totalEvents})…`;
                 let landed = false;
                 try {
-                    const { event: unsigned } = await buildBehavioralFindingEvent({
+                    const { event: unsigned, dTag } = await buildBehavioralFindingEvent({
                         subjectPubkey: sel.subjectPubkey,
                         maneuver:      sel.finding.maneuver,
                         role:          sel.finding.role,
@@ -2719,7 +2719,7 @@ async function publish() {
                         if (resp.results.successful > 0) {
                             findingResults.ok++;
                             landed = true;
-                            try { await ForensicModel.markPublished(sel.finding.id, resp.signedEvent?.id || null, userPubkey); }
+                            try { await ForensicModel.markPublished(sel.finding.id, resp.signedEvent?.id || null, userPubkey, dTag); }
                             catch (_) { /* best-effort */ }
                         } else {
                             findingResults.fail++;

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -24,7 +24,8 @@ import { openAssessModal } from '../shared/assess-modal.js';
 import { AssessmentModel } from '../shared/assessment-model.js';
 import { makeClaimRefCanonicalizer } from '../shared/claim-ref.js';
 import { selectAssessmentsToPublish, selectLinksToPublish, selectMirrors } from '../shared/assessment-publish.js';
-import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent } from '../shared/metadata/builders.js';
+import { selectFindingsToPublish, selectFindingMirrors, selectRevisionEdgesToPublish } from '../shared/forensic-publish.js';
+import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent, buildBehavioralFindingEvent, buildForensicFindingMirrorEvent } from '../shared/metadata/builders.js';
 import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
 import { ForensicModel } from '../shared/forensic-model.js';
 import { openFindingModal, openBaselineModal } from '../shared/forensic-modal.js';
@@ -2640,6 +2641,165 @@ async function publish() {
             }
         }
 
+        // ---- Forensic findings (Phase 14, flag-gated) -----------------
+        // Behind `forensicPublishing` (default off): behavioral findings
+        // (30062) + their kind-1985 maneuver mirrors + the `revision/*`
+        // story-change edges (30055). A finding publishes against a
+        // RESOLVED subject pubkey — a tagged entity's keypair or an
+        // external pubkey; a subject known only by label/handle waits for
+        // entity linking. Runs after claims so revision-edge endpoints
+        // resolve.
+        const findingResults = { ok: 0, fail: 0, errors: [] };
+        const fMirrorResults = { ok: 0, fail: 0, errors: [] };
+        const revEdgeResults = { ok: 0, fail: 0, errors: [] };
+        let findingSel = [], fMirrorSel = [], revEdgeSel = [];
+        if (isEnabled('forensicPublishing')) {
+            const [findingsAll, entitiesF, linksF, claimsF, canonF] = await Promise.all([
+                ForensicModel.getAll(), EntityModel.getAll(), EvidenceLinker.getAll(),
+                ClaimModel.getAll(), makeClaimRefCanonicalizer()
+            ]);
+            findingSel  = selectFindingsToPublish({ findings: findingsAll, entities: entitiesF });
+            fMirrorSel  = selectFindingMirrors({ findings: findingsAll, entities: entitiesF });
+            revEdgeSel  = selectRevisionEdgesToPublish({ links: linksF, claims: claimsF, canon: canonF });
+        }
+        const forensicTotal = findingSel.length + fMirrorSel.length + revEdgeSel.length;
+        if (forensicTotal > 0) {
+            const fBase = totalEvents;
+            totalEvents += forensicTotal;
+            let fStep = 0;
+            toast(`Also publishing forensic findings: ${findingSel.length} finding${findingSel.length === 1 ? '' : 's'}`
+                  + (fMirrorSel.length ? ` + ${fMirrorSel.length} mirror${fMirrorSel.length === 1 ? '' : 's'}` : '')
+                  + (revEdgeSel.length ? ` + ${revEdgeSel.length} revision edge${revEdgeSel.length === 1 ? '' : 's'}` : '')
+                  + '…', 'warning', 4000);
+
+            const sendForensic = async (unsigned) => {
+                unsigned.pubkey = userPubkey;
+                return await browserApi.runtime.sendMessage({
+                    type: 'xray:capture:publish', id: state.id, event: unsigned
+                });
+            };
+
+            // Findings (kind 30062). Track those whose 30062 failed this
+            // batch — their mirror must not emit (its target wouldn't be
+            // on relays).
+            const failed30062 = new Set();
+            for (const sel of findingSel) {
+                btn.textContent = `Publishing (${fBase + (++fStep)}/${totalEvents})…`;
+                let landed = false;
+                try {
+                    const { event: unsigned } = await buildBehavioralFindingEvent({
+                        subjectPubkey: sel.subjectPubkey,
+                        maneuver:      sel.finding.maneuver,
+                        role:          sel.finding.role,
+                        anchors:       sel.anchors,
+                        counterNote:   sel.finding.counter_note,
+                        note:          sel.finding.note,
+                        basis:         sel.finding.basis,
+                        sourceUrl:     sel.sourceUrl,
+                        suggestedBy:   sel.finding.suggested_by || 'user'
+                    });
+                    const resp = await sendForensic(unsigned);
+                    if (resp && resp.ok && resp.results) {
+                        recordRelayResults(resp.results);
+                        if (resp.results.successful > 0) {
+                            findingResults.ok++;
+                            landed = true;
+                            try { await ForensicModel.markPublished(sel.finding.id, resp.signedEvent?.id || null, userPubkey); }
+                            catch (_) { /* best-effort */ }
+                        } else {
+                            findingResults.fail++;
+                            findingResults.errors.push(`${sel.finding.maneuver}: no relays accepted`);
+                        }
+                    } else {
+                        findingResults.fail++;
+                        findingResults.errors.push(`${sel.finding.maneuver}: ${(resp && resp.error) || 'unknown'}`);
+                    }
+                } catch (err) {
+                    findingResults.fail++;
+                    findingResults.errors.push(`${sel.finding.maneuver}: ${err.message || String(err)}`);
+                    console.warn('[X-Ray Reader] finding publish failed:', sel.finding.id, err);
+                }
+                if (!landed) failed30062.add(sel.finding.id);
+                setProgress(fBase + fStep, totalEvents);
+                await sleep(BATCH_PUBLISH_DELAY_MS);
+            }
+
+            // Finding mirrors (kind 1985). Skip a candidate whose 30062
+            // was attempted this batch and failed.
+            for (const sel of fMirrorSel) {
+                btn.textContent = `Publishing (${fBase + (++fStep)}/${totalEvents})…`;
+                if (failed30062.has(sel.finding.id)) {
+                    setProgress(fBase + fStep, totalEvents);
+                    await sleep(BATCH_PUBLISH_DELAY_MS);
+                    continue;
+                }
+                try {
+                    const { event: unsigned } = buildForensicFindingMirrorEvent({
+                        subjectPubkey: sel.subjectPubkey,
+                        maneuver:      sel.maneuver,
+                        sourceUrl:     sel.sourceUrl
+                    });
+                    const resp = await sendForensic(unsigned);
+                    if (resp && resp.ok && resp.results) {
+                        recordRelayResults(resp.results);
+                        if (resp.results.successful > 0) {
+                            fMirrorResults.ok++;
+                            try { await ForensicModel.markMirrored(sel.finding.id); }
+                            catch (_) { /* best-effort */ }
+                        } else { fMirrorResults.fail++; fMirrorResults.errors.push('finding mirror: no relays accepted'); }
+                    } else {
+                        fMirrorResults.fail++;
+                        fMirrorResults.errors.push(`finding mirror: ${(resp && resp.error) || 'unknown'}`);
+                    }
+                } catch (err) {
+                    fMirrorResults.fail++;
+                    fMirrorResults.errors.push(`finding mirror: ${err.message || String(err)}`);
+                }
+                setProgress(fBase + fStep, totalEvents);
+                await sleep(BATCH_PUBLISH_DELAY_MS);
+            }
+
+            // Revision edges (kind 30055, the directional story-change links).
+            for (const sel of revEdgeSel) {
+                btn.textContent = `Publishing (${fBase + (++fStep)}/${totalEvents})…`;
+                try {
+                    const { event: unsigned } = await buildClaimRelationshipEvent({
+                        sourceCoord:   sel.source.coord,
+                        targetCoord:   sel.target.coord,
+                        relationship:  sel.link.relationship,
+                        sourceUrl:     sel.source.url,
+                        targetUrl:     sel.target.url,
+                        sourceEventId: sel.source.eventId,
+                        targetEventId: sel.target.eventId,
+                        note:          sel.link.note,
+                        suggestedBy:   sel.link.suggested_by || 'user'
+                    });
+                    const resp = await sendForensic(unsigned);
+                    if (resp && resp.ok && resp.results) {
+                        recordRelayResults(resp.results);
+                        if (resp.results.successful > 0) {
+                            revEdgeResults.ok++;
+                            try { await EvidenceLinker.markPublished(sel.link.id, resp.signedEvent?.id || null); }
+                            catch (_) { /* best-effort */ }
+                        } else {
+                            revEdgeResults.fail++;
+                            revEdgeResults.errors.push(`${sel.link.relationship} edge: no relays accepted`);
+                        }
+                    } else {
+                        revEdgeResults.fail++;
+                        revEdgeResults.errors.push(`${sel.link.relationship} edge: ${(resp && resp.error) || 'unknown'}`);
+                    }
+                } catch (err) {
+                    revEdgeResults.fail++;
+                    revEdgeResults.errors.push(`${sel.link.relationship} edge: ${err.message || String(err)}`);
+                    console.warn('[X-Ray Reader] revision-edge publish failed:', sel.link.id, err);
+                }
+                setProgress(fBase + fStep, totalEvents);
+                await sleep(BATCH_PUBLISH_DELAY_MS);
+            }
+            refreshFindingsBar().catch(() => {});
+        }
+
         // Build + surface the end-of-batch summary.
         showPublishSummary({
             includeComments,
@@ -2660,6 +2820,12 @@ async function publish() {
             jLinkCount: linkSel.length,
             auditResults,
             auditCount,
+            findingResults,
+            findingCount: findingSel.length,
+            fMirrorResults,
+            fMirrorCount: fMirrorSel.length,
+            revEdgeResults,
+            revEdgeCount: revEdgeSel.length,
             relayStats
         });
 
@@ -2852,6 +3018,9 @@ function showPublishSummary({
     assessResults, assessCount = 0, mirrorResults, mirrorCount = 0,
     jLinkResults, jLinkCount = 0,
     auditResults = { ok: 0, fail: 0, errors: [], skipped: 0 }, auditCount = 0,
+    findingResults = { ok: 0, fail: 0, errors: [] }, findingCount = 0,
+    fMirrorResults = { ok: 0, fail: 0, errors: [] }, fMirrorCount = 0,
+    revEdgeResults = { ok: 0, fail: 0, errors: [] }, revEdgeCount = 0,
     relayStats
 }) {
     // Console breakdown (always useful for debugging)
@@ -2865,6 +3034,9 @@ function showPublishSummary({
     if (mirrorResults && mirrorCount > 0)                    console.log('label mirrors:',  mirrorResults);
     if (jLinkResults && jLinkCount > 0)                      console.log('claim links:',    jLinkResults);
     if (auditResults && (auditCount > 0 || auditResults.errors.length > 0 || auditResults.skipped > 0)) console.log('audit events:', auditResults);
+    if (findingResults && findingCount > 0)                  console.log('findings:',       findingResults);
+    if (fMirrorResults && fMirrorCount > 0)                  console.log('finding mirrors:', fMirrorResults);
+    if (revEdgeResults && revEdgeCount > 0)                  console.log('revision edges:',  revEdgeResults);
     console.log('per relay:', Object.fromEntries(relayStats));
     console.groupEnd();
 
@@ -2881,6 +3053,9 @@ function showPublishSummary({
                     + ((mirrorResults && mirrorResults.fail) || 0)
                     + ((jLinkResults && jLinkResults.fail) || 0);
     const audFails  = (auditResults && auditResults.fail) || 0;
+    const forFails  = ((findingResults && findingResults.fail) || 0)
+                    + ((fMirrorResults && fMirrorResults.fail) || 0)
+                    + ((revEdgeResults && revEdgeResults.fail) || 0);
 
     const segments = [];
     segments.push(articleResults.successful > 0
@@ -2911,6 +3086,15 @@ function showPublishSummary({
         segments.push(`${auditResults.ok}/${auditCount} audit event${auditCount === 1 ? '' : 's'}`
             + (auditResults.skipped > 0 ? ` (${auditResults.skipped} skipped)` : ''));
     }
+    if (findingCount > 0) {
+        segments.push(`${findingResults.ok}/${findingCount} finding${findingCount === 1 ? '' : 's'}`);
+    }
+    if (fMirrorCount > 0) {
+        segments.push(`${fMirrorResults.ok}/${fMirrorCount} finding mirror${fMirrorCount === 1 ? '' : 's'}`);
+    }
+    if (revEdgeCount > 0) {
+        segments.push(`${revEdgeResults.ok}/${revEdgeCount} revision edge${revEdgeCount === 1 ? '' : 's'}`);
+    }
     let line = 'Published: ' + segments.join(', ') + '.';
 
     const acceptedAll = [...relayStats.values()].filter((s) => s.fail === 0 && s.ok > 0).length;
@@ -2923,7 +3107,7 @@ function showPublishSummary({
         line += ` Rejected by ${names} — consider removing in Options.`;
     }
 
-    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0 || jdgFails > 0 || audFails > 0;
+    const anyFail = dead.length > 0 || cmtFails > 0 || entFails > 0 || clmFails > 0 || relFails > 0 || jdgFails > 0 || audFails > 0 || forFails > 0;
     const level = (anyFail || articleResults.successful === 0)
         ? (articleResults.successful > 0 ? 'warning' : 'error')
         : 'success';

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -526,7 +526,7 @@ async function refreshClaimsBar() {
 }
 
 // ------------------------------------------------------------------
-// Forensic findings bar (Phase 13.2)
+// Forensic findings bar (Phase 14.2)
 // ------------------------------------------------------------------
 
 /** Tagged entities on this article become the subject choices. */

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -801,6 +801,21 @@ function renderReader() {
                 toast('Claim saved', 'success', 2000);
                 await refreshClaimsBar();
             }
+        },
+        onFinding: async ({ text, anchor }) => {
+            // Open the finding modal seeded with the selected span as the
+            // first evidence anchor — the discoverable path to naming a
+            // maneuver (the "+ Finding" bar button is the other).
+            const result = await openFindingModal({
+                subjectChoices: subjectChoicesFromArticle(),
+                anchorContext:  { container: $('.xr-article__body') },
+                seedAnchor:     { quote: text, selector: anchor },
+                sourceRef:      { url: state.article.url, title: state.article.title || '' }
+            });
+            if (result) {
+                toast(result.deleted ? 'Finding removed' : 'Finding saved', 'success', 1500);
+                await refreshFindingsBar();
+            }
         }
     });
 

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -26,6 +26,11 @@ import { makeClaimRefCanonicalizer } from '../shared/claim-ref.js';
 import { selectAssessmentsToPublish, selectLinksToPublish, selectMirrors } from '../shared/assessment-publish.js';
 import { buildAssessmentEvent, buildClaimRelationshipEvent, buildAssessmentMirrorEvent } from '../shared/metadata/builders.js';
 import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
+import { ForensicModel } from '../shared/forensic-model.js';
+import { openFindingModal, openBaselineModal } from '../shared/forensic-modal.js';
+import { renderFindingsBar } from './findings-section.js';
+import { captureFromRange } from '../shared/metadata/anchor-capture.js';
+import { normalize as normalizeUrl } from '../shared/metadata/url-normalizer.js';
 
 const browserApi = typeof browser !== 'undefined' && browser.runtime ? browser : chrome;
 
@@ -436,6 +441,7 @@ function renderReader() {
     // Render the claims bar below the article body. Fires in the
     // background — we don't block the main render on it.
     refreshClaimsBar().catch((err) => console.warn('[X-Ray Reader] claims-bar render failed:', err));
+    refreshFindingsBar().catch((err) => console.warn('[X-Ray Reader] findings-bar render failed:', err));
 
     // Wire metadata-field edits back to the article object.
     main.querySelectorAll('[contenteditable]').forEach((el) => {
@@ -515,6 +521,95 @@ async function refreshClaimsBar() {
                 toast('Link removed', 'success', 1500);
                 await refreshClaimsBar();
             });
+        });
+    });
+}
+
+// ------------------------------------------------------------------
+// Forensic findings bar (Phase 13.2)
+// ------------------------------------------------------------------
+
+/** Tagged entities on this article become the subject choices. */
+function subjectChoicesFromArticle() {
+    const seen = new Set();
+    const choices = [];
+    for (const e of (state.article && state.article.entities) || []) {
+        if (!e.entity_id || seen.has(e.entity_id)) continue;
+        seen.add(e.entity_id);
+        choices.push({ key: e.entity_id, label: e.name || e.context || e.entity_id });
+    }
+    return choices;
+}
+
+/** The current article-body selection, as a seed anchor (quote + span). */
+function captureSelectionSeed() {
+    const body = $('.xr-article__body');
+    const sel = typeof window !== 'undefined' ? window.getSelection() : null;
+    if (!body || !sel || sel.rangeCount === 0) return null;
+    const range = sel.getRangeAt(0);
+    if (range.collapsed || !body.contains(range.commonAncestorContainer)) return null;
+    const quote = String(range.toString() || '').trim();
+    if (!quote) return null;
+    try {
+        const captured = captureFromRange(range, body);
+        return { quote, selector: captured ? captured.selectors : null };
+    } catch (_) { return { quote, selector: null }; }
+}
+
+/**
+ * Render the findings bar: findings whose evidence is anchored to this
+ * article's URL (findings are keyed by subject, not URL, so we match on
+ * the per-anchor source). Wires the capture affordances + row actions.
+ */
+async function refreshFindingsBar() {
+    const host = $('#xr-findings-host');
+    if (!host || !state.article || !state.article.url) return;
+
+    const url = normalizeUrl(state.article.url);
+    const all = await ForensicModel.getAll();
+    const findings = Object.values(all)
+        .filter((f) => (f.anchors || []).some((a) => a.source_ref && a.source_ref.url === url))
+        .sort((a, b) => (a.created || 0) - (b.created || 0));
+    host.innerHTML = renderFindingsBar(findings);
+
+    const anchorContext  = { container: $('.xr-article__body') };
+    const sourceRef      = { url: state.article.url, title: state.article.title || '' };
+    const subjectChoices = subjectChoicesFromArticle();
+
+    const addBtn = host.querySelector('#xr-findings-add');
+    if (addBtn) addBtn.addEventListener('click', async () => {
+        const seedAnchor = captureSelectionSeed();
+        const result = await openFindingModal({ subjectChoices, anchorContext, seedAnchor, sourceRef });
+        if (result) {
+            toast(result.deleted ? 'Finding removed' : 'Finding saved', 'success', 1500);
+            await refreshFindingsBar();
+        }
+    });
+
+    const baseBtn = host.querySelector('#xr-findings-baseline');
+    if (baseBtn) baseBtn.addEventListener('click', async () => {
+        const result = await openBaselineModal({ subjectChoices, sourceRef });
+        if (result) toast('Baseline saved', 'success', 1500);
+    });
+
+    host.querySelectorAll('.xr-findings__item').forEach((row) => {
+        const id = row.dataset.id;
+        const editBtn = row.querySelector('[data-action="edit"]');
+        const delBtn  = row.querySelector('[data-action="delete"]');
+        if (editBtn) editBtn.addEventListener('click', async () => {
+            const existing = await ForensicModel.get(id);
+            if (!existing) return;
+            const result = await openFindingModal({ subjectChoices, anchorContext, existing, sourceRef });
+            if (result) {
+                toast(result.deleted ? 'Finding removed' : 'Finding saved', 'success', 1500);
+                await refreshFindingsBar();
+            }
+        });
+        if (delBtn) delBtn.addEventListener('click', async () => {
+            if (!confirm('Delete this finding?')) return;
+            await ForensicModel.delete(id);
+            toast('Finding removed', 'success', 1500);
+            await refreshFindingsBar();
         });
     });
 }

--- a/src/shared/assessment-publish.js
+++ b/src/shared/assessment-publish.js
@@ -18,6 +18,7 @@
 // snapshot canonicalizer — no storage access here.
 
 import { isLocalClaimId, parseClaimCoord, buildClaimCoord } from './claim-ref.js';
+import { REVISION_RELATIONSHIPS } from './assessment-taxonomy.js';
 
 /**
  * Wire-readiness of one claim ref. Returns
@@ -86,6 +87,9 @@ export function selectLinksToPublish({ links, claims, canon }) {
     const out = [];
     for (const link of Object.values(links || {})) {
         if (link.relationship === 'contextualizes') continue;
+        // The Phase-14 `revision/*` story-change edges publish under
+        // `forensicPublishing` (forensic-publish.js), not here.
+        if (REVISION_RELATIONSHIPS.includes(link.relationship)) continue;
         if (link.publishedAt && (link.updated || 0) <= link.publishedAt) continue;
         const source = claimWireInfo(claims, canon(link.source_claim_id), link.source_snapshot || {});
         const target = claimWireInfo(claims, canon(link.target_claim_id), link.target_snapshot || {});

--- a/src/shared/assessment-taxonomy.js
+++ b/src/shared/assessment-taxonomy.js
@@ -103,12 +103,12 @@ export function isSymmetricRelationship(relationship) {
 }
 
 /**
- * Phase 13 (docs/CRIMINOLOGY_DESIGN.md) diachronic "story-change"
+ * Phase 14 (docs/CRIMINOLOGY_DESIGN.md) diachronic "story-change"
  * relationship values, additive to the kind-30055 link substrate.
  * All DIRECTIONAL: source = the earlier statement, target = the later.
  * Kept OUT of CLAIM_RELATIONSHIPS so the Phase-11 link picker is
  * unchanged; the linker validates against the union, and a forensic
- * finding (kind 30056) may characterize such an edge.
+ * finding (kind 30062) may characterize such an edge.
  *
  *   - narrative-patch  B is a new explanation added after A was damaged,
  *                      so A's conclusion survives ("covered, not solved")

--- a/src/shared/assessment-taxonomy.js
+++ b/src/shared/assessment-taxonomy.js
@@ -102,6 +102,28 @@ export function isSymmetricRelationship(relationship) {
     return SYMMETRIC_RELATIONSHIPS.includes(relationship);
 }
 
+/**
+ * Phase 13 (docs/CRIMINOLOGY_DESIGN.md) diachronic "story-change"
+ * relationship values, additive to the kind-30055 link substrate.
+ * All DIRECTIONAL: source = the earlier statement, target = the later.
+ * Kept OUT of CLAIM_RELATIONSHIPS so the Phase-11 link picker is
+ * unchanged; the linker validates against the union, and a forensic
+ * finding (kind 30056) may characterize such an edge.
+ *
+ *   - narrative-patch  B is a new explanation added after A was damaged,
+ *                      so A's conclusion survives ("covered, not solved")
+ *   - recharacterizes  B redefines a key term from A to dodge evidence
+ *                      (the diachronic face of defense/definitional-retreat)
+ *   - walks-back       B retreats from / softens A once A was cornered
+ */
+export const REVISION_RELATIONSHIPS = Object.freeze([
+    'narrative-patch', 'recharacterizes', 'walks-back'
+]);
+
+export function isRevisionRelationship(relationship) {
+    return REVISION_RELATIONSHIPS.includes(relationship);
+}
+
 // ------------------------------------------------------------------
 // Provenance — the manual-now / LLM-ready seam.
 // ------------------------------------------------------------------

--- a/src/shared/evidence-linker.js
+++ b/src/shared/evidence-linker.js
@@ -35,7 +35,8 @@ import { Utils } from './utils.js';
 import { ClaimModel } from './claim-model.js';
 import { normalize as normalizeUrl } from './metadata/url-normalizer.js';
 import {
-    CLAIM_RELATIONSHIPS, isSymmetricRelationship, isValidSuggestedBy
+    CLAIM_RELATIONSHIPS, REVISION_RELATIONSHIPS,
+    isSymmetricRelationship, isValidSuggestedBy
 } from './assessment-taxonomy.js';
 import {
     isLocalClaimId, parseClaimCoord, assertValidClaimRef,
@@ -48,22 +49,37 @@ import {
 
 export const EVIDENCE_RELATIONSHIPS = CLAIM_RELATIONSHIPS;
 
+// Every relationship the linker will STORE: the Phase-11 four plus the
+// Phase-13 diachronic `revision/*` values. `EVIDENCE_RELATIONSHIPS`
+// (above) is deliberately the original four so the Phase-11 link picker
+// is unchanged; create() validates against this wider union.
+const ALL_LINK_RELATIONSHIPS = Object.freeze([
+    ...CLAIM_RELATIONSHIPS, ...REVISION_RELATIONSHIPS
+]);
+
 // Legacy `contextualizes` keeps label/icon entries so pre-11.1
-// records render; it is not offered for new links.
+// records render; it is not offered for new links. The `revision/*`
+// values get entries too so diachronic edges render.
 export const EVIDENCE_RELATIONSHIP_LABELS = {
-    contradicts:    'Contradicts',
-    supports:       'Supports',
-    updates:        'Updates',
-    duplicates:     'Duplicates',
-    contextualizes: 'Contextualizes'
+    contradicts:       'Contradicts',
+    supports:          'Supports',
+    updates:           'Updates',
+    duplicates:        'Duplicates',
+    contextualizes:    'Contextualizes',
+    'narrative-patch': 'Patches',
+    recharacterizes:   'Recharacterizes',
+    'walks-back':      'Walks back'
 };
 
 export const EVIDENCE_RELATIONSHIP_ICONS = {
-    contradicts:    '⚔',
-    supports:       '↗',
-    updates:        '↻',
-    duplicates:     '≡',
-    contextualizes: '◇'
+    contradicts:       '⚔',
+    supports:          '↗',
+    updates:           '↻',
+    duplicates:        '≡',
+    contextualizes:    '◇',
+    'narrative-patch': '▥',
+    recharacterizes:   '✎',
+    'walks-back':      '↩'
 };
 
 // ------------------------------------------------------------------
@@ -138,8 +154,8 @@ export async function generateEvidenceLinkId(sourceRef, targetRef, relationship)
 // ------------------------------------------------------------------
 
 function assertValidRelationship(relationship) {
-    if (!CLAIM_RELATIONSHIPS.includes(relationship)) {
-        throw new Error(`Invalid relationship: ${relationship} (expected one of ${CLAIM_RELATIONSHIPS.join(', ')})`);
+    if (!ALL_LINK_RELATIONSHIPS.includes(relationship)) {
+        throw new Error(`Invalid relationship: ${relationship} (expected one of ${ALL_LINK_RELATIONSHIPS.join(', ')})`);
     }
 }
 

--- a/src/shared/evidence-linker.js
+++ b/src/shared/evidence-linker.js
@@ -50,7 +50,7 @@ import {
 export const EVIDENCE_RELATIONSHIPS = CLAIM_RELATIONSHIPS;
 
 // Every relationship the linker will STORE: the Phase-11 four plus the
-// Phase-13 diachronic `revision/*` values. `EVIDENCE_RELATIONSHIPS`
+// Phase-14 diachronic `revision/*` values. `EVIDENCE_RELATIONSHIPS`
 // (above) is deliberately the original four so the Phase-11 link picker
 // is unchanged; create() validates against this wider union.
 const ALL_LINK_RELATIONSHIPS = Object.freeze([

--- a/src/shared/forensic-modal.js
+++ b/src/shared/forensic-modal.js
@@ -1,0 +1,618 @@
+// Forensic finding modal — Phase 13.2 (docs/CRIMINOLOGY_DESIGN.md).
+//
+// The capture UI for one behavioral finding: a subject + role, a single
+// maneuver from the canon-seeded taxonomy (+ a custom escape hatch), an
+// ORDERED evidence chain (each step a quote + optional marked span), a
+// structural `note`, the REQUIRED `counter_note` (the alternative
+// reading), and the `basis` enum that stands in for a score. Saving
+// goes through ForensicModel (create or update).
+//
+// The methodology rules are surfaced in the UI, not just enforced at
+// save: the selected maneuver shows its definition + counter-indicators
+// inline (the falsifiability prompt), the counter-note field is marked
+// required, and there is no stance/score control anywhere — there is no
+// score.
+//
+// UI-in-shared exception, exactly like assess-modal.js: this renders DOM
+// because the finding surface is shared between extension pages. It
+// injects its own <style> (xr-finding-* only) and must NOT be imported
+// by the content script. Span anchoring is capability-gated on
+// `anchorContext.container` (the reader's article body) — the modal
+// minimizes to a pill, the user selects the offending passage, and
+// `captureFromRange` builds the selector array.
+
+import { ForensicModel, ForensicBaseline } from './forensic-model.js';
+import { captureFromRange } from './metadata/anchor-capture.js';
+import {
+    FORENSIC_MANEUVER_GROUPS, MANEUVER_GUIDE, isStandardManeuver, isValidManeuver,
+    ROLES, BASIS_VALUES, isValidBasis
+} from './forensic-taxonomy.js';
+
+const BASIS_LABELS = {
+    quoted:                 'Quoted — a verbatim span',
+    paraphrased:            'Paraphrased — my summary of what was said',
+    'behavioral-cue':       'Behavioral cue — tone / body language (weakest)',
+    'structural-inference': 'Structural inference — the move the structure makes'
+};
+
+// ------------------------------------------------------------------
+// Badges (findings bar)
+// ------------------------------------------------------------------
+
+/**
+ * Compact badge strip for a finding: maneuver pill + role + basis +
+ * published marker. Pure HTML string. Renders nothing for null.
+ */
+export function renderFindingBadges(finding) {
+    if (!finding) return '';
+    ensureStyles();
+    const bits = [];
+    if (finding.publishedAt) {
+        bits.push(`<span class="xr-finding-badge xr-finding-badge--pub" title="Published ${new Date(finding.publishedAt * 1000).toLocaleString()}">🌐</span>`);
+    }
+    const custom = isStandardManeuver(finding.maneuver) ? '' : ' xr-finding-badge--custom';
+    const n = (finding.anchors || []).length;
+    const steps = n > 1 ? ` ·${n}` : '';
+    bits.push(`<span class="xr-finding-badge xr-finding-badge--maneuver${custom}" title="${escapeHtml(finding.maneuver)}">${escapeHtml(finding.maneuver)}${steps}</span>`);
+    if (finding.role) bits.push(`<span class="xr-finding-badge xr-finding-badge--role">${escapeHtml(finding.role)}</span>`);
+    if (finding.basis) bits.push(`<span class="xr-finding-badge xr-finding-badge--basis" title="Evidence basis">${escapeHtml(finding.basis)}</span>`);
+    return `<div class="xr-finding-badges">${bits.join('')}</div>`;
+}
+
+// ------------------------------------------------------------------
+// The finding modal
+// ------------------------------------------------------------------
+
+/**
+ * Open the finding modal.
+ *
+ * @param {{
+ *   subjectChoices?: Array<{ key: string, label: string }>,  // tagged entities
+ *   anchorContext?: { container: Element } | null,
+ *   seedAnchor?: { quote?: string, selector?: any, source_ref?: object } | null,
+ *   existing?: object | null,        // a finding to edit
+ *   sourceRef?: { url?: string, title?: string } | null  // default per-anchor source
+ * }} opts
+ * @returns {Promise<object | {deleted: true} | null>}
+ */
+export async function openFindingModal({
+    subjectChoices = [], anchorContext = null, seedAnchor = null,
+    existing = null, sourceRef = null
+} = {}) {
+    ensureStyles();
+
+    const initialSubjectKey = existing
+        ? (subjectKeyOf(existing.subject_ref) || '__custom__')
+        : (subjectChoices[0] ? subjectChoices[0].key : '__custom__');
+
+    const state = {
+        subjectKey:  initialSubjectKey,
+        customLabel: existing && !subjectChoices.some((c) => c.key === initialSubjectKey)
+            ? (existing.subject_ref.label || '') : '',
+        role:        existing ? existing.role : 'apologist',
+        maneuver:    existing ? existing.maneuver : null,
+        basis:       existing ? existing.basis : 'quoted',
+        note:        existing ? existing.note : '',
+        counter:     existing ? existing.counter_note : '',
+        anchors:     seedAnchors(existing, seedAnchor)
+    };
+
+    return new Promise((resolve) => {
+        const host = document.createElement('div');
+        host.className = 'xr-finding';
+        host.innerHTML = buildHtml(state, subjectChoices, !!existing,
+            !!(anchorContext && anchorContext.container));
+        document.body.appendChild(host);
+
+        const $ = (sel) => host.querySelector(sel);
+        const pill = $('.xr-finding__pill');
+        let markingIndex = null;
+        let markedRange = null;
+
+        const close = (result) => {
+            document.removeEventListener('keydown', onKey);
+            document.removeEventListener('mouseup', onMouseUp);
+            if (host.parentNode) host.parentNode.removeChild(host);
+            resolve(result);
+        };
+        const onKey = (ev) => {
+            if (ev.key !== 'Escape') return;
+            if (markingIndex !== null) { exitMarkMode(false); return; }
+            close(null);
+        };
+        const onMouseUp = () => {
+            if (markingIndex === null || !anchorContext) return;
+            const sel = window.getSelection();
+            if (!sel || sel.rangeCount === 0) return;
+            const range = sel.getRangeAt(0);
+            if (range.collapsed) return;
+            if (!anchorContext.container.contains(range.commonAncestorContainer)) return;
+            markedRange = range.cloneRange();
+            pill.querySelector('[data-action="mark-done"]').disabled = false;
+        };
+
+        function enterMarkMode(i) {
+            markingIndex = i;
+            markedRange = null;
+            host.classList.add('xr-finding--marking');
+            pill.querySelector('[data-action="mark-done"]').disabled = true;
+        }
+        function exitMarkMode(save) {
+            if (save && markedRange && markingIndex !== null && anchorContext) {
+                const captured = captureFromRange(markedRange, anchorContext.container);
+                const a = state.anchors[markingIndex];
+                if (captured && a) {
+                    a.selector = captured.selectors;
+                    if (!a.quote) a.quote = String(markedRange.toString() || '').trim();
+                }
+            }
+            markingIndex = null;
+            markedRange = null;
+            host.classList.remove('xr-finding--marking');
+            renderAnchors();
+        }
+
+        const showError = (msg) => { const e = $('.xr-finding__err'); e.textContent = msg; e.hidden = false; };
+        const clearError = () => { $('.xr-finding__err').hidden = true; };
+
+        // ---- subject + role ----------------------------------------
+        const subjectSel = $('.xr-finding__subject');
+        const customWrap = $('.xr-finding__custom-subject');
+        const syncSubject = () => {
+            state.subjectKey = subjectSel.value;
+            customWrap.hidden = state.subjectKey !== '__custom__';
+        };
+        subjectSel.addEventListener('change', syncSubject);
+        $('.xr-finding__custom-subject-input').addEventListener('input', (ev) => {
+            state.customLabel = ev.target.value;
+        });
+        $('.xr-finding__role').addEventListener('change', (ev) => { state.role = ev.target.value; });
+
+        // ---- maneuver (single-select) ------------------------------
+        const syncManeuver = () => {
+            host.querySelectorAll('.xr-finding__man-btn').forEach((b) => {
+                b.classList.toggle('xr-finding__man-btn--active', b.dataset.man === state.maneuver);
+            });
+            renderGuide();
+        };
+        host.querySelectorAll('.xr-finding__man-btn').forEach((b) => {
+            b.addEventListener('click', () => {
+                state.maneuver = (state.maneuver === b.dataset.man) ? null : b.dataset.man;
+                $('.xr-finding__custom-man-input').value = '';
+                syncManeuver();
+            });
+        });
+        const customManInput = $('.xr-finding__custom-man-input');
+        const addCustomMan = () => {
+            const normalized = String(customManInput.value || '').trim().toLowerCase().replace(/\s+/g, '-');
+            if (!normalized) return;
+            if (!isValidManeuver(normalized)) {
+                showError(`Not a valid maneuver: ${normalized} (lowercase a-z0-9-, one optional "family/" prefix, ≤64 chars)`);
+                return;
+            }
+            clearError();
+            state.maneuver = normalized;
+            syncManeuver();
+        };
+        $('.xr-finding__custom-man-add').addEventListener('click', addCustomMan);
+        customManInput.addEventListener('keydown', (ev) => {
+            if (ev.key === 'Enter') { ev.preventDefault(); addCustomMan(); }
+        });
+
+        function renderGuide() {
+            const wrap = $('.xr-finding__guide');
+            const g = state.maneuver ? MANEUVER_GUIDE[state.maneuver] : null;
+            if (!g) {
+                wrap.innerHTML = state.maneuver
+                    ? `<em>Custom maneuver — describe it in the note, and give the alternative reading below.</em>`
+                    : '';
+                return;
+            }
+            wrap.innerHTML = `
+              <div class="xr-finding__guide-def"><strong>${escapeHtml(state.maneuver)}</strong>${g.alias ? ` <span class="xr-finding__guide-alias">(${escapeHtml(g.alias)})</span>` : ''} — ${escapeHtml(g.definition)} <span class="xr-finding__guide-src">${escapeHtml(g.source)}</span></div>
+              <div class="xr-finding__guide-counter"><span>Would make it NOT this:</span> ${g.counterIndicators.map((c) => escapeHtml(c)).join('; ')}</div>`;
+        }
+
+        // ---- basis -------------------------------------------------
+        $('.xr-finding__basis').addEventListener('change', (ev) => { state.basis = ev.target.value; });
+
+        // ---- ordered evidence chain --------------------------------
+        const canAnchor = !!(anchorContext && anchorContext.container);
+        function renderAnchors() {
+            const wrap = $('.xr-finding__anchors');
+            wrap.innerHTML = state.anchors.map((a, i) => `
+              <div class="xr-finding__anchor" data-i="${i}">
+                <span class="xr-finding__anchor-n">${state.anchors.length > 1 ? `Step ${i + 1}` : 'Evidence'}</span>
+                <input type="text" class="xr-finding__anchor-quote" placeholder="quote the span…" value="${escapeHtml(a.quote || '')}" />
+                ${canAnchor ? `<button type="button" class="xr-finding__anchor-mark" title="${a.selector ? 'Re-mark the span' : 'Mark the span in the article'}">📍${a.selector ? '✓' : ''}</button>` : ''}
+                ${state.anchors.length > 1 ? `<button type="button" class="xr-finding__anchor-del" title="Remove step">✕</button>` : ''}
+              </div>`).join('');
+            wrap.querySelectorAll('.xr-finding__anchor').forEach((row) => {
+                const i = Number(row.dataset.i);
+                row.querySelector('.xr-finding__anchor-quote').addEventListener('input', (ev) => {
+                    state.anchors[i].quote = ev.target.value;
+                });
+                const mark = row.querySelector('.xr-finding__anchor-mark');
+                if (mark) mark.addEventListener('click', () => enterMarkMode(i));
+                const del = row.querySelector('.xr-finding__anchor-del');
+                if (del) del.addEventListener('click', () => {
+                    state.anchors.splice(i, 1);
+                    renderAnchors();
+                });
+            });
+        }
+        $('.xr-finding__anchor-add').addEventListener('click', () => {
+            state.anchors.push({ quote: '', selector: null, source_ref: sourceRef ? { ...sourceRef } : null });
+            renderAnchors();
+        });
+
+        // ---- note + counter ----------------------------------------
+        $('.xr-finding__note').addEventListener('input', (ev) => { state.note = ev.target.value; });
+        $('.xr-finding__counter').addEventListener('input', (ev) => { state.counter = ev.target.value; });
+
+        // ---- footer ------------------------------------------------
+        $('[data-action="cancel"]').addEventListener('click', () => close(null));
+        $('.xr-finding__close').addEventListener('click', () => close(null));
+        $('.xr-finding__backdrop').addEventListener('click', () => { if (markingIndex === null) close(null); });
+        pill.querySelector('[data-action="mark-done"]').addEventListener('click', () => exitMarkMode(true));
+        pill.querySelector('[data-action="mark-cancel"]').addEventListener('click', () => exitMarkMode(false));
+
+        const removeBtn = $('[data-action="remove"]');
+        if (removeBtn) removeBtn.addEventListener('click', async () => {
+            try { await ForensicModel.delete(existing.id); close({ deleted: true }); }
+            catch (err) { showError(err.message || String(err)); }
+        });
+
+        $('[data-action="save"]').addEventListener('click', async () => {
+            clearError();
+            const subject_ref = resolveSubjectRef(state, subjectChoices);
+            const anchors = state.anchors
+                .map((a) => ({
+                    quote: a.quote, selector: a.selector,
+                    source_ref: a.source_ref || (sourceRef ? { ...sourceRef } : null)
+                }))
+                .filter((a) => String(a.quote || '').trim());
+            // Friendly pre-checks (the model enforces these too).
+            if (!state.maneuver) return showError('Pick a maneuver.');
+            if (anchors.length === 0) return showError('Add at least one evidence step with a quote.');
+            if (!String(state.counter || '').trim()) {
+                return showError('A counter-note is required — give the alternative / exonerating reading.');
+            }
+            const fields = {
+                subject_ref, role: state.role, maneuver: state.maneuver,
+                anchors, note: state.note, counter_note: state.counter, basis: state.basis
+            };
+            try {
+                const saved = existing
+                    ? await ForensicModel.update(existing.id, {
+                        role: fields.role, note: fields.note,
+                        counter_note: fields.counter_note, basis: fields.basis
+                    })
+                    : await ForensicModel.create(fields);
+                close(saved);
+            } catch (err) { showError(err.message || String(err)); }
+        });
+
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('mouseup', onMouseUp);
+        syncSubject();
+        syncManeuver();
+        renderAnchors();
+    });
+}
+
+// ------------------------------------------------------------------
+// Baseline modal (Rule 3 — a deviation needs something to deviate from)
+// ------------------------------------------------------------------
+
+/**
+ * Open the baseline-marking modal: a subject + a descriptive register
+ * note (no score). Saves through ForensicBaseline.
+ */
+export async function openBaselineModal({ subjectChoices = [], sourceRef = null } = {}) {
+    ensureStyles();
+    const state = {
+        subjectKey: subjectChoices[0] ? subjectChoices[0].key : '__custom__',
+        customLabel: '', note: ''
+    };
+    return new Promise((resolve) => {
+        const host = document.createElement('div');
+        host.className = 'xr-finding';
+        host.innerHTML = `
+          <div class="xr-finding__backdrop"></div>
+          <div class="xr-finding__card">
+            <header class="xr-finding__head">
+              <h2 class="xr-finding__title">Set behavioral baseline</h2>
+              <button type="button" class="xr-finding__close" aria-label="Cancel">✕</button>
+            </header>
+            <div class="xr-finding__body">
+              <div class="xr-finding__err" hidden></div>
+              <label class="xr-finding__field">
+                <span class="xr-finding__field-label">Subject</span>
+                ${subjectSelectHtml(subjectChoices, state.subjectKey)}
+              </label>
+              <div class="xr-finding__custom-subject" ${state.subjectKey === '__custom__' ? '' : 'hidden'}>
+                <input type="text" class="xr-finding__custom-subject-input" placeholder="subject name…" />
+              </div>
+              <label class="xr-finding__field">
+                <span class="xr-finding__field-label">Baseline register <em>(descriptive — not a score)</em></span>
+                <textarea class="xr-finding__note" rows="3" placeholder="e.g. even tone, fact-anchored, held across the first three sessions"></textarea>
+              </label>
+            </div>
+            <footer class="xr-finding__foot">
+              <span class="xr-finding__foot-gap"></span>
+              <button type="button" class="xr-finding__btn xr-finding__btn--ghost" data-action="cancel">Cancel</button>
+              <button type="button" class="xr-finding__btn xr-finding__btn--primary" data-action="save">Save</button>
+            </footer>
+          </div>`;
+        document.body.appendChild(host);
+        const $ = (s) => host.querySelector(s);
+        const close = (r) => { if (host.parentNode) host.parentNode.removeChild(host); resolve(r); };
+        const showError = (m) => { const e = $('.xr-finding__err'); e.textContent = m; e.hidden = false; };
+
+        const subjectSel = $('.xr-finding__subject');
+        const customWrap = $('.xr-finding__custom-subject');
+        subjectSel.addEventListener('change', () => {
+            state.subjectKey = subjectSel.value;
+            customWrap.hidden = state.subjectKey !== '__custom__';
+        });
+        $('.xr-finding__custom-subject-input').addEventListener('input', (ev) => { state.customLabel = ev.target.value; });
+        $('.xr-finding__note').addEventListener('input', (ev) => { state.note = ev.target.value; });
+        $('.xr-finding__close').addEventListener('click', () => close(null));
+        $('[data-action="cancel"]').addEventListener('click', () => close(null));
+        $('.xr-finding__backdrop').addEventListener('click', () => close(null));
+        $('[data-action="save"]').addEventListener('click', async () => {
+            const subject_ref = resolveSubjectRef(state, subjectChoices);
+            if (!String(state.note || '').trim()) return showError('Describe the baseline register.');
+            try {
+                const saved = await ForensicBaseline.create({
+                    subject_ref, note: state.note,
+                    source_url: (sourceRef && sourceRef.url) || ''
+                });
+                close(saved);
+            } catch (err) { showError(err.message || String(err)); }
+        });
+    });
+}
+
+// ------------------------------------------------------------------
+// Subject-ref helpers
+// ------------------------------------------------------------------
+
+function subjectKeyOf(ref) {
+    return ref && (ref.identity_id || ref.pubkey || ref.account) || '';
+}
+
+function resolveSubjectRef(state, subjectChoices) {
+    if (state.subjectKey === '__custom__') {
+        return { label: String(state.customLabel || '').trim() };
+    }
+    const choice = subjectChoices.find((c) => c.key === state.subjectKey);
+    return { identity_id: state.subjectKey, label: choice ? choice.label : state.subjectKey };
+}
+
+function seedAnchors(existing, seedAnchor) {
+    if (existing && Array.isArray(existing.anchors) && existing.anchors.length) {
+        return existing.anchors.map((a) => ({
+            quote: a.quote || '', selector: a.selector || null, source_ref: a.source_ref || null
+        }));
+    }
+    if (seedAnchor) {
+        return [{ quote: seedAnchor.quote || '', selector: seedAnchor.selector || null,
+                  source_ref: seedAnchor.source_ref || null }];
+    }
+    return [{ quote: '', selector: null, source_ref: null }];
+}
+
+// ------------------------------------------------------------------
+// Markup
+// ------------------------------------------------------------------
+
+function subjectSelectHtml(subjectChoices, selectedKey) {
+    const opts = subjectChoices.map((c) =>
+        `<option value="${escapeHtml(c.key)}" ${c.key === selectedKey ? 'selected' : ''}>${escapeHtml(c.label)}</option>`).join('');
+    const customSelected = selectedKey === '__custom__' ? 'selected' : '';
+    return `<select class="xr-finding__subject">${opts}<option value="__custom__" ${customSelected}>Other…</option></select>`;
+}
+
+function buildHtml(state, subjectChoices, isExisting, canAnchor) {
+    const roleOpts = ROLES.map((r) =>
+        `<option value="${r}" ${r === state.role ? 'selected' : ''}>${escapeHtml(r)}</option>`).join('');
+    const basisOpts = BASIS_VALUES.map((b) =>
+        `<option value="${b}" ${b === state.basis ? 'selected' : ''}>${escapeHtml(BASIS_LABELS[b] || b)}</option>`).join('');
+    const manGroups = Object.entries(FORENSIC_MANEUVER_GROUPS).map(([group, mans]) => `
+        <div class="xr-finding__man-group">
+          <span class="xr-finding__man-group-name">${escapeHtml(group)}</span>
+          <div class="xr-finding__man-labels">
+            ${mans.map((m) => {
+                const g = MANEUVER_GUIDE[m] || {};
+                const short = m.split('/')[1] || m;
+                return `<button type="button" class="xr-finding__man-btn" data-man="${escapeHtml(m)}" title="${escapeHtml(g.definition || m)}">${escapeHtml(short)}</button>`;
+            }).join('')}
+          </div>
+        </div>`).join('');
+
+    return `
+      <div class="xr-finding__backdrop"></div>
+      <div class="xr-finding__card">
+        <header class="xr-finding__head">
+          <h2 class="xr-finding__title">${isExisting ? 'Edit finding' : 'Name a maneuver'}</h2>
+          <button type="button" class="xr-finding__close" aria-label="Cancel">✕</button>
+        </header>
+        <div class="xr-finding__body">
+          <div class="xr-finding__err" hidden></div>
+
+          <div class="xr-finding__row">
+            <label class="xr-finding__field xr-finding__field--grow">
+              <span class="xr-finding__field-label">Subject</span>
+              ${subjectSelectHtml(subjectChoices, state.subjectKey)}
+            </label>
+            <label class="xr-finding__field">
+              <span class="xr-finding__field-label">Role</span>
+              <select class="xr-finding__role">${roleOpts}</select>
+            </label>
+          </div>
+          <div class="xr-finding__custom-subject" ${state.subjectKey === '__custom__' ? '' : 'hidden'}>
+            <input type="text" class="xr-finding__custom-subject-input" placeholder="subject name…"
+                   value="${escapeHtml(state.customLabel)}" />
+          </div>
+
+          <div class="xr-finding__field">
+            <span class="xr-finding__field-label">Maneuver <em>(one)</em></span>
+            ${manGroups}
+            <div class="xr-finding__custom">
+              <input type="text" class="xr-finding__custom-man-input" placeholder="custom maneuver…" spellcheck="false" />
+              <button type="button" class="xr-finding__custom-man-add">Add</button>
+            </div>
+            <div class="xr-finding__guide"></div>
+          </div>
+
+          <div class="xr-finding__field">
+            <span class="xr-finding__field-label">Evidence <em>(ordered — add steps for a sequence)</em></span>
+            <div class="xr-finding__anchors"></div>
+            <button type="button" class="xr-finding__anchor-add">+ evidence step</button>
+          </div>
+
+          <label class="xr-finding__field">
+            <span class="xr-finding__field-label">Basis <em>(how we know — not a score)</em></span>
+            <select class="xr-finding__basis">${basisOpts}</select>
+          </label>
+
+          <label class="xr-finding__field">
+            <span class="xr-finding__field-label">Note <em>(what the structure does, optional)</em></span>
+            <textarea class="xr-finding__note" rows="2" placeholder="Describe the move — structure, not intent.">${escapeHtml(state.note)}</textarea>
+          </label>
+
+          <label class="xr-finding__field">
+            <span class="xr-finding__field-label xr-finding__field-label--req">Counter-note <em>(required — the alternative reading)</em></span>
+            <textarea class="xr-finding__counter" rows="2" placeholder="What would make this NOT this? The exonerating read.">${escapeHtml(state.counter)}</textarea>
+          </label>
+        </div>
+        <footer class="xr-finding__foot">
+          ${isExisting ? '<button type="button" class="xr-finding__btn xr-finding__btn--danger" data-action="remove">Remove</button>' : ''}
+          <span class="xr-finding__foot-gap"></span>
+          <button type="button" class="xr-finding__btn xr-finding__btn--ghost" data-action="cancel">Cancel</button>
+          <button type="button" class="xr-finding__btn xr-finding__btn--primary" data-action="save">Save</button>
+        </footer>
+      </div>
+      <div class="xr-finding__pill">
+        📍 Select the span in the article, then
+        <button type="button" data-action="mark-done" disabled>Done</button>
+        <button type="button" data-action="mark-cancel">Cancel</button>
+      </div>`;
+}
+
+// ------------------------------------------------------------------
+// Styles
+// ------------------------------------------------------------------
+
+let stylesInjected = false;
+function ensureStyles() {
+    if (stylesInjected || typeof document === 'undefined') return;
+    stylesInjected = true;
+    const style = document.createElement('style');
+    style.id = 'xr-finding-styles';
+    style.textContent = `
+.xr-finding { position: fixed; inset: 0; z-index: 10010; }
+.xr-finding__backdrop { position: absolute; inset: 0; background: rgba(0,0,0,.55); }
+.xr-finding__card {
+  position: relative; margin: 5vh auto 0; width: min(600px, calc(100vw - 32px));
+  max-height: 88vh; display: flex; flex-direction: column;
+  background: var(--xr-surface, #242424); color: var(--xr-text, #e6e6e6);
+  border: 1px solid var(--xr-border, #333); border-radius: 10px;
+  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+.xr-finding--marking .xr-finding__card, .xr-finding--marking .xr-finding__backdrop { display: none; }
+.xr-finding__pill {
+  display: none; position: fixed; left: 50%; bottom: 24px; transform: translateX(-50%);
+  background: var(--xr-surface, #242424); color: var(--xr-text, #e6e6e6);
+  border: 1px solid var(--xr-primary, #8b5cf6); border-radius: 999px;
+  padding: 8px 14px; z-index: 10011; box-shadow: 0 4px 18px rgba(0,0,0,.4); font-size: 13px;
+}
+.xr-finding--marking .xr-finding__pill { display: block; }
+.xr-finding__pill button { margin-left: 6px; }
+.xr-finding__head, .xr-finding__foot { display: flex; align-items: center; gap: 8px; padding: 12px 16px; }
+.xr-finding__head { border-bottom: 1px solid var(--xr-border, #333); }
+.xr-finding__foot { border-top: 1px solid var(--xr-border, #333); }
+.xr-finding__foot-gap { flex: 1; }
+.xr-finding__title { margin: 0; font-size: 15px; flex: 1; }
+.xr-finding__close { background: none; border: none; color: inherit; cursor: pointer; font-size: 14px; }
+.xr-finding__body { padding: 12px 16px; overflow-y: auto; }
+.xr-finding__err {
+  background: color-mix(in srgb, var(--xr-danger, #f87171) 18%, transparent);
+  border: 1px solid var(--xr-danger, #f87171); border-radius: 6px;
+  padding: 6px 10px; margin-bottom: 10px; font-size: 12.5px;
+}
+.xr-finding__row { display: flex; gap: 10px; }
+.xr-finding__field { display: block; margin-bottom: 14px; }
+.xr-finding__field--grow { flex: 1; }
+.xr-finding__field-label { display: block; font-size: 11px; text-transform: uppercase;
+  letter-spacing: .04em; color: var(--xr-text-dim, #9a9a9a); margin-bottom: 6px; }
+.xr-finding__field-label em { text-transform: none; letter-spacing: 0; }
+.xr-finding__field-label--req { color: var(--xr-warning, #fbbf24); }
+.xr-finding__subject, .xr-finding__role, .xr-finding__basis,
+.xr-finding__custom-subject-input, .xr-finding__note, .xr-finding__counter,
+.xr-finding__anchor-quote, .xr-finding__custom-man-input {
+  width: 100%; box-sizing: border-box; padding: 5px 8px; border-radius: 6px; font: 13px/1.4 inherit;
+  background: var(--xr-surface-2, #2e2e2e); color: inherit; border: 1px solid var(--xr-border, #333);
+}
+.xr-finding__note, .xr-finding__counter { resize: vertical; }
+.xr-finding__custom-subject { margin: -8px 0 12px; }
+.xr-finding__man-group { margin-bottom: 6px; }
+.xr-finding__man-group-name { font-size: 10.5px; color: var(--xr-text-dim, #9a9a9a);
+  text-transform: capitalize; display: inline-block; width: 100px; vertical-align: top; padding-top: 4px; }
+.xr-finding__man-labels { display: inline-flex; gap: 4px; flex-wrap: wrap; width: calc(100% - 106px); }
+.xr-finding__man-btn {
+  padding: 2px 8px; border-radius: 999px; font-size: 11.5px; cursor: pointer;
+  background: var(--xr-surface-2, #2e2e2e); color: inherit; border: 1px solid var(--xr-border, #333);
+}
+.xr-finding__man-btn--active {
+  border-color: var(--xr-warning, #fbbf24);
+  background: color-mix(in srgb, var(--xr-warning, #fbbf24) 22%, transparent);
+}
+.xr-finding__custom { display: flex; gap: 6px; margin-top: 6px; }
+.xr-finding__custom-man-add { padding: 4px 10px; border-radius: 6px; cursor: pointer;
+  background: var(--xr-surface-2, #2e2e2e); color: inherit; border: 1px solid var(--xr-border, #333); }
+.xr-finding__guide { margin-top: 8px; font-size: 12px; }
+.xr-finding__guide-def { color: var(--xr-text, #e6e6e6); margin-bottom: 4px; }
+.xr-finding__guide-alias { color: var(--xr-text-dim, #9a9a9a); }
+.xr-finding__guide-src { color: var(--xr-text-dim, #9a9a9a); font-style: italic; }
+.xr-finding__guide-counter { color: var(--xr-text-dim, #9a9a9a); }
+.xr-finding__guide-counter span { color: var(--xr-warning, #fbbf24); }
+.xr-finding__anchor { display: flex; align-items: center; gap: 6px; margin-bottom: 4px; }
+.xr-finding__anchor-n { font-size: 11px; color: var(--xr-text-dim, #9a9a9a); min-width: 56px; }
+.xr-finding__anchor-mark, .xr-finding__anchor-del {
+  background: none; border: 1px solid var(--xr-border, #333); border-radius: 6px;
+  color: inherit; cursor: pointer; font-size: 11px; padding: 4px 6px; flex: none;
+}
+.xr-finding__anchor-add { margin-top: 4px; padding: 3px 10px; border-radius: 6px; cursor: pointer;
+  background: var(--xr-surface-2, #2e2e2e); color: inherit; border: 1px solid var(--xr-border, #333); font-size: 12px; }
+.xr-finding__btn { padding: 6px 14px; border-radius: 6px; cursor: pointer; font-size: 13px;
+  border: 1px solid var(--xr-border, #333); background: var(--xr-surface-2, #2e2e2e); color: inherit; }
+.xr-finding__btn--primary { background: var(--xr-primary, #8b5cf6); border-color: var(--xr-primary, #8b5cf6); color: #fff; }
+.xr-finding__btn--danger { border-color: var(--xr-danger, #f87171); color: var(--xr-danger, #f87171); background: none; }
+/* badge strip */
+.xr-finding-badges { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
+.xr-finding-badge {
+  display: inline-block; padding: 1px 8px; border-radius: 999px; font-size: 11px;
+  background: var(--xr-surface-2, #2e2e2e); border: 1px solid var(--xr-border, #333); color: var(--xr-text, #e6e6e6);
+}
+.xr-finding-badge--maneuver { border-color: var(--xr-warning, #fbbf24); }
+.xr-finding-badge--custom { border-style: dashed; }
+.xr-finding-badge--role { color: var(--xr-text-dim, #9a9a9a); }
+.xr-finding-badge--basis { color: var(--xr-text-dim, #9a9a9a); }
+.xr-finding-badge--pub { border-color: var(--xr-success, #34d399); padding: 1px 5px; }
+`;
+    document.head.appendChild(style);
+}
+
+function escapeHtml(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+}
+
+// `isValidBasis` is imported for parity with the model's validation
+// surface; the <select> can only emit valid values, but a future
+// programmatic caller may not.
+export { isValidBasis };

--- a/src/shared/forensic-modal.js
+++ b/src/shared/forensic-modal.js
@@ -1,4 +1,4 @@
-// Forensic finding modal — Phase 13.2 (docs/CRIMINOLOGY_DESIGN.md).
+// Forensic finding modal — Phase 14.2 (docs/CRIMINOLOGY_DESIGN.md).
 //
 // The capture UI for one behavioral finding: a subject + role, a single
 // maneuver from the canon-seeded taxonomy (+ a custom escape hatch), an

--- a/src/shared/forensic-model.js
+++ b/src/shared/forensic-model.js
@@ -1,0 +1,357 @@
+// Forensic finding model — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+//
+// A BehavioralFinding names a MANEUVER a subject performs around the
+// truth — an evasion, an immunizing defense, a self-serving revision —
+// and binds it to evidence. It is the companion to the Phase 11
+// assessment: where an assessment grades whether a CLAIM is true, a
+// finding describes what a SUBJECT is doing, and renders no verdict on
+// honesty or intent.
+//
+// The six methodology rules (CRIMINOLOGY_DESIGN.md) are enforced here,
+// not just documented:
+//   1. Structure, not intent — there is NO lying/intent/confidence field.
+//   2. Evidence-bound       — at least one anchor (with a quote) is required.
+//   6. Falsifiability       — a non-empty `counter_note` is required.
+// `basis` (quoted | paraphrased | behavioral-cue | structural-inference)
+// records HOW WE KNOW, in place of a numeric score.
+//
+// The id hashes (subject | maneuver | anchors), so create() is
+// idempotent — re-recording the same maneuver against the same subject
+// with the same evidence returns the existing record.
+//
+// Storage: Storage.get('behavioral_findings', {}) keyed by finding id —
+// the same single-key id→record map as 'claim_assessments'. Baselines
+// live under 'forensic_baselines'. Wire mapping (kind 30056) lands in
+// slice 13.3; publishing is gated behind the `forensicPublishing` flag.
+
+import { Storage } from './storage.js';
+import { Crypto } from './crypto.js';
+import { Utils } from './utils.js';
+import { normalize as normalizeUrl } from './metadata/url-normalizer.js';
+import {
+    isValidManeuver, isValidRole, isValidBasis, isValidSuggestedBy
+} from './forensic-taxonomy.js';
+
+const FINDINGS_KEY  = 'behavioral_findings';
+const BASELINES_KEY = 'forensic_baselines';
+
+// ------------------------------------------------------------------
+// Subject ref + canonical key
+// ------------------------------------------------------------------
+
+/**
+ * The stable string a subject answers to, for id derivation and
+ * lookup. Prefers the most durable identifier present: a resolved
+ * identity id, then a pubkey, then a platform account handle, then the
+ * display label as a last resort. Mirrors the claim-ref "one logical
+ * thing ⇒ one canonical key" idea without needing the relay round-trip.
+ */
+export function subjectRefKey(ref) {
+    const r = ref || {};
+    const pick = r.identity_id || r.pubkey || r.account || r.label || '';
+    return String(pick).trim().toLowerCase();
+}
+
+function cleanSubjectRef(input) {
+    const r = input || {};
+    const identity_id = r.identity_id ? String(r.identity_id) : null;
+    const pubkey      = (typeof r.pubkey === 'string' && /^[0-9a-f]{64}$/.test(r.pubkey)) ? r.pubkey : null;
+    const account     = r.account ? String(r.account) : null;
+    const label       = String(r.label || '').trim();
+    if (!identity_id && !pubkey && !account && !label) {
+        throw new Error('subject_ref needs one of identity_id / pubkey / account / label');
+    }
+    return { identity_id, pubkey, account, label };
+}
+
+// ------------------------------------------------------------------
+// Anchors (the evidence chain)
+// ------------------------------------------------------------------
+
+/**
+ * Normalize the ordered evidence chain. At least one anchor is
+ * required, and each anchor must carry a non-empty `quote` — a finding
+ * with no quotable evidence cannot be saved (Rule 2). `selector` is
+ * optional (tests and not-yet-anchored captures may omit it); the
+ * source URL is stored normalized + verbatim like the assessment URL
+ * rule.
+ */
+function cleanAnchors(anchors) {
+    if (!Array.isArray(anchors) || anchors.length === 0) {
+        throw new Error('A finding needs at least one evidence anchor');
+    }
+    return anchors.map((a, i) => {
+        const rec = a || {};
+        const quote = String(rec.quote || '').trim();
+        if (!quote) throw new Error(`Anchor ${i} needs a non-empty quote`);
+        const src = rec.source_ref || {};
+        const rawUrl = src.url ? String(src.url) : '';
+        const source_ref = (src && (src.url || src.coord || src.event_id || src.title)) ? {
+            url:      rawUrl ? normalizeUrl(rawUrl) : '',
+            url_raw:  src.url_raw || rawUrl,
+            title:    src.title || null,
+            coord:    src.coord || null,
+            event_id: src.event_id || null
+        } : null;
+        const ts = (rec.timestamp === 0 || rec.timestamp)
+            ? Number(rec.timestamp) : null;
+        return {
+            selector:  rec.selector || null,
+            quote,
+            source_ref,
+            timestamp: Number.isFinite(ts) ? ts : null,
+            step_note: rec.step_note ? String(rec.step_note) : ''
+        };
+    });
+}
+
+async function anchorsHash(anchors) {
+    // Stable over the load-bearing parts only (selector + quote + ts),
+    // so an edited step-note doesn't fork the id.
+    const key = JSON.stringify(anchors.map((a) => [a.selector, a.quote, a.timestamp]));
+    return await Crypto.sha256(key);
+}
+
+// ------------------------------------------------------------------
+// ID derivation
+// ------------------------------------------------------------------
+
+/**
+ * Deterministic id from (subjectKey | maneuver | anchorsHash). NOTE:
+ * this is the LOCAL id; the kind-30056 wire d-tag hashes the subject
+ * ref + maneuver + anchors at publish time (slice 13.3) — local ids
+ * never hit the wire.
+ */
+export async function generateFindingId(subjectKey, maneuver, anchors) {
+    const ah = await anchorsHash(anchors);
+    const hash = await Crypto.sha256(`${subjectKey}|${maneuver}|${ah}`);
+    return `find_${hash.slice(0, 16)}`;
+}
+
+// ------------------------------------------------------------------
+// Validation helpers
+// ------------------------------------------------------------------
+
+function assertValidManeuver(maneuver) {
+    if (!isValidManeuver(maneuver)) throw new Error(`Invalid maneuver: ${maneuver}`);
+    return maneuver;
+}
+
+function assertValidRole(role) {
+    if (!isValidRole(role)) throw new Error(`Invalid role: ${role}`);
+    return role;
+}
+
+function assertValidBasis(basis) {
+    const v = basis || 'structural-inference';
+    if (!isValidBasis(v)) throw new Error(`Invalid basis: ${v}`);
+    return v;
+}
+
+function assertValidSuggestedBy(value) {
+    const v = value === undefined || value === null ? 'user' : value;
+    if (!isValidSuggestedBy(v)) {
+        throw new Error(`Invalid suggested_by: ${v} (expected 'user' or 'llm:<model>')`);
+    }
+    return v;
+}
+
+function assertCounterNote(value) {
+    const v = String(value || '').trim();
+    // Rule 6 — the falsifiability discipline. A finding that implicates a
+    // subject cannot be saved without the alternative reading.
+    if (!v) throw new Error('A finding needs a counter_note (the alternative reading)');
+    return v;
+}
+
+// ------------------------------------------------------------------
+// CRUD — findings
+// ------------------------------------------------------------------
+
+export const ForensicModel = {
+    get: async (id) => {
+        if (!id) return null;
+        const all = await Storage.get(FINDINGS_KEY, {});
+        return all[id] || null;
+    },
+
+    getAll: async () => {
+        return await Storage.get(FINDINGS_KEY, {});
+    },
+
+    /** Every finding about a subject, matched on the canonical subject key. */
+    getForSubject: async (ref) => {
+        const key = subjectRefKey(ref);
+        if (!key) return [];
+        const all = await Storage.get(FINDINGS_KEY, {});
+        const out = Object.values(all).filter((f) => subjectRefKey(f.subject_ref) === key);
+        out.sort((a, b) => (a.created || 0) - (b.created || 0));
+        return out;
+    },
+
+    /**
+     * Create a finding. Required: `subject_ref` (one durable id +
+     * label), `role`, `maneuver`, a non-empty `anchors` chain, and a
+     * `counter_note`. No stance, no score, no intent field exists to
+     * supply. Idempotent on (subject, maneuver, anchors).
+     */
+    create: async (fields) => {
+        const given = fields || {};
+        const subject_ref = cleanSubjectRef(given.subject_ref);
+        const role        = assertValidRole(given.role);
+        const maneuver    = assertValidManeuver(given.maneuver);
+        const anchors     = cleanAnchors(given.anchors);
+        const counter_note = assertCounterNote(given.counter_note);
+        const basis       = assertValidBasis(given.basis);
+        const suggested_by = assertValidSuggestedBy(given.suggested_by);
+
+        const id = await generateFindingId(subjectRefKey(subject_ref), maneuver, anchors);
+        const all = await Storage.get(FINDINGS_KEY, {});
+        if (all[id]) return all[id];   // idempotent
+
+        const now = Math.floor(Date.now() / 1000);
+        const record = {
+            id,
+            subject_ref,
+            role,
+            maneuver,
+            anchors,
+            baseline_ref: given.baseline_ref ? String(given.baseline_ref) : null,
+            note:         String(given.note || ''),
+            counter_note,
+            basis,
+            related_rel:  given.related_rel ? String(given.related_rel) : null,
+            suggested_by,
+            created:          now,
+            updated:          now,
+            publishedAt:      null,
+            publishedEventId: null,
+            publishedPubkey:  null
+        };
+        all[id] = record;
+        await Storage.set(FINDINGS_KEY, all);
+        Utils.log('Created forensic finding:', id, maneuver);
+        return record;
+    },
+
+    /**
+     * Patch a finding. `subject_ref` / `maneuver` / `anchors` are
+     * IMMUTABLE — they derive the id; to change them, delete + recreate.
+     * Patchable: role, note, counter_note (still required non-empty),
+     * basis, baseline_ref, related_rel, suggested_by.
+     */
+    update: async (id, updates) => {
+        const all = await Storage.get(FINDINGS_KEY, {});
+        const record = all[id];
+        if (!record) throw new Error(`Finding not found: ${id}`);
+        const patched = { ...record };
+        if ('role' in updates)         patched.role = assertValidRole(updates.role);
+        if ('note' in updates)         patched.note = String(updates.note || '');
+        if ('counter_note' in updates) patched.counter_note = assertCounterNote(updates.counter_note);
+        if ('basis' in updates)        patched.basis = assertValidBasis(updates.basis);
+        if ('baseline_ref' in updates) patched.baseline_ref = updates.baseline_ref ? String(updates.baseline_ref) : null;
+        if ('related_rel' in updates)  patched.related_rel = updates.related_rel ? String(updates.related_rel) : null;
+        if ('suggested_by' in updates) patched.suggested_by = assertValidSuggestedBy(updates.suggested_by);
+        patched.updated = Math.floor(Date.now() / 1000);
+        all[id] = patched;
+        await Storage.set(FINDINGS_KEY, all);
+        return patched;
+    },
+
+    delete: async (id) => {
+        const all = await Storage.get(FINDINGS_KEY, {});
+        if (!all[id]) return false;
+        delete all[id];
+        await Storage.set(FINDINGS_KEY, all);
+        return true;
+    },
+
+    /**
+     * Record a successful kind-30056 publish. Does NOT bump `updated`,
+     * so edits after a publish correctly re-emit next time.
+     */
+    markPublished: async (id, eventId, pubkey) => {
+        const all = await Storage.get(FINDINGS_KEY, {});
+        const record = all[id];
+        if (!record) return null;
+        record.publishedAt = Math.floor(Date.now() / 1000);
+        if (eventId) record.publishedEventId = eventId;
+        if (pubkey)  record.publishedPubkey = pubkey;
+        all[id] = record;
+        await Storage.set(FINDINGS_KEY, all);
+        return record;
+    }
+};
+
+// ------------------------------------------------------------------
+// CRUD — baselines (Rule 3: deviation needs something to deviate from)
+// ------------------------------------------------------------------
+
+/** Deterministic baseline id from (subjectKey | sourceUrl). */
+export async function generateBaselineId(subjectKey, sourceUrl) {
+    const hash = await Crypto.sha256(`${subjectKey}|${normalizeUrl(sourceUrl || '')}`);
+    return `baseline_${hash.slice(0, 16)}`;
+}
+
+export const ForensicBaseline = {
+    get: async (id) => {
+        if (!id) return null;
+        const all = await Storage.get(BASELINES_KEY, {});
+        return all[id] || null;
+    },
+
+    getForSubject: async (ref) => {
+        const key = subjectRefKey(ref);
+        if (!key) return [];
+        const all = await Storage.get(BASELINES_KEY, {});
+        return Object.values(all).filter((b) => subjectRefKey(b.subject_ref) === key);
+    },
+
+    /**
+     * Record a subject's established register for a source — descriptive
+     * prose (+ optional illustrative anchors), never a score. Idempotent
+     * on (subject, source url): re-marking updates the note in place.
+     */
+    create: async (fields) => {
+        const given = fields || {};
+        const subject_ref = cleanSubjectRef(given.subject_ref);
+        const sourceUrlRaw = String((given.source_ref && given.source_ref.url) || given.source_url || '');
+        const note = String(given.note || '').trim();
+        if (!note) throw new Error('A baseline needs a descriptive note');
+
+        const id = await generateBaselineId(subjectRefKey(subject_ref), sourceUrlRaw);
+        const all = await Storage.get(BASELINES_KEY, {});
+        const now = Math.floor(Date.now() / 1000);
+        const anchors = Array.isArray(given.anchors) && given.anchors.length
+            ? cleanAnchors(given.anchors) : [];
+        if (all[id]) {
+            const patched = { ...all[id], note, anchors, updated: now };
+            all[id] = patched;
+            await Storage.set(BASELINES_KEY, all);
+            return patched;
+        }
+        const record = {
+            id,
+            subject_ref,
+            source_ref: sourceUrlRaw ? {
+                url: normalizeUrl(sourceUrlRaw), url_raw: sourceUrlRaw
+            } : null,
+            note,
+            anchors,
+            created: now,
+            updated: now
+        };
+        all[id] = record;
+        await Storage.set(BASELINES_KEY, all);
+        Utils.log('Created forensic baseline:', id);
+        return record;
+    },
+
+    delete: async (id) => {
+        const all = await Storage.get(BASELINES_KEY, {});
+        if (!all[id]) return false;
+        delete all[id];
+        await Storage.set(BASELINES_KEY, all);
+        return true;
+    }
+};

--- a/src/shared/forensic-model.js
+++ b/src/shared/forensic-model.js
@@ -35,6 +35,71 @@ import {
 const FINDINGS_KEY  = 'behavioral_findings';
 const BASELINES_KEY = 'forensic_baselines';
 
+const FORENSIC_NAMESPACE = 'xray/forensic';
+const COUNTER_HEADING = '### Counter-read';
+
+// ------------------------------------------------------------------
+// Wire read-back (Phase 14.3)
+// ------------------------------------------------------------------
+
+/**
+ * Inverse of metadata/builders.js `buildBehavioralFindingEvent` —
+ * reconstruct a finding from a kind-30062 event, for the portal's
+ * read-back path. Pure and defensive (the parseAssessmentEvent style):
+ * returns null for a wrong-kind event or one with no maneuver (the
+ * structural minimum). `note`/`counter_note` split on the LAST
+ * `### Counter-read` heading in content; `maneuver-step` tags are read
+ * in their declared index order.
+ */
+export function parseBehavioralFindingEvent(event) {
+    if (!event || event.kind !== 30062) return null;
+    const tags = event.tags || [];
+    const first = (name) => { const t = tags.find((x) => x[0] === name); return t ? t[1] : ''; };
+
+    const lTag = tags.find((x) => x[0] === 'l' && x[2] === FORENSIC_NAMESPACE);
+    const maneuver = lTag ? lTag[1] : '';
+    if (!maneuver) return null;
+
+    const subjectP = tags.find((x) => x[0] === 'p' && x[3] === 'subject')
+        || tags.find((x) => x[0] === 'p');
+
+    const anchors = tags
+        .filter((x) => x[0] === 'maneuver-step')
+        .sort((a, b) => (Number(a[1]) || 0) - (Number(b[1]) || 0))
+        .map((x) => {
+            let selector = null;
+            if (x[3]) { try { selector = JSON.parse(x[3]); } catch (_) { /* stays null */ } }
+            const ts = x[4] !== undefined && x[4] !== '' ? Number(x[4]) : null;
+            return { quote: x[2] || '', selector, timestamp: Number.isFinite(ts) ? ts : null };
+        });
+
+    const content = event.content || '';
+    const idx = content.lastIndexOf(COUNTER_HEADING);
+    let note = content, counterNote = '';
+    if (idx >= 0) {
+        note = content.slice(0, idx).trim();
+        counterNote = content.slice(idx + COUNTER_HEADING.length).trim();
+    }
+
+    const relA = tags.find((x) => x[0] === 'a' && /^30055:/.test(x[1] || ''));
+    return {
+        id:                 first('d') || event.id || '',
+        subjectPubkey:      (subjectP && subjectP[1]) || null,
+        maneuver,
+        role:               first('role') || null,
+        anchors,
+        note,
+        counterNote,
+        basis:              first('basis') || null,
+        url:                first('r') || null,
+        relationshipCoord:  (relA && relA[1]) || null,
+        suggestedBy:        first('suggested-by') || 'user',
+        pubkey:             event.pubkey || '',
+        created_at:         event.created_at || 0,
+        eventId:            event.id || null
+    };
+}
+
 // ------------------------------------------------------------------
 // Subject ref + canonical key
 // ------------------------------------------------------------------

--- a/src/shared/forensic-model.js
+++ b/src/shared/forensic-model.js
@@ -1,4 +1,4 @@
-// Forensic finding model — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+// Forensic finding model — Phase 14.1 (docs/CRIMINOLOGY_DESIGN.md).
 //
 // A BehavioralFinding names a MANEUVER a subject performs around the
 // truth — an evasion, an immunizing defense, a self-serving revision —
@@ -21,8 +21,8 @@
 //
 // Storage: Storage.get('behavioral_findings', {}) keyed by finding id —
 // the same single-key id→record map as 'claim_assessments'. Baselines
-// live under 'forensic_baselines'. Wire mapping (kind 30056) lands in
-// slice 13.3; publishing is gated behind the `forensicPublishing` flag.
+// live under 'forensic_baselines'. Wire mapping (kind 30062) lands in
+// slice 14.3; publishing is gated behind the `forensicPublishing` flag.
 
 import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
@@ -118,8 +118,8 @@ async function anchorsHash(anchors) {
 
 /**
  * Deterministic id from (subjectKey | maneuver | anchorsHash). NOTE:
- * this is the LOCAL id; the kind-30056 wire d-tag hashes the subject
- * ref + maneuver + anchors at publish time (slice 13.3) — local ids
+ * this is the LOCAL id; the kind-30062 wire d-tag hashes the subject
+ * ref + maneuver + anchors at publish time (slice 14.3) — local ids
  * never hit the wire.
  */
 export async function generateFindingId(subjectKey, maneuver, anchors) {
@@ -267,7 +267,7 @@ export const ForensicModel = {
     },
 
     /**
-     * Record a successful kind-30056 publish. Does NOT bump `updated`,
+     * Record a successful kind-30062 publish. Does NOT bump `updated`,
      * so edits after a publish correctly re-emit next time.
      */
     markPublished: async (id, eventId, pubkey) => {

--- a/src/shared/forensic-model.js
+++ b/src/shared/forensic-model.js
@@ -335,13 +335,17 @@ export const ForensicModel = {
      * Record a successful kind-30062 publish. Does NOT bump `updated`,
      * so edits after a publish correctly re-emit next time.
      */
-    markPublished: async (id, eventId, pubkey) => {
+    markPublished: async (id, eventId, pubkey, dTag) => {
         const all = await Storage.get(FINDINGS_KEY, {});
         const record = all[id];
         if (!record) return null;
         record.publishedAt = Math.floor(Date.now() / 1000);
         if (eventId) record.publishedEventId = eventId;
         if (pubkey)  record.publishedPubkey = pubkey;
+        // The wire d-tag (find:<sha16…>) — recorded so the portal can
+        // rebuild the 30062 coordinate for reconciliation without
+        // re-deriving the anchors hash.
+        if (dTag) record.publishedDTag = dTag;
         all[id] = record;
         await Storage.set(FINDINGS_KEY, all);
         return record;

--- a/src/shared/forensic-model.js
+++ b/src/shared/forensic-model.js
@@ -345,6 +345,22 @@ export const ForensicModel = {
         all[id] = record;
         await Storage.set(FINDINGS_KEY, all);
         return record;
+    },
+
+    /**
+     * Record a successful kind-1985 maneuver-mirror publish. Tracked
+     * SEPARATELY from `publishedAt` (kind 1985 is non-replaceable), so a
+     * rejected mirror retries while its 30062 stays published. Does not
+     * bump `updated`.
+     */
+    markMirrored: async (id) => {
+        const all = await Storage.get(FINDINGS_KEY, {});
+        const record = all[id];
+        if (!record) return null;
+        record.mirroredAt = Math.floor(Date.now() / 1000);
+        all[id] = record;
+        await Storage.set(FINDINGS_KEY, all);
+        return record;
     }
 };
 

--- a/src/shared/forensic-publish.js
+++ b/src/shared/forensic-publish.js
@@ -1,0 +1,116 @@
+// Forensic publish selection — Phase 14 publish wiring
+// (docs/CRIMINOLOGY_DESIGN.md). The flag-gated cousin of
+// assessment-publish.js: pure, unit-testable selection logic for which
+// behavioral findings, finding mirrors, and revision/* edges are
+// wire-ready in a publish batch.
+//
+//   - a FINDING publishes when its subject resolves to a pubkey: an
+//     external `subject_ref.pubkey`, or a tagged entity's keypair
+//     (`identity_id` → registry → `keypair.pubkey`). A subject known
+//     only by label/handle can't publish yet — it waits for the user to
+//     link it to a keyed entity. The usual `updated > publishedAt`
+//     staleness gate applies.
+//   - a finding MIRROR (kind 1985) is keyed on `mirroredAt`, like the
+//     assessment mirror, so a rejected mirror retries.
+//   - a REVISION edge is a kind-30055 link whose relationship is one of
+//     the `revision/*` values; both claim endpoints must be wire-ready
+//     (reusing assessment-publish's `claimWireInfo`). These are gated by
+//     `forensicPublishing`, NOT `assessmentPublishing` — the assessment
+//     link selector deliberately skips them.
+
+import { claimWireInfo } from './assessment-publish.js';
+import { REVISION_RELATIONSHIPS } from './assessment-taxonomy.js';
+
+const HEX64 = /^[0-9a-f]{64}$/;
+
+/**
+ * Resolve a finding's `subject_ref` to a publishable 64-hex pubkey, or
+ * null when it can't be wired yet. An external `pubkey` wins; otherwise
+ * a tagged entity's `keypair.pubkey` (the same registry path the
+ * assessment about-entity mirror uses).
+ */
+export function resolveSubjectPubkey(subjectRef, entities) {
+    const r = subjectRef || {};
+    if (typeof r.pubkey === 'string' && HEX64.test(r.pubkey)) return r.pubkey;
+    if (r.identity_id && entities) {
+        const ent = entities[r.identity_id];
+        const pk = ent && ent.keypair && ent.keypair.pubkey;
+        if (typeof pk === 'string' && HEX64.test(pk)) return pk;
+    }
+    return null;
+}
+
+/** The verbatim source URL for a finding's wire `r` — the first anchor that has one. */
+function findingSourceUrl(finding) {
+    for (const a of finding.anchors || []) {
+        const s = a && a.source_ref;
+        if (s && (s.url_raw || s.url)) return s.url_raw || s.url;
+    }
+    return '';
+}
+
+/** Map stored anchors to the builder's `{quote, selector, timestamp}` shape. */
+function wireAnchors(finding) {
+    return (finding.anchors || []).map((a) => ({
+        quote:     a.quote,
+        selector:  a.selector || null,
+        timestamp: a.timestamp == null ? null : a.timestamp
+    }));
+}
+
+/**
+ * Findings that are wire-ready (subject resolvable) and stale. Each
+ * entry: `{ finding, subjectPubkey, sourceUrl, anchors }`.
+ */
+export function selectFindingsToPublish({ findings, entities }) {
+    const out = [];
+    for (const f of Object.values(findings || {})) {
+        if (f.publishedAt && (f.updated || 0) <= f.publishedAt) continue;
+        const subjectPubkey = resolveSubjectPubkey(f.subject_ref, entities);
+        if (!subjectPubkey) continue;   // subject not keyed yet — a later batch / never
+        const anchors = wireAnchors(f);
+        if (!anchors.length || !anchors.some((a) => String(a.quote || '').trim())) continue;
+        out.push({ finding: f, subjectPubkey, sourceUrl: findingSourceUrl(f), anchors });
+    }
+    out.sort((x, y) => (x.finding.created || 0) - (y.finding.created || 0));
+    return out;
+}
+
+/**
+ * The kind-1985 maneuver mirrors to publish: every wire-ready finding
+ * not yet mirrored (`mirroredAt` unset). Keyed on mirror state, not the
+ * finding's publish state — a rejected mirror retries next batch. The
+ * reader still skips a candidate whose 30062 was attempted this batch
+ * and failed.
+ */
+export function selectFindingMirrors({ findings, entities }) {
+    const out = [];
+    for (const f of Object.values(findings || {})) {
+        if (f.mirroredAt) continue;
+        const subjectPubkey = resolveSubjectPubkey(f.subject_ref, entities);
+        if (!subjectPubkey) continue;
+        out.push({ finding: f, subjectPubkey, maneuver: f.maneuver, sourceUrl: findingSourceUrl(f) });
+    }
+    out.sort((x, y) => (x.finding.created || 0) - (y.finding.created || 0));
+    return out;
+}
+
+/**
+ * The `revision/*` story-change edges to publish — kind-30055 links
+ * whose relationship is a revision value, wire-ready on both endpoints.
+ * Each entry: `{ link, source, target }` (the selectLinksToPublish
+ * shape), so the reader emits them with the same builder.
+ */
+export function selectRevisionEdgesToPublish({ links, claims, canon }) {
+    const out = [];
+    for (const link of Object.values(links || {})) {
+        if (!REVISION_RELATIONSHIPS.includes(link.relationship)) continue;
+        if (link.publishedAt && (link.updated || 0) <= link.publishedAt) continue;
+        const source = claimWireInfo(claims, canon(link.source_claim_id), link.source_snapshot || {});
+        const target = claimWireInfo(claims, canon(link.target_claim_id), link.target_snapshot || {});
+        if (!source || !target) continue;
+        out.push({ link, source, target });
+    }
+    out.sort((x, y) => (x.link.created || 0) - (y.link.created || 0));
+    return out;
+}

--- a/src/shared/forensic-taxonomy.js
+++ b/src/shared/forensic-taxonomy.js
@@ -1,0 +1,337 @@
+// Forensic taxonomy — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+//
+// Single source of truth for the behavioral-finding vocabulary: the
+// maneuver families (seeded from the criminology / thought-reform
+// canon), the subject role enum, and the evidence `basis` enum. Model
+// validation, the picker UI (13.2), the wire builders (13.3), and the
+// NIP draft all read from here — extending the vocabulary means editing
+// this file *and* the exhaustive-enum tests that pin it.
+//
+// A finding names a MANEUVER a subject performs around the truth and
+// binds it to evidence. It carries NO stance, NO score, and NO intent
+// field — by construction (see CRIMINOLOGY_DESIGN.md §Methodology). The
+// `basis` enum records *how we know* (a quote vs. a body-language read);
+// it is a bounded, checkable statement, not a 0–100 confidence.
+//
+// Every standard maneuver ships with a MANEUVER_GUIDE entry pairing a
+// canon citation + Dawn-alias + definition with INDICATORS and
+// COUNTER-INDICATORS — so "what would make this NOT this" is always on
+// the page (the falsifiability discipline; pinned by a test).
+
+import { isValidSuggestedBy, REVISION_RELATIONSHIPS } from './assessment-taxonomy.js';
+
+// NIP-32 namespace the maneuvers publish under (`['L', <ns>]` +
+// `['l', <maneuver>, <ns>]` on kind 30056, mirrored to kind 1985).
+export const FORENSIC_MANEUVER_NAMESPACE = 'xray/forensic';
+
+/**
+ * The maneuver families, grouped for the picker UI. Values are the
+ * exact strings that hit the wire — lowercase, hyphenated, each family
+ * namespaced by its `family/` prefix. Reuse `fallacy/*` and
+ * `consistency/*` from the assessment taxonomy where Dawn's vocabulary
+ * already coincides (strawman = "reduction challenge", false-dilemma =
+ * "false dilemma framing", moved-goalposts, flip-flop) — this file only
+ * adds the behavioral / institutional families that have no home there.
+ */
+export const FORENSIC_MANEUVER_GROUPS = Object.freeze({
+    // Sykes & Matza 1957 (+ Klockars 1974, Minor 1981).
+    neutralization: Object.freeze([
+        'neutralization/deny-responsibility', 'neutralization/deny-injury',
+        'neutralization/deny-victim', 'neutralization/condemn-condemners',
+        'neutralization/higher-loyalties', 'neutralization/ledger',
+        'neutralization/necessity', 'neutralization/normalcy',
+        'neutralization/deny-negative-intent'
+    ]),
+    // Freyd 1997 — Deny, Attack, Reverse Victim & Offender.
+    darvo: Object.freeze([
+        'darvo/deny', 'darvo/attack', 'darvo/reverse-victim-offender'
+    ]),
+    // Lifton 1961 — eight criteria of thought reform.
+    'thought-reform': Object.freeze([
+        'thought-reform/milieu-control', 'thought-reform/loading-the-language',
+        'thought-reform/sacred-science', 'thought-reform/doctrine-over-person',
+        'thought-reform/dispensing-of-existence', 'thought-reform/demand-for-purity',
+        'thought-reform/thought-terminating-cliche'
+    ]),
+    // Popper 1963 / Lakatos 1970 / Proctor 2008 (agnotology).
+    defense: Object.freeze([
+        'defense/ad-hoc-patch', 'defense/immunizing-stratagem',
+        'defense/manufactured-doubt', 'defense/frame-control',
+        'defense/definitional-retreat', 'defense/presentism',
+        'defense/usefulness-pivot', 'defense/credibility-armor'
+    ]),
+    // Finkelhor 1984 / Craven, Brown & Gilchrist 2006 — ORDERED sequence.
+    grooming: Object.freeze([
+        'grooming/build-vulnerability', 'grooming/establish-trust',
+        'grooming/redefine-boundaries', 'grooming/apply-pressure'
+    ])
+});
+
+/** Flat list of every standard maneuver. */
+export const FORENSIC_MANEUVERS = Object.freeze(
+    Object.values(FORENSIC_MANEUVER_GROUPS).flat()
+);
+
+export function isStandardManeuver(maneuver) {
+    return FORENSIC_MANEUVERS.includes(maneuver);
+}
+
+// Custom maneuvers ride the same rails as standard ones (and as
+// assessment labels): a lowercase token, optionally one `family/value`
+// namespace segment, ≤ 64 chars. Anything that passes is stored and
+// published verbatim under the same namespace.
+const MANEUVER_RE = /^[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)?$/;
+
+export function isValidManeuver(maneuver) {
+    return typeof maneuver === 'string'
+        && maneuver.length > 0
+        && maneuver.length <= 64
+        && MANEUVER_RE.test(maneuver);
+}
+
+// ------------------------------------------------------------------
+// Subject role — who is being profiled, in what capacity. The
+// taxonomy carries no side: every role is runnable against either
+// interlocutor (the bias-symmetry requirement).
+// ------------------------------------------------------------------
+
+export const ROLES = Object.freeze([
+    'apologist', 'critic', 'institution', 'witness', 'survivor', 'other'
+]);
+
+export function isValidRole(role) {
+    return ROLES.includes(role);
+}
+
+// ------------------------------------------------------------------
+// Evidence basis — *how we know*, in place of a numeric score. Ordered
+// strongest → weakest; `behavioral-cue` (micro-expression / body
+// language) is the lowest-evidentiary tier and is never aggregated
+// into a score, because there is no score.
+// ------------------------------------------------------------------
+
+export const BASIS_VALUES = Object.freeze([
+    'quoted', 'paraphrased', 'behavioral-cue', 'structural-inference'
+]);
+
+export function isValidBasis(value) {
+    return BASIS_VALUES.includes(value);
+}
+
+// Re-exported so the model + UI pull the whole forensic vocabulary from
+// one place. REVISION_RELATIONSHIPS are the diachronic story-change
+// edge types — they live on kind 30055 (the link substrate), not on a
+// finding, so they are defined in assessment-taxonomy.js next to the
+// rest of the claim-relationship vocabulary and surfaced here.
+export { isValidSuggestedBy, REVISION_RELATIONSHIPS };
+
+// ------------------------------------------------------------------
+// Maneuver guide — canon citation, Dawn-alias, definition, and the
+// indicators / counter-indicators that keep each finding falsifiable.
+// Consumed by the finding modal (tooltips), the LLM-assist prompt, and
+// the NIP draft. A test pins that every standard maneuver has an entry
+// with at least one counter-indicator.
+// ------------------------------------------------------------------
+
+export const MANEUVER_GUIDE = Object.freeze({
+    'neutralization/deny-responsibility': {
+        source: 'Sykes & Matza 1957',
+        definition: 'Recasts the act as caused by forces outside the actor’s control.',
+        indicators: ['"I had no choice"', 'blames circumstance or conditioning'],
+        counterIndicators: ['the constraint named is externally verifiable',
+            'the actor does not also claim the act was good']
+    },
+    'neutralization/deny-injury': {
+        source: 'Sykes & Matza 1957',
+        definition: 'Minimizes or denies that any harm occurred.',
+        indicators: ['"no one was really hurt"', '"it was the way of the time"'],
+        counterIndicators: ['the existence of harm is genuinely contested on evidence']
+    },
+    'neutralization/deny-victim': {
+        source: 'Sykes & Matza 1957',
+        definition: 'Reframes the injured party as deserving it or as not a victim.',
+        indicators: ['"they had it coming"', 'victim recast as the aggressor'],
+        counterIndicators: ['a real, documented prior provocation exists']
+    },
+    'neutralization/condemn-condemners': {
+        source: 'Sykes & Matza 1957',
+        alias: 'attack the questioner',
+        definition: 'Deflects by attacking the motives or legitimacy of the critics.',
+        indicators: ['"you’re just biased / an anti"', 'critic’s character substituted for the claim'],
+        counterIndicators: ['a specific, evidenced conflict of interest is raised, not a blanket smear']
+    },
+    'neutralization/higher-loyalties': {
+        source: 'Sykes & Matza 1957',
+        definition: 'Subordinates the norm to a higher allegiance (faith, family, cause).',
+        indicators: ['"I answer to God / the brethren, not to you"'],
+        counterIndicators: ['the loyalty is openly avowed, not a post-hoc shield']
+    },
+    'neutralization/ledger': {
+        source: 'Klockars 1974',
+        alias: 'metaphor of the ledger',
+        definition: 'Offsets the act against accumulated good deeds.',
+        indicators: ['"look at all the good we do"', 'good works cited as a credit balance'],
+        counterIndicators: ['the good and the harm are genuinely independent, not being traded off']
+    },
+    'neutralization/necessity': {
+        source: 'Minor 1981',
+        alias: 'defense of necessity',
+        definition: 'Casts the act as unavoidable given the situation.',
+        indicators: ['"it had to be done"'],
+        counterIndicators: ['an actual forced choice, with no alternative, is shown']
+    },
+    'neutralization/normalcy': {
+        source: 'Coleman 1994 (claim of normalcy)',
+        alias: 'everybody does it',
+        definition: 'Neutralizes by appeal to ubiquity.',
+        indicators: ['"everyone did it back then"'],
+        counterIndicators: ['the prevalence claim is accurately stated, not invented']
+    },
+    'neutralization/deny-negative-intent': {
+        source: 'Henry 1990',
+        definition: 'Concedes the act but denies any bad intent.',
+        indicators: ['"I was just joking"', '"that’s not what I meant"'],
+        counterIndicators: ['a contemporaneous record corroborates the benign intent']
+    },
+    'darvo/deny': {
+        source: 'Freyd 1997',
+        definition: 'Flat denial of the conduct under challenge.',
+        indicators: ['categorical "that never happened"'],
+        counterIndicators: ['the denial is specific and falsifiable, not blanket']
+    },
+    'darvo/attack': {
+        source: 'Freyd 1997',
+        definition: 'Attacks the person raising the issue.',
+        indicators: ['pivot to the critic’s credibility or tone'],
+        counterIndicators: ['a concrete, evidenced objection to method — not motive']
+    },
+    'darvo/reverse-victim-offender': {
+        source: 'Freyd 1997',
+        alias: 'victim-flip',
+        definition: 'Recasts the responsible party as the true victim.',
+        indicators: ['"I’m the one being persecuted here"', 'enforcement framed as self-defense'],
+        counterIndicators: ['a genuine, documented harm to the speaker exists']
+    },
+    'thought-reform/milieu-control': {
+        source: 'Lifton 1961',
+        alias: 'cognitive containment',
+        definition: 'Controls which information and views are admissible.',
+        indicators: ['"don’t listen to the other side"', 'other views framed as unsafe / immoral / irrational'],
+        counterIndicators: ['engages the strongest opposing source on the merits']
+    },
+    'thought-reform/loading-the-language': {
+        source: 'Lifton 1961',
+        alias: 'semantic inversion',
+        definition: 'A word keeps its authority while its meaning is quietly reversed or softened.',
+        indicators: ['"translation" → "revelation / inspiration" after the evidence failed'],
+        counterIndicators: ['the redefinition predates, rather than follows, the damaging evidence']
+    },
+    'thought-reform/sacred-science': {
+        source: 'Lifton 1961',
+        alias: 'credibility armor / trust-credential spoofing',
+        definition: 'Treats a doctrine or authority as beyond question.',
+        indicators: ['a title or role used as proof', '"a prophet can’t lead you astray"'],
+        counterIndicators: ['the authority’s claims are themselves held open to test']
+    },
+    'thought-reform/doctrine-over-person': {
+        source: 'Lifton 1961',
+        definition: 'Privileges the doctrine over lived experience or evidence.',
+        indicators: ['"your experience must be wrong"'],
+        counterIndicators: ['the experience cited is itself unreliable on independent grounds']
+    },
+    'thought-reform/dispensing-of-existence': {
+        source: 'Lifton 1961',
+        definition: 'Casts outsiders or critics as illegitimate or doomed.',
+        indicators: ['"apostates end up miserable / nihilist"'],
+        counterIndicators: ['the outcome claim is backed by representative evidence, not anecdote']
+    },
+    'thought-reform/demand-for-purity': {
+        source: 'Lifton 1961',
+        definition: 'Enforces an all-or-nothing standard.',
+        indicators: ['black-and-white framing of belief or loyalty'],
+        counterIndicators: ['the standard is explicit and applied to the speaker too']
+    },
+    'thought-reform/thought-terminating-cliche': {
+        source: 'Lifton 1961',
+        definition: 'A stock phrase that closes inquiry.',
+        indicators: ['"it’s messy but true"', '"milk before meat"'],
+        counterIndicators: ['the phrase is followed by — not a substitute for — an argument']
+    },
+    'defense/ad-hoc-patch': {
+        source: 'Popper 1963',
+        alias: 'narrative patching',
+        definition: 'A new explanation added after a claim is damaged, preserving the original conclusion.',
+        indicators: ['the new story appears exactly when the evidence lands', '"catalyst theory"'],
+        counterIndicators: ['the patch makes an independent, testable prediction']
+    },
+    'defense/immunizing-stratagem': {
+        source: 'Lakatos 1970',
+        alias: 'systemic overextension',
+        definition: 'Each contradiction spawns a workaround until the claim is unfalsifiable.',
+        indicators: ['accumulating exceptions', '"you can’t prove it didn’t happen"'],
+        counterIndicators: ['the defense gives something up to gain coherence']
+    },
+    'defense/manufactured-doubt': {
+        source: 'Proctor 2008 (agnotology)',
+        alias: 'epistemological fog',
+        definition: 'Blurs the evidence field so that no conclusion feels reachable.',
+        indicators: ['"we’re only arguing plausibility"', '"it could be anywhere"'],
+        counterIndicators: ['the uncertainty cited is real and load-bearing, not generalized']
+    },
+    'defense/frame-control': {
+        source: 'Goffman 1974 / Entman 1993',
+        alias: 'framing',
+        definition: 'Sets the conversation’s boundaries so some facts feel out of bounds.',
+        indicators: ['shrinking the target', '"that’s not what this is about"'],
+        counterIndicators: ['the reframing is announced and reversible']
+    },
+    'defense/definitional-retreat': {
+        source: 'Popper 1963',
+        definition: 'Redefines a key term to dodge a refutation (the point-in-time face of loading-the-language).',
+        indicators: ['the term’s meaning shifts mid-argument'],
+        counterIndicators: ['the new definition is applied consistently, including against the speaker']
+    },
+    'defense/presentism': {
+        source: 'Butterfield 1931 (defensive use)',
+        definition: 'Deflects a moral challenge by appeal to "the standards of the time".',
+        indicators: ['"it was acceptable then"'],
+        counterIndicators: ['contemporaneous sources show the conduct was in fact contested at the time']
+    },
+    'defense/usefulness-pivot': {
+        source: 'James 1907 (pragmatism, misapplied)',
+        definition: 'Shifts the debate from "is it true" to "is it useful / good fruits".',
+        indicators: ['"look at the good it does"', 'a truth claim swapped for a utility claim'],
+        counterIndicators: ['utility is offered alongside, not instead of, the truth claim']
+    },
+    'defense/credibility-armor': {
+        source: 'Cialdini 1984 (authority)',
+        alias: 'trust-credential spoofing',
+        definition: 'Uses a credential, role, or platform to bypass scrutiny — having the credential is fine; using it as proof is the move.',
+        indicators: ['"as an expert / a bishop, trust me"'],
+        counterIndicators: ['the credential is relevant and the argument still stands without it']
+    },
+    'grooming/build-vulnerability': {
+        source: 'Finkelhor 1984',
+        definition: 'Identifies and cultivates a target’s susceptibility (sequence step 1).',
+        indicators: ['isolates the target', 'exploits a need or insecurity'],
+        counterIndicators: ['the attention is age-appropriate and non-isolating']
+    },
+    'grooming/establish-trust': {
+        source: 'Craven, Brown & Gilchrist 2006',
+        definition: 'Manufactures closeness or authority to lower defenses (sequence step 2).',
+        indicators: ['special-relationship framing'],
+        counterIndicators: ['the closeness is transparent and reciprocal, not secrecy-bound']
+    },
+    'grooming/redefine-boundaries': {
+        source: 'Craven, Brown & Gilchrist 2006',
+        definition: 'Incrementally normalizes boundary-crossing (sequence step 3).',
+        indicators: ['reframes the transgressive as ordinary or spiritual'],
+        counterIndicators: ['boundary changes are consensual, documented, and reversible']
+    },
+    'grooming/apply-pressure': {
+        source: 'Craven, Brown & Gilchrist 2006',
+        definition: 'Converts the relationship into compliance via obligation or fear (sequence step 4).',
+        indicators: ['spiritual or social pressure to comply'],
+        counterIndicators: ['compliance is freely refusable without penalty']
+    }
+});

--- a/src/shared/forensic-taxonomy.js
+++ b/src/shared/forensic-taxonomy.js
@@ -1,9 +1,9 @@
-// Forensic taxonomy — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+// Forensic taxonomy — Phase 14.1 (docs/CRIMINOLOGY_DESIGN.md).
 //
 // Single source of truth for the behavioral-finding vocabulary: the
 // maneuver families (seeded from the criminology / thought-reform
 // canon), the subject role enum, and the evidence `basis` enum. Model
-// validation, the picker UI (13.2), the wire builders (13.3), and the
+// validation, the picker UI (14.2), the wire builders (14.3), and the
 // NIP draft all read from here — extending the vocabulary means editing
 // this file *and* the exhaustive-enum tests that pin it.
 //
@@ -21,7 +21,7 @@
 import { isValidSuggestedBy, REVISION_RELATIONSHIPS } from './assessment-taxonomy.js';
 
 // NIP-32 namespace the maneuvers publish under (`['L', <ns>]` +
-// `['l', <maneuver>, <ns>]` on kind 30056, mirrored to kind 1985).
+// `['l', <maneuver>, <ns>]` on kind 30062, mirrored to kind 1985).
 export const FORENSIC_MANEUVER_NAMESPACE = 'xray/forensic';
 
 /**

--- a/src/shared/metadata/builders.js
+++ b/src/shared/metadata/builders.js
@@ -33,8 +33,12 @@
 import { normalize } from './url-normalizer.js';
 import {
   ASSESSMENT_LABEL_NAMESPACE, isValidLabel, isValidStance,
-  isValidSuggestedBy, CLAIM_RELATIONSHIPS, isSymmetricRelationship
+  isValidSuggestedBy, CLAIM_RELATIONSHIPS, REVISION_RELATIONSHIPS,
+  isSymmetricRelationship
 } from '../assessment-taxonomy.js';
+import {
+  FORENSIC_MANEUVER_NAMESPACE, isValidManeuver, isValidRole, isValidBasis
+} from '../forensic-taxonomy.js';
 
 // ------------------------------------------------------------------
 // Common helpers
@@ -627,8 +631,12 @@ export async function buildClaimRelationshipEvent({
 } = {}) {
   assertClaimCoordinate(sourceCoord, 'buildClaimRelationshipEvent', 'sourceCoord');
   assertClaimCoordinate(targetCoord, 'buildClaimRelationshipEvent', 'targetCoord');
-  if (!CLAIM_RELATIONSHIPS.includes(relationship)) {
-    throw new Error(`buildClaimRelationshipEvent: relationship must be one of ${CLAIM_RELATIONSHIPS.join(', ')} (got ${relationship})`);
+  // Phase 14.3: the directional `revision/*` story-change values join the
+  // Phase-11 four on this kind. They are never symmetric, so the
+  // endpoint sort below correctly leaves source = earlier, target = later.
+  const ALL_RELATIONSHIPS = [...CLAIM_RELATIONSHIPS, ...REVISION_RELATIONSHIPS];
+  if (!ALL_RELATIONSHIPS.includes(relationship)) {
+    throw new Error(`buildClaimRelationshipEvent: relationship must be one of ${ALL_RELATIONSHIPS.join(', ')} (got ${relationship})`);
   }
   if (sourceCoord === targetCoord) {
     throw new Error('buildClaimRelationshipEvent: cannot link a claim to itself');
@@ -719,6 +727,194 @@ export function buildAssessmentMirrorEvent({
   if (claimUrl) tags.push(tag('r', claimUrl));
   tags.push(tag('client', 'xray'));
 
+  return {
+    event: { kind: 1985, created_at: createdAt, tags, content: '' },
+    body: '',
+    dTag: null
+  };
+}
+
+// ------------------------------------------------------------------
+// BehavioralFinding — kind 30062 (Phase 14.3; publish flag-gated)
+// ------------------------------------------------------------------
+
+// The content carries the structural `note` then the REQUIRED
+// `counter_note`, split by this stable heading. Parsers split on its
+// LAST occurrence, so a note that happens to contain the heading can't
+// swallow the appended counter-read.
+export const FORENSIC_COUNTER_HEADING = '### Counter-read';
+
+function cleanFindingSteps(anchors, fnName) {
+  if (!Array.isArray(anchors) || anchors.length === 0) {
+    throw new Error(`${fnName}: at least one evidence anchor (with a quote) required`);
+  }
+  return anchors.map((a, i) => {
+    const quote = String((a && a.quote) || '').trim();
+    if (!quote) throw new Error(`${fnName}: anchor ${i} needs a non-empty quote`);
+    const ts = a && (a.timestamp === 0 || a.timestamp) ? Number(a.timestamp) : null;
+    return {
+      quote,
+      selector: a && a.selector != null ? a.selector : null,
+      timestamp: Number.isFinite(ts) ? ts : null
+    };
+  });
+}
+
+/**
+ * Build an unsigned kind 30062 BehavioralFinding event (NIP draft
+ * §30062) — names a MANEUVER a subject performs around the truth and
+ * binds it to an ordered evidence chain. The companion to the kind-30054
+ * assessment: where an assessment grades a *claim*, a finding describes
+ * a *subject's* move, and renders NO verdict on honesty or intent.
+ *
+ * Firewall (enforced by construction, pinned by tests): the closed tag
+ * vocabulary never emits `stance`, `rating-value`, or the
+ * `xray/assessment` namespace — a forensic finding is a distinct
+ * aggregation signal that consumers MUST NOT merge with assessments.
+ *
+ * Wire rules (docs/CRIMINOLOGY_DESIGN.md §30062):
+ *   - the subject is referenced by `p` with a `subject` slot-4 marker;
+ *     the finding publishes against a RESOLVED subject pubkey, so local
+ *     subject refs (label/account) never hit the wire.
+ *   - `d` = find:<sha16(subjectPubkey|maneuver|anchorsHash)> is
+ *     recomputable from the event's own tags (`p` + `l` + the ordered
+ *     `maneuver-step` tags), so edits replace (NIP-01).
+ *   - `L`/`l` carry the maneuver under `xray/forensic`; a kind-1985
+ *     mirror (buildForensicFindingMirrorEvent) is the NIP-32 path.
+ *   - `maneuver-step` tags are ordered `[index, quote, selector-json,
+ *     timestamp]`; n>1 is a sequence. Multi-letter tags (`role`,
+ *     `maneuver-step`, `basis`, `suggested-by`) are not relay-indexed.
+ *   - `content` = the structural `note`, then the REQUIRED `counter_note`
+ *     under the `### Counter-read` heading (the falsifiability rule).
+ *
+ * @param {object} args
+ * @param {string} args.subjectPubkey       — 64-hex (required; the `p` subject)
+ * @param {string} args.maneuver            — taxonomy value (required)
+ * @param {string} args.role                — role enum (required)
+ * @param {Array<{quote,selector?,timestamp?}>} args.anchors — ordered, ≥1
+ * @param {string} args.counterNote         — REQUIRED (the alternative reading)
+ * @param {string} [args.note]              — structural rationale (markdown)
+ * @param {string} [args.basis='structural-inference']
+ * @param {string} [args.sourceUrl]         — verbatim, for `r`/`i`/`k`
+ * @param {string} [args.relationshipCoord] — optional `30055:…` revision edge
+ * @param {string} [args.suggestedBy='user']
+ * @param {number} [args.createdAt]
+ * @returns {Promise<{event, body, dTag}>}
+ */
+export async function buildBehavioralFindingEvent({
+  subjectPubkey,
+  maneuver,
+  role,
+  anchors = [],
+  counterNote,
+  note = '',
+  basis = 'structural-inference',
+  sourceUrl = '',
+  relationshipCoord = null,
+  suggestedBy = 'user',
+  createdAt = nowSeconds()
+} = {}) {
+  if (!/^[0-9a-f]{64}$/.test(String(subjectPubkey || ''))) {
+    throw new Error('buildBehavioralFindingEvent: subjectPubkey must be a 64-hex pubkey (a finding publishes against a resolved subject)');
+  }
+  if (!isValidManeuver(maneuver)) {
+    throw new Error(`buildBehavioralFindingEvent: invalid maneuver (got ${maneuver})`);
+  }
+  if (!isValidRole(role)) {
+    throw new Error(`buildBehavioralFindingEvent: invalid role (got ${role})`);
+  }
+  if (!isValidBasis(basis)) {
+    throw new Error(`buildBehavioralFindingEvent: invalid basis (got ${basis})`);
+  }
+  const cn = String(counterNote || '').trim();
+  if (!cn) {
+    throw new Error('buildBehavioralFindingEvent: counterNote required (the alternative reading)');
+  }
+  if (relationshipCoord != null && !/^30055:[0-9a-f]{64}:.+$/.test(String(relationshipCoord))) {
+    throw new Error(`buildBehavioralFindingEvent: relationshipCoord must be a 30055 coordinate (got ${relationshipCoord})`);
+  }
+  const provenance = assertSuggestedBy(suggestedBy, 'buildBehavioralFindingEvent');
+  const steps = cleanFindingSteps(anchors, 'buildBehavioralFindingEvent');
+
+  // anchorsHash over the wire-visible step data, so the `d` recomputes
+  // from the `maneuver-step` tags alone.
+  const preimage = steps.map((s) => [
+    s.quote,
+    s.selector ? JSON.stringify(s.selector) : '',
+    s.timestamp == null ? '' : String(s.timestamp)
+  ]);
+  const anchorsHash = await sha256Hex(JSON.stringify(preimage));
+  const dTag = 'find:' + (await sha16(`${subjectPubkey}|${maneuver}|${anchorsHash}`));
+
+  const tags = [
+    tag('d', dTag),
+    tag('p', subjectPubkey, '', 'subject'),
+    tag('L', FORENSIC_MANEUVER_NAMESPACE),
+    tag('l', maneuver, FORENSIC_MANEUVER_NAMESPACE),
+    tag('role', role)
+  ];
+  if (sourceUrl) {
+    tags.push(tag('r', sourceUrl));
+    tags.push(tag('i', normalize(sourceUrl)));
+    tags.push(tag('k', 'web'));
+  }
+  if (relationshipCoord) tags.push(tag('a', relationshipCoord));
+  steps.forEach((s, i) => {
+    tags.push(tag('maneuver-step', String(i), s.quote,
+      s.selector ? JSON.stringify(s.selector) : '',
+      s.timestamp == null ? '' : String(s.timestamp)));
+  });
+  tags.push(tag('basis', basis));
+  tags.push(tag('suggested-by', provenance));
+  tags.push(tag('client', 'xray'));
+
+  const body = `${String(note || '').trim()}\n\n${FORENSIC_COUNTER_HEADING}\n\n${cn}`;
+  return {
+    event: { kind: 30062, created_at: createdAt, tags, content: body },
+    body,
+    dTag
+  };
+}
+
+/**
+ * Build an unsigned kind 1985 label event mirroring a finding's
+ * maneuver — the NIP-32 ecosystem-aggregation path for forensic
+ * findings (NIP draft §30062).
+ *
+ * Unlike the assessment mirror (which omits `p` to avoid labeling the
+ * claim's author), this mirror DOES carry `p` = the subject: the
+ * maneuver label is *about* that person's move. The NIP text MUST frame
+ * these as structural observations carrying a required counter-read on
+ * the richer 30062 — never verdicts — and recommend consumers surface
+ * that counter-read. Emitted alongside a 30062 on its first publish,
+ * behind the same `forensicPublishing` flag.
+ *
+ * @param {object} args
+ * @param {string} args.subjectPubkey   — 64-hex (the labeled subject)
+ * @param {string} args.maneuver        — taxonomy value
+ * @param {string} [args.sourceUrl]     — verbatim, for the draft's `#r` query
+ * @param {number} [args.createdAt]
+ * @returns {{event, body, dTag: null}}  (kind 1985 is a regular event)
+ */
+export function buildForensicFindingMirrorEvent({
+  subjectPubkey,
+  maneuver,
+  sourceUrl = '',
+  createdAt = nowSeconds()
+} = {}) {
+  if (!/^[0-9a-f]{64}$/.test(String(subjectPubkey || ''))) {
+    throw new Error('buildForensicFindingMirrorEvent: subjectPubkey must be a 64-hex pubkey');
+  }
+  if (!isValidManeuver(maneuver)) {
+    throw new Error(`buildForensicFindingMirrorEvent: invalid maneuver (got ${maneuver})`);
+  }
+  const tags = [
+    tag('L', FORENSIC_MANEUVER_NAMESPACE),
+    tag('l', maneuver, FORENSIC_MANEUVER_NAMESPACE),
+    tag('p', subjectPubkey)
+  ];
+  if (sourceUrl) tags.push(tag('r', sourceUrl));
+  tags.push(tag('client', 'xray'));
   return {
     event: { kind: 1985, created_at: createdAt, tags, content: '' },
     body: '',

--- a/src/shared/metadata/feature-flags.js
+++ b/src/shared/metadata/feature-flags.js
@@ -45,7 +45,13 @@ export const FLAGS_DEFAULTS = Object.freeze({
   // import/render/ledger is never gated — the Phase 11 split. Audit
   // EXECUTION additionally requires a user-supplied API key, which is
   // its own consent gate on top of this flag.
-  epistemicAuditing: false
+  epistemicAuditing: false,
+
+  // Phase 14 (docs/CRIMINOLOGY_DESIGN.md): gates the PUBLISH paths for
+  // kind 30062 behavioral findings, their kind-1985 maneuver mirror, and
+  // the `revision/*` story-change edges on kind 30055. Local capture /
+  // baselines / rollups are never gated — they're the product.
+  forensicPublishing: false
 });
 
 /**

--- a/tests/forensic-builders.test.mjs
+++ b/tests/forensic-builders.test.mjs
@@ -1,0 +1,156 @@
+// Forensic wire builders — Phase 14.3 (docs/CRIMINOLOGY_DESIGN.md §30062).
+// Build/parse round-trip for kind 30062 BehavioralFinding, the kind-1985
+// maneuver mirror, the revision/* values on kind 30055, and the
+// audit/assessment firewall (no stance / rating-value / xray/assessment).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// storage.js touches chrome at import time; the parser lives in
+// forensic-model.js, which pulls it in.
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const {
+    buildBehavioralFindingEvent, buildForensicFindingMirrorEvent,
+    buildClaimRelationshipEvent, FORENSIC_COUNTER_HEADING
+} = await import('../src/shared/metadata/builders.js');
+const { parseBehavioralFindingEvent } = await import('../src/shared/forensic-model.js');
+
+const PK = 'a'.repeat(64);
+const SELECTOR = [{ type: 'TextQuoteSelector', exact: 'I care about the truth' }];
+
+function baseArgs(over = {}) {
+    return {
+        subjectPubkey: PK,
+        maneuver: 'defense/usefulness-pivot',
+        role: 'apologist',
+        anchors: [{ quote: 'I care about the truth, not what the church says.', selector: SELECTOR }],
+        counterNote: 'He may simply be conceding utility alongside the truth claim.',
+        note: 'Shifts the axis from is-it-true to is-it-useful.',
+        basis: 'quoted',
+        sourceUrl: 'https://example.com/clip?utm_source=x',
+        ...over
+    };
+}
+
+function tagsByName(ev, name) { return ev.tags.filter((t) => t[0] === name); }
+
+test('30062: tag set matches the §30062 spec', async () => {
+    const { event, dTag } = await buildBehavioralFindingEvent(baseArgs());
+    assert.equal(event.kind, 30062);
+    assert.match(dTag, /^find:[0-9a-f]{16}$/);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'd'), ['d', dTag]);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'p'), ['p', PK, '', 'subject']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'L'), ['L', 'xray/forensic']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'l'), ['l', 'defense/usefulness-pivot', 'xray/forensic']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'role'), ['role', 'apologist']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'r'), ['r', 'https://example.com/clip?utm_source=x']);
+    assert.equal(event.tags.find((t) => t[0] === 'i')[1], 'https://example.com/clip', 'i is normalized (utm stripped)');
+    assert.deepEqual(event.tags.find((t) => t[0] === 'k'), ['k', 'web']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'basis'), ['basis', 'quoted']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'suggested-by'), ['suggested-by', 'user']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'client'), ['client', 'xray']);
+    const step = event.tags.find((t) => t[0] === 'maneuver-step');
+    assert.equal(step[1], '0');
+    assert.equal(step[2], 'I care about the truth, not what the church says.');
+    assert.equal(JSON.parse(step[3])[0].exact, 'I care about the truth');
+});
+
+test('30062: content carries note then the required counter-read', async () => {
+    const { event, body } = await buildBehavioralFindingEvent(baseArgs());
+    assert.ok(body.startsWith('Shifts the axis'));
+    assert.ok(body.includes(FORENSIC_COUNTER_HEADING));
+    assert.ok(body.trimEnd().endsWith('alongside the truth claim.'));
+    assert.equal(event.content, body);
+});
+
+test('30062: the audit/assessment firewall holds (no stance / rating / xray/assessment)', async () => {
+    const { event } = await buildBehavioralFindingEvent(baseArgs());
+    assert.equal(tagsByName(event, 'stance').length, 0);
+    assert.equal(tagsByName(event, 'rating-value').length, 0);
+    for (const t of event.tags) {
+        assert.notEqual(t[1], 'xray/assessment', 'never the assessment namespace');
+        if (t[0] === 'l') assert.equal(t[2], 'xray/forensic');
+    }
+});
+
+test('30062: d is deterministic and recomputable from the same inputs', async () => {
+    const a = await buildBehavioralFindingEvent(baseArgs());
+    const b = await buildBehavioralFindingEvent(baseArgs({ note: 'different note', createdAt: 123 }));
+    assert.equal(a.dTag, b.dTag, 'd ignores note/createdAt — keys on subject|maneuver|anchors');
+    const c = await buildBehavioralFindingEvent(baseArgs({ maneuver: 'darvo/attack' }));
+    assert.notEqual(a.dTag, c.dTag, 'a different maneuver derives a different d');
+});
+
+test('30062: rejects missing counter-note / anchors / bad enums / bad subject', async () => {
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ counterNote: '  ' })), /counterNote required/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ anchors: [] })), /at least one evidence anchor/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ anchors: [{ quote: ' ' }] })), /non-empty quote/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ maneuver: 'Bad' })), /invalid maneuver/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ role: 'prosecutor' })), /invalid role/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ basis: 'vibes' })), /invalid basis/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ subjectPubkey: 'xyz' })), /64-hex/);
+    await assert.rejects(() => buildBehavioralFindingEvent(baseArgs({ relationshipCoord: '30040:bad' })), /30055 coordinate/);
+});
+
+test('30062: build → parse round-trip', async () => {
+    const relCoord = `30055:${'b'.repeat(64)}:rel:abc`;
+    const { event } = await buildBehavioralFindingEvent(baseArgs({
+        relationshipCoord: relCoord,
+        anchors: [
+            { quote: 'first step', selector: SELECTOR, timestamp: 12 },
+            { quote: 'second step' }
+        ]
+    }));
+    event.pubkey = 'f'.repeat(64);
+    event.id = 'e'.repeat(64);
+    const p = parseBehavioralFindingEvent(event);
+    assert.equal(p.subjectPubkey, PK);
+    assert.equal(p.maneuver, 'defense/usefulness-pivot');
+    assert.equal(p.role, 'apologist');
+    assert.equal(p.basis, 'quoted');
+    assert.equal(p.note, 'Shifts the axis from is-it-true to is-it-useful.');
+    assert.equal(p.counterNote, 'He may simply be conceding utility alongside the truth claim.');
+    assert.equal(p.relationshipCoord, relCoord);
+    assert.equal(p.anchors.length, 2);
+    assert.equal(p.anchors[0].quote, 'first step');
+    assert.equal(p.anchors[0].timestamp, 12);
+    assert.equal(p.anchors[0].selector[0].exact, 'I care about the truth');
+    assert.equal(p.anchors[1].quote, 'second step');
+    assert.equal(p.anchors[1].selector, null);
+    assert.equal(parseBehavioralFindingEvent({ kind: 30054 }), null, 'wrong kind → null');
+});
+
+test('1985 mirror: labels the SUBJECT pubkey under xray/forensic', async () => {
+    const { event, dTag } = buildForensicFindingMirrorEvent({
+        subjectPubkey: PK, maneuver: 'darvo/attack', sourceUrl: 'https://example.com/x'
+    });
+    assert.equal(event.kind, 1985);
+    assert.equal(dTag, null);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'L'), ['L', 'xray/forensic']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'l'), ['l', 'darvo/attack', 'xray/forensic']);
+    assert.deepEqual(event.tags.find((t) => t[0] === 'p'), ['p', PK], 'the subject is the labeled target');
+    assert.deepEqual(event.tags.find((t) => t[0] === 'r'), ['r', 'https://example.com/x']);
+    assert.throws(() => buildForensicFindingMirrorEvent({ subjectPubkey: PK, maneuver: 'BAD' }), /invalid maneuver/);
+});
+
+test('30055: the directional revision/* values now build', async () => {
+    const A = `30040:${'a'.repeat(64)}:claim_a`;
+    const B = `30040:${'b'.repeat(64)}:claim_b`;
+    for (const rel of ['narrative-patch', 'recharacterizes', 'walks-back']) {
+        const { event } = await buildClaimRelationshipEvent({
+            sourceCoord: A, targetCoord: B, relationship: rel,
+            sourceUrl: 'https://ex.com/a', targetUrl: 'https://ex.com/b'
+        });
+        assert.equal(event.kind, 30055);
+        assert.deepEqual(event.tags.find((t) => t[0] === 'relationship'), ['relationship', rel]);
+        // directional: source stays first (not sorted like symmetric rels)
+        assert.equal(event.tags.find((t) => t[0] === 'a' && t[3] === 'source')[1], A);
+        assert.equal(event.tags.find((t) => t[0] === 'a' && t[3] === 'target')[1], B);
+    }
+    await assert.rejects(() => buildClaimRelationshipEvent({
+        sourceCoord: A, targetCoord: B, relationship: 'vibes-shift'
+    }), /relationship must be one of/);
+});

--- a/tests/forensic-model.test.mjs
+++ b/tests/forensic-model.test.mjs
@@ -1,4 +1,4 @@
-// Forensic finding model tests — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+// Forensic finding model tests — Phase 14.1 (docs/CRIMINOLOGY_DESIGN.md).
 // Same chrome.storage.local shim pattern as assessment-model.test.mjs.
 
 import { test } from 'node:test';

--- a/tests/forensic-model.test.mjs
+++ b/tests/forensic-model.test.mjs
@@ -1,0 +1,234 @@
+// Forensic finding model tests — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+// Same chrome.storage.local shim pattern as assessment-model.test.mjs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const {
+    ForensicModel, ForensicBaseline,
+    generateFindingId, subjectRefKey
+} = await import('../src/shared/forensic-model.js');
+const { EvidenceLinker } = await import('../src/shared/evidence-linker.js');
+
+function resetState() { _stateStore.clear(); }
+
+const SUBJECT = { pubkey: 'a'.repeat(64), label: 'Jacob Hansen' };
+
+function anchor(quote, extra = {}) {
+    return { quote, source_ref: { url: 'https://example.com/clip-1' }, ...extra };
+}
+
+function baseFinding(over = {}) {
+    return {
+        subject_ref:  SUBJECT,
+        role:         'apologist',
+        maneuver:     'defense/usefulness-pivot',
+        anchors:      [anchor('I care about the truth, not what the church says.')],
+        note:         'Shifts the axis from is-it-true to is-it-useful.',
+        counter_note: 'He may simply be conceding utility alongside the truth claim.',
+        basis:        'quoted',
+        ...over
+    };
+}
+
+// ---------------------------------------------------------------------
+
+test('finding: deterministic id derivation', async () => {
+    const anchors = [{ quote: 'q', selector: null, timestamp: null }];
+    const a = await generateFindingId('jacob', 'defense/ad-hoc-patch', anchors);
+    const b = await generateFindingId('jacob', 'defense/manufactured-doubt', anchors);
+    assert.match(a, /^find_[0-9a-f]{16}$/);
+    assert.notEqual(a, b, 'different maneuvers derive different ids');
+    assert.equal(a, await generateFindingId('jacob', 'defense/ad-hoc-patch', anchors), 'stable');
+});
+
+test('finding: subjectRefKey prefers the most durable identifier', () => {
+    assert.equal(subjectRefKey({ identity_id: 'id-1', pubkey: 'b'.repeat(64), label: 'X' }), 'id-1');
+    assert.equal(subjectRefKey({ pubkey: 'B'.repeat(64) }), 'b'.repeat(64), 'lowercased');
+    assert.equal(subjectRefKey({ account: 'yt:@jacob' }), 'yt:@jacob');
+    assert.equal(subjectRefKey({ label: 'Jacob Hansen' }), 'jacob hansen');
+    assert.equal(subjectRefKey({}), '');
+});
+
+test('finding: create + get round-trip; no stance/intent field exists', async () => {
+    resetState();
+    const f = await ForensicModel.create(baseFinding());
+    assert.match(f.id, /^find_[0-9a-f]{16}$/);
+    assert.equal(f.maneuver, 'defense/usefulness-pivot');
+    assert.equal(f.role, 'apologist');
+    assert.equal(f.basis, 'quoted');
+    assert.equal(f.anchors.length, 1);
+    assert.equal(f.anchors[0].quote, 'I care about the truth, not what the church says.');
+    assert.equal(f.anchors[0].source_ref.url, 'https://example.com/clip-1', 'url normalized + stored');
+    assert.equal(f.counter_note.length > 0, true);
+    assert.equal(f.suggested_by, 'user');
+    assert.equal(f.publishedAt, null);
+    // The no-verdict guarantee: the model carries no honesty/intent/score.
+    assert.equal('stance' in f, false);
+    assert.equal('intent' in f, false);
+    assert.equal('confidence' in f, false);
+    assert.equal('lying' in f, false);
+
+    const got = await ForensicModel.get(f.id);
+    assert.deepEqual(got, f);
+});
+
+test('finding: idempotent on (subject, maneuver, anchors)', async () => {
+    resetState();
+    const a = await ForensicModel.create(baseFinding());
+    const b = await ForensicModel.create(baseFinding({ note: 'different note, same evidence' }));
+    assert.equal(a.id, b.id, 'same evidence ⇒ same record');
+    assert.equal(b.note, a.note, 'idempotent create returns the existing record (note unchanged)');
+    assert.equal(Object.keys(await ForensicModel.getAll()).length, 1);
+});
+
+test('finding: Rule 2 — at least one anchor with a quote is required', async () => {
+    resetState();
+    await assert.rejects(() => ForensicModel.create(baseFinding({ anchors: [] })),
+        /at least one evidence anchor/);
+    await assert.rejects(() => ForensicModel.create(baseFinding({ anchors: [{ quote: '   ' }] })),
+        /non-empty quote/);
+});
+
+test('finding: Rule 6 — a counter_note is required', async () => {
+    resetState();
+    await assert.rejects(() => ForensicModel.create(baseFinding({ counter_note: '' })),
+        /counter_note/);
+    await assert.rejects(() => ForensicModel.create(baseFinding({ counter_note: '   ' })),
+        /counter_note/);
+});
+
+test('finding: rejects invalid maneuver / role / basis', async () => {
+    resetState();
+    await assert.rejects(() => ForensicModel.create(baseFinding({ maneuver: 'Bad Maneuver' })),
+        /Invalid maneuver/);
+    await assert.rejects(() => ForensicModel.create(baseFinding({ role: 'prosecutor' })),
+        /Invalid role/);
+    await assert.rejects(() => ForensicModel.create(baseFinding({ basis: 'vibes' })),
+        /Invalid basis/);
+});
+
+test('finding: getForSubject matches across representations sharing a key', async () => {
+    resetState();
+    await ForensicModel.create(baseFinding({ maneuver: 'defense/ad-hoc-patch' }));
+    await ForensicModel.create(baseFinding({
+        maneuver: 'darvo/attack',
+        anchors: [anchor('You are just biased.')]
+    }));
+    // A subject ref with only the pubkey (no label) resolves to the same key.
+    const found = await ForensicModel.getForSubject({ pubkey: 'a'.repeat(64) });
+    assert.equal(found.length, 2);
+    const other = await ForensicModel.getForSubject({ pubkey: 'c'.repeat(64) });
+    assert.equal(other.length, 0);
+});
+
+test('finding: update patches mutable fields; counter_note stays required', async () => {
+    resetState();
+    const f = await ForensicModel.create(baseFinding());
+    const updated = await ForensicModel.update(f.id, {
+        note: 'sharper', basis: 'structural-inference', role: 'institution'
+    });
+    assert.equal(updated.note, 'sharper');
+    assert.equal(updated.basis, 'structural-inference');
+    assert.equal(updated.role, 'institution');
+    assert.ok(updated.updated >= f.updated);
+    await assert.rejects(() => ForensicModel.update(f.id, { counter_note: '' }),
+        /counter_note/, 'cannot blank the counter-note via update');
+});
+
+test('finding: markPublished stamps publish fields without bumping updated', async () => {
+    resetState();
+    const f = await ForensicModel.create(baseFinding());
+    const before = f.updated;
+    const pub = await ForensicModel.markPublished(f.id, 'evt123', 'd'.repeat(64));
+    assert.ok(pub.publishedAt > 0);
+    assert.equal(pub.publishedEventId, 'evt123');
+    assert.equal(pub.publishedPubkey, 'd'.repeat(64));
+    assert.equal(pub.updated, before, 'publish is not an edit — updated unchanged');
+});
+
+test('finding: delete', async () => {
+    resetState();
+    const f = await ForensicModel.create(baseFinding());
+    assert.equal(await ForensicModel.delete(f.id), true);
+    assert.equal(await ForensicModel.get(f.id), null);
+    assert.equal(await ForensicModel.delete(f.id), false);
+});
+
+// --- baselines (Rule 3) ----------------------------------------------
+
+test('baseline: create idempotent on (subject, url) + deviation ref', async () => {
+    resetState();
+    const b = await ForensicBaseline.create({
+        subject_ref: SUBJECT,
+        source_url: 'https://example.com/clip-1',
+        note: 'Even, fact-anchored register across the first three sessions.'
+    });
+    assert.match(b.id, /^baseline_[0-9a-f]{16}$/);
+    const b2 = await ForensicBaseline.create({
+        subject_ref: SUBJECT,
+        source_url: 'https://example.com/clip-1',
+        note: 'updated register note'
+    });
+    assert.equal(b2.id, b.id, 'same subject+url ⇒ same baseline');
+    assert.equal(b2.note, 'updated register note', 're-marking updates the note in place');
+    assert.equal((await ForensicBaseline.getForSubject(SUBJECT)).length, 1);
+
+    // A finding can deviate from it.
+    const f = await ForensicModel.create(baseFinding({ baseline_ref: b.id }));
+    assert.equal(f.baseline_ref, b.id);
+});
+
+// --- the revision/* edge substrate (kind 30055) ----------------------
+
+test('revision: the linker accepts directional revision/* edges', async () => {
+    resetState();
+    const A = 'claim_aaaaaaaaaaaaaaaa';
+    const B = 'claim_bbbbbbbbbbbbbbbb';
+    const link = await EvidenceLinker.create({
+        source_claim_id: A, target_claim_id: B, relationship: 'narrative-patch',
+        note: 'the catalyst-theory cover story, added after the translation evidence failed'
+    });
+    assert.equal(link.relationship, 'narrative-patch');
+    assert.equal(link.source_claim_id, A, 'directional: source = earlier statement');
+    assert.equal(link.target_claim_id, B, 'directional: target = later statement');
+
+    // Directional ⇒ the reverse is a distinct edge (not collapsed).
+    const reverse = await EvidenceLinker.create({
+        source_claim_id: B, target_claim_id: A, relationship: 'narrative-patch'
+    });
+    assert.notEqual(reverse.id, link.id);
+
+    // recharacterizes + walks-back are accepted too.
+    const rc = await EvidenceLinker.create({
+        source_claim_id: A, target_claim_id: B, relationship: 'recharacterizes'
+    });
+    assert.equal(rc.relationship, 'recharacterizes');
+    // ...but a bogus relationship is still rejected.
+    await assert.rejects(() => EvidenceLinker.create({
+        source_claim_id: A, target_claim_id: B, relationship: 'vibes-shift'
+    }), /Invalid relationship/);
+});

--- a/tests/forensic-publish.test.mjs
+++ b/tests/forensic-publish.test.mjs
@@ -1,0 +1,92 @@
+// Forensic publish selection — Phase 14 publish wiring.
+// Wire-readiness of findings, mirrors, and revision/* edges, plus the
+// split that keeps revision edges OUT of the assessment link batch.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// claim-ref.js (pulled in via assessment-publish.js) touches chrome at import.
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const {
+    resolveSubjectPubkey, selectFindingsToPublish, selectFindingMirrors,
+    selectRevisionEdgesToPublish
+} = await import('../src/shared/forensic-publish.js');
+const { selectLinksToPublish } = await import('../src/shared/assessment-publish.js');
+
+const PK = 'a'.repeat(64);
+const ENT_PK = 'b'.repeat(64);
+const entities = { 'ent-1': { id: 'ent-1', keypair: { pubkey: ENT_PK } }, 'ent-2': { id: 'ent-2' } };
+const canon = (x) => x;
+
+function finding(over = {}) {
+    return {
+        id: 'find_1', subject_ref: { identity_id: 'ent-1', label: 'Jacob' },
+        maneuver: 'defense/usefulness-pivot', role: 'apologist', basis: 'quoted',
+        anchors: [{ quote: 'q', selector: null, timestamp: null, source_ref: { url: 'https://e.com/x', url_raw: 'https://e.com/x?utm=1' } }],
+        note: 'n', counter_note: 'c', created: 1, updated: 1, publishedAt: null,
+        ...over
+    };
+}
+
+test('resolveSubjectPubkey: external pubkey wins, else entity keypair, else null', () => {
+    assert.equal(resolveSubjectPubkey({ pubkey: PK, identity_id: 'ent-1' }, entities), PK);
+    assert.equal(resolveSubjectPubkey({ identity_id: 'ent-1' }, entities), ENT_PK);
+    assert.equal(resolveSubjectPubkey({ identity_id: 'ent-2' }, entities), null, 'entity without a keypair');
+    assert.equal(resolveSubjectPubkey({ label: 'Jacob' }, entities), null, 'label-only is not publishable');
+    assert.equal(resolveSubjectPubkey({ pubkey: 'nothex' }, entities), null);
+});
+
+test('selectFindingsToPublish: resolves subject, applies staleness, carries verbatim url', () => {
+    const sel = selectFindingsToPublish({ findings: { f: finding() }, entities });
+    assert.equal(sel.length, 1);
+    assert.equal(sel[0].subjectPubkey, ENT_PK);
+    assert.equal(sel[0].sourceUrl, 'https://e.com/x?utm=1', 'verbatim url_raw for the wire r');
+    assert.equal(sel[0].anchors[0].quote, 'q');
+
+    // staleness: published and not edited → skipped
+    assert.equal(selectFindingsToPublish({ findings: { f: finding({ publishedAt: 5, updated: 3 }) }, entities }).length, 0);
+    // edited after publish → re-selected
+    assert.equal(selectFindingsToPublish({ findings: { f: finding({ publishedAt: 5, updated: 9 }) }, entities }).length, 1);
+    // unresolvable subject → skipped
+    assert.equal(selectFindingsToPublish({ findings: { f: finding({ subject_ref: { label: 'x' } }) }, entities }).length, 0);
+});
+
+test('selectFindingMirrors: keyed on mirroredAt, needs a resolvable subject', () => {
+    assert.equal(selectFindingMirrors({ findings: { f: finding() }, entities }).length, 1);
+    assert.equal(selectFindingMirrors({ findings: { f: finding({ mirroredAt: 7 }) }, entities }).length, 0);
+    // a published-but-unmirrored finding still mirrors
+    assert.equal(selectFindingMirrors({ findings: { f: finding({ publishedAt: 5, updated: 3 }) }, entities }).length, 1);
+});
+
+// --- the revision-edge split ----------------------------------------
+
+const A = 'claim_aaaaaaaaaaaaaaaa', B = 'claim_bbbbbbbbbbbbbbbb';
+const claims = {
+    [A]: { id: A, publishedPubkey: PK, source_url: 'https://e.com/a' },
+    [B]: { id: B, publishedPubkey: ENT_PK, source_url: 'https://e.com/b' }
+};
+function link(rel, over = {}) {
+    return { id: `link_${rel}`, relationship: rel, source_claim_id: A, target_claim_id: B, created: 1, updated: 1, publishedAt: null, ...over };
+}
+
+test('selectRevisionEdgesToPublish: only revision/* edges, both endpoints wire-ready', () => {
+    const links = { r: link('narrative-patch'), c: link('contradicts') };
+    const sel = selectRevisionEdgesToPublish({ links, claims, canon });
+    assert.equal(sel.length, 1);
+    assert.equal(sel[0].link.relationship, 'narrative-patch');
+    assert.equal(sel[0].source.coord, `30040:${PK}:${A}`);
+    assert.equal(sel[0].target.coord, `30040:${ENT_PK}:${B}`);
+    // an unpublished endpoint defers the edge
+    const claims2 = { [A]: claims[A], [B]: { id: B, source_url: 'x' } };
+    assert.equal(selectRevisionEdgesToPublish({ links: { r: link('walks-back') }, claims: claims2, canon }).length, 0);
+});
+
+test('the assessment link batch now SKIPS revision/* (they publish under forensicPublishing)', () => {
+    const links = { r: link('narrative-patch'), c: link('contradicts'), x: link('contextualizes') };
+    const sel = selectLinksToPublish({ links, claims, canon });
+    assert.deepEqual(sel.map((s) => s.link.relationship).sort(), ['contradicts'],
+        'only the truth-relationship publishes here; revision/* and legacy contextualizes are excluded');
+});

--- a/tests/forensic-section.test.mjs
+++ b/tests/forensic-section.test.mjs
@@ -1,0 +1,80 @@
+// Forensic findings render tests — Phase 13.2 (docs/CRIMINOLOGY_DESIGN.md).
+//
+// The modal itself is DOM-driven (smoke-tested manually), but the badge
+// strip and the reader findings bar are pure HTML-string builders, so
+// they're unit-testable in node. ensureStyles() no-ops when `document`
+// is undefined, so importing the modal module here is safe.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// storage.js touches chrome.* at import time; the modal's import chain
+// pulls it in even though these pure renderers never read storage.
+globalThis.chrome = { storage: { local: {
+    get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); }
+} } };
+
+const { renderFindingBadges } = await import('../src/shared/forensic-modal.js');
+const { renderFindingsBar } = await import('../src/reader/findings-section.js');
+
+function finding(over = {}) {
+    return {
+        id: 'find_0123456789abcdef',
+        subject_ref: { identity_id: 'ent-1', label: 'Jacob Hansen' },
+        role: 'apologist',
+        maneuver: 'defense/usefulness-pivot',
+        basis: 'quoted',
+        anchors: [{ quote: 'I care about the truth, not what the church says.' }],
+        ...over
+    };
+}
+
+test('badges: null renders nothing', () => {
+    assert.equal(renderFindingBadges(null), '');
+});
+
+test('badges: maneuver + role + basis, with published + custom + sequence markers', () => {
+    const html = renderFindingBadges(finding());
+    assert.match(html, /defense\/usefulness-pivot/);
+    assert.match(html, /apologist/);
+    assert.match(html, /quoted/);
+    assert.doesNotMatch(html, /xr-finding-badge--pub/, 'no publish marker when unpublished');
+
+    const pub = renderFindingBadges(finding({ publishedAt: 1 }));
+    assert.match(pub, /xr-finding-badge--pub/);
+
+    const custom = renderFindingBadges(finding({ maneuver: 'defense/gish-gallop' }));
+    assert.match(custom, /xr-finding-badge--custom/, 'non-standard maneuver flagged custom');
+
+    const seq = renderFindingBadges(finding({
+        maneuver: 'grooming/build-vulnerability',
+        anchors: [{ quote: 'a' }, { quote: 'b' }, { quote: 'c' }]
+    }));
+    assert.match(seq, /·3/, 'sequence step count shown');
+});
+
+test('bar: empty state prompts the no-verdict capture flow', () => {
+    const html = renderFindingsBar([]);
+    assert.match(html, /\+ Finding/);
+    assert.match(html, /Set baseline/);
+    assert.match(html, /counter-read/i, 'empty hint states the falsifiability discipline');
+    assert.doesNotMatch(html, /xr-findings__item\b/, 'no rows');
+});
+
+test('bar: a row carries the subject, maneuver, lead quote, and actions', () => {
+    const html = renderFindingsBar([finding()]);
+    assert.match(html, /Forensic findings \(1\)/);
+    assert.match(html, /data-id="find_0123456789abcdef"/);
+    assert.match(html, /Jacob Hansen/);
+    assert.match(html, /defense\/usefulness-pivot/);
+    assert.match(html, /I care about the truth/);
+    assert.match(html, /data-action="edit"/);
+    assert.match(html, /data-action="delete"/);
+});
+
+test('bar: long lead quotes are truncated with an ellipsis', () => {
+    const long = 'x'.repeat(400);
+    const html = renderFindingsBar([finding({ anchors: [{ quote: long }] })]);
+    assert.match(html, /…/, 'truncated');
+    assert.doesNotMatch(html, new RegExp('x{300}'), 'not the full 400-char quote');
+});

--- a/tests/forensic-section.test.mjs
+++ b/tests/forensic-section.test.mjs
@@ -1,4 +1,4 @@
-// Forensic findings render tests — Phase 13.2 (docs/CRIMINOLOGY_DESIGN.md).
+// Forensic findings render tests — Phase 14.2 (docs/CRIMINOLOGY_DESIGN.md).
 //
 // The modal itself is DOM-driven (smoke-tested manually), but the badge
 // strip and the reader findings bar are pure HTML-string builders, so

--- a/tests/forensic-taxonomy.test.mjs
+++ b/tests/forensic-taxonomy.test.mjs
@@ -1,4 +1,4 @@
-// Forensic taxonomy tests — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+// Forensic taxonomy tests — Phase 14.1 (docs/CRIMINOLOGY_DESIGN.md).
 //
 // Exhaustive-enum pins (the EVIDENCE_RELATIONSHIPS / ASSESSMENT_LABELS
 // house pattern): extending the maneuver vocabulary, the role enum, or

--- a/tests/forensic-taxonomy.test.mjs
+++ b/tests/forensic-taxonomy.test.mjs
@@ -1,0 +1,107 @@
+// Forensic taxonomy tests — Phase 13.1 (docs/CRIMINOLOGY_DESIGN.md).
+//
+// Exhaustive-enum pins (the EVIDENCE_RELATIONSHIPS / ASSESSMENT_LABELS
+// house pattern): extending the maneuver vocabulary, the role enum, or
+// the basis enum means editing this file in the same change. The
+// MANEUVER_GUIDE pin enforces the falsifiability discipline — every
+// standard maneuver must ship a counter-indicator.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const {
+    FORENSIC_MANEUVER_NAMESPACE, FORENSIC_MANEUVER_GROUPS, FORENSIC_MANEUVERS,
+    isStandardManeuver, isValidManeuver,
+    ROLES, isValidRole, BASIS_VALUES, isValidBasis,
+    MANEUVER_GUIDE, REVISION_RELATIONSHIPS, isValidSuggestedBy
+} = await import('../src/shared/forensic-taxonomy.js');
+const { isSymmetricRelationship, isRevisionRelationship } =
+    await import('../src/shared/assessment-taxonomy.js');
+
+test('forensic: namespace is pinned', () => {
+    assert.equal(FORENSIC_MANEUVER_NAMESPACE, 'xray/forensic');
+});
+
+test('forensic: maneuver families are exhaustive', () => {
+    assert.deepEqual(Object.keys(FORENSIC_MANEUVER_GROUPS).sort(),
+        ['darvo', 'defense', 'grooming', 'neutralization', 'thought-reform']);
+    assert.deepEqual(FORENSIC_MANEUVER_GROUPS.darvo.slice().sort(),
+        ['darvo/attack', 'darvo/deny', 'darvo/reverse-victim-offender']);
+    assert.deepEqual(FORENSIC_MANEUVER_GROUPS.grooming.slice().sort(),
+        ['grooming/apply-pressure', 'grooming/build-vulnerability',
+         'grooming/establish-trust', 'grooming/redefine-boundaries']);
+    assert.equal(FORENSIC_MANEUVER_GROUPS.neutralization.length, 9);
+    assert.equal(FORENSIC_MANEUVER_GROUPS['thought-reform'].length, 7);
+    assert.equal(FORENSIC_MANEUVER_GROUPS.defense.length, 8);
+});
+
+test('forensic: flat list is the union of the groups, no duplicates', () => {
+    const union = Object.values(FORENSIC_MANEUVER_GROUPS).flat();
+    assert.deepEqual(FORENSIC_MANEUVERS.slice().sort(), union.slice().sort());
+    assert.equal(new Set(FORENSIC_MANEUVERS).size, FORENSIC_MANEUVERS.length);
+    for (const m of FORENSIC_MANEUVERS) {
+        assert.equal(isStandardManeuver(m), true, `${m} is standard`);
+        assert.equal(isValidManeuver(m), true, `${m} passes its own validation`);
+    }
+});
+
+test('forensic: custom maneuvers ride the same rails (the escape hatch)', () => {
+    assert.equal(isStandardManeuver('defense/gish-gallop'), false);
+    assert.equal(isValidManeuver('defense/gish-gallop'), true, 'custom value in a known family');
+    assert.equal(isValidManeuver('sealioning'), true);
+    assert.equal(isValidManeuver(''), false);
+    assert.equal(isValidManeuver('Has Space'), false);
+    assert.equal(isValidManeuver('UPPER'), false);
+    assert.equal(isValidManeuver('a/b/c'), false, 'one namespace segment max');
+    assert.equal(isValidManeuver('x'.repeat(65)), false, 'length cap');
+    assert.equal(isValidManeuver(42), false);
+});
+
+test('forensic: role enum is exhaustive + symmetric across sides', () => {
+    assert.deepEqual(ROLES.slice().sort(),
+        ['apologist', 'critic', 'institution', 'other', 'survivor', 'witness']);
+    for (const r of ROLES) assert.equal(isValidRole(r), true);
+    // The bias-symmetry point: a critic is as profilable as an apologist.
+    assert.equal(isValidRole('apologist'), true);
+    assert.equal(isValidRole('critic'), true);
+    assert.equal(isValidRole('prosecutor'), false);
+});
+
+test('forensic: basis enum is exhaustive (no numeric score)', () => {
+    assert.deepEqual(BASIS_VALUES.slice(),
+        ['quoted', 'paraphrased', 'behavioral-cue', 'structural-inference']);
+    for (const b of BASIS_VALUES) assert.equal(isValidBasis(b), true);
+    assert.equal(isValidBasis('vibes'), false);
+    assert.equal(isValidBasis(0.95), false, 'a number is not a basis — there is no score');
+});
+
+test('forensic: revision relationships are directional (re-exported)', () => {
+    assert.deepEqual(REVISION_RELATIONSHIPS.slice().sort(),
+        ['narrative-patch', 'recharacterizes', 'walks-back']);
+    for (const r of REVISION_RELATIONSHIPS) {
+        assert.equal(isRevisionRelationship(r), true);
+        assert.equal(isSymmetricRelationship(r), false, `${r} is directional (earlier → later)`);
+    }
+});
+
+test('forensic: every standard maneuver has a guide entry with a counter-indicator', () => {
+    for (const m of FORENSIC_MANEUVERS) {
+        const g = MANEUVER_GUIDE[m];
+        assert.ok(g, `MANEUVER_GUIDE must cover ${m}`);
+        assert.ok(g.source && typeof g.source === 'string', `${m} cites a source`);
+        assert.ok(g.definition && g.definition.length > 0, `${m} has a definition`);
+        assert.ok(Array.isArray(g.indicators) && g.indicators.length > 0, `${m} has indicators`);
+        assert.ok(Array.isArray(g.counterIndicators) && g.counterIndicators.length > 0,
+            `${m} has at least one counter-indicator (the falsifiability discipline)`);
+    }
+    // No orphan guide entries for non-existent maneuvers.
+    for (const key of Object.keys(MANEUVER_GUIDE)) {
+        assert.equal(isStandardManeuver(key), true, `guide key ${key} is a real maneuver`);
+    }
+});
+
+test('forensic: suggested_by provenance is re-exported', () => {
+    assert.equal(isValidSuggestedBy('user'), true);
+    assert.equal(isValidSuggestedBy('llm:claude-fable-5'), true);
+    assert.equal(isValidSuggestedBy('bot'), false);
+});

--- a/tests/portal-corpus.test.mjs
+++ b/tests/portal-corpus.test.mjs
@@ -58,6 +58,8 @@ test('CONTENT_KINDS pins the full corpus kind list from the design note', () => 
         30053, 30054, 30055,
         // Phase 13.7: the audit family (docs/EPISTEMIC_AUDIT_DESIGN.md)
         30056, 30057, 30058, 30059, 30060, 30061,
+        // Phase 14.4: behavioral findings (docs/CRIMINOLOGY_DESIGN.md)
+        30062,
         30078, 32125, 32126
     ]);
 });

--- a/tests/portal-findings.test.mjs
+++ b/tests/portal-findings.test.mjs
@@ -1,0 +1,81 @@
+// Portal forensic findings — Phase 14.4 (docs/CRIMINOLOGY_DESIGN.md).
+// The 30062 → library item routing (subject-name resolution from the
+// entity index) and the pure forensic-data joins/summaries the lens
+// views render. Real builder → real parser → buildItems → forensic-data.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// library.js → forensic-model.js → storage.js probes chrome at load.
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const { buildItems } = await import('../src/portal/library.js');
+const { buildBehavioralFindingEvent } = await import('../src/shared/metadata/builders.js');
+const {
+    findingsForEntity, maneuverTally, leadQuote, maneuverShort, FINDING_LENSES
+} = await import('../src/portal/forensic-data.js');
+
+const SUBJECT_PK = 'a'.repeat(64);
+const OTHER_PK = 'c'.repeat(64);
+const ENTITY_INDEX = { [SUBJECT_PK]: { entityId: 'ent_jacob', name: 'Jacob Hansen', type: 'person' } };
+
+async function findingRecord({ maneuver, role = 'apologist', quote, createdAt }) {
+    const { event } = await buildBehavioralFindingEvent({
+        subjectPubkey: SUBJECT_PK, maneuver, role,
+        anchors: [{ quote }], counterNote: 'A fair alternative reading.',
+        note: 'structural', basis: 'quoted', sourceUrl: 'https://e.com/x',
+        createdAt
+    });
+    return { event, relays: ['wss://relay.example'] };
+}
+
+test('30062 routes to the "finding" facet with subject name resolved', async () => {
+    const recs = [await findingRecord({ maneuver: 'defense/usefulness-pivot', quote: 'I care about the truth.', createdAt: 100 })];
+    const items = buildItems(recs, { entityIndex: ENTITY_INDEX });
+    const item = items.find((i) => i.kind === 30062);
+    assert.ok(item, 'a finding item exists');
+    assert.equal(item.typeKey, 'finding');
+    assert.equal(item.title, 'Finding — defense/usefulness-pivot');
+    assert.match(item.sub, /Jacob Hansen · apologist/);
+    assert.ok(item.parsedFinding, 'parsedFinding rides on the item');
+    assert.equal(item.parsedFinding.subjectPubkey, SUBJECT_PK);
+    assert.match(item.searchText, /jacob hansen/);
+});
+
+test('30062 with no local entity falls back to a short pubkey', async () => {
+    const recs = [await findingRecord({ maneuver: 'darvo/attack', quote: 'You are biased.', createdAt: 100 })];
+    const items = buildItems(recs, { entityIndex: {} });
+    const item = items.find((i) => i.kind === 30062);
+    assert.match(item.sub, /^aaaaaaaaaa… · apologist/);
+});
+
+test('findingsForEntity joins by subject pubkey, newest first', async () => {
+    const recs = [
+        await findingRecord({ maneuver: 'defense/ad-hoc-patch', quote: 'older', createdAt: 100 }),
+        await findingRecord({ maneuver: 'darvo/attack', quote: 'newer', createdAt: 300 })
+    ];
+    const items = buildItems(recs, { entityIndex: ENTITY_INDEX });
+    const mine = findingsForEntity(items, SUBJECT_PK);
+    assert.equal(mine.length, 2);
+    assert.equal(mine[0].anchors[0].quote, 'newer', 'sorted newest-first');
+    assert.equal(findingsForEntity(items, OTHER_PK).length, 0, 'a different subject gets none');
+    assert.equal(findingsForEntity(items, null).length, 0);
+});
+
+test('maneuverTally counts most-frequent first; leadQuote/maneuverShort', async () => {
+    const findings = [
+        { maneuver: 'defense/ad-hoc-patch', anchors: [{ quote: 'q1' }] },
+        { maneuver: 'defense/ad-hoc-patch', anchors: [{ quote: 'q2' }] },
+        { maneuver: 'darvo/attack', anchors: [] }
+    ];
+    assert.deepEqual(maneuverTally(findings), [
+        { maneuver: 'defense/ad-hoc-patch', count: 2 },
+        { maneuver: 'darvo/attack', count: 1 }
+    ]);
+    assert.equal(leadQuote(findings[0]), 'q1');
+    assert.equal(leadQuote(findings[2]), '', 'no anchors → empty lead quote');
+    assert.equal(maneuverShort('defense/ad-hoc-patch'), 'ad-hoc-patch');
+    assert.deepEqual(FINDING_LENSES, ['evidentiary', 'executive', 'survivor', 'editor']);
+});

--- a/tests/portal-library.test.mjs
+++ b/tests/portal-library.test.mjs
@@ -171,8 +171,11 @@ test('EMPTY_FILTERS and TYPE_DEFS are pinned', () => {
         ['article', 'claim', 'comment', 'assessment',
             // Phase 13.7 facets:
             'audit', 'prediction',
+            // Phase 14.4 facet:
+            'finding',
             'link', 'entity', 'case', 'account', 'other']);
     assert.equal(kindLabel(30040), 'Claim');
+    assert.equal(kindLabel(30062), 'Behavioral finding');
     assert.equal(kindLabel(12345), 'kind 12345');
 });
 


### PR DESCRIPTION
## What this is

A new **behavior layer** built **on top of** the Phase 13 epistemic audit (now merged to `main`) and alongside the Phase 11 assessment layer. Where an assessment grades whether a *claim* is true, a **forensic finding** names a *maneuver* a subject performs around the truth — an evasion, an immunizing defense, a self-serving revision — and binds it to evidence, **with no verdict on the subject's honesty or intent.** Framing adapted, with attribution, from Dawn McCarty's "forensic criminology" segment on *Mormonism Live* ([`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)); her vocabulary is reduced to the criminology / thought-reform canon so the taxonomy is citable.

> Renumbered from "Phase 13" to **Phase 14** and re-kinded `30056` → `30062` to avoid colliding with the (now-merged) epistemic-audit Phase 13. Full design: [`docs/CRIMINOLOGY_DESIGN.md`](https://github.com/bryanmatthewsimonson/xray/blob/claude/x-ray-criminology-framework-t2cegk/docs/CRIMINOLOGY_DESIGN.md).

## The core guarantee — no verdict, no score, by construction
The model has **no `lying` / `intent` / `confidence` / `stance` field**. A `counter_note` (the exonerating read) is *required* to save; a bounded **`basis`** enum (`quoted` / `paraphrased` / `behavioral-cue` / `structural-inference`) records *how we know* in place of a number. The wire firewall holds by construction: a `30062` never carries `stance` / `rating-value` / `score` / the `xray/assessment` namespace; consumers MUST NOT merge findings with assessments/fact-checks/audits.

## Slices in this PR

| Slice | What |
| --- | --- |
| **14.1** Foundation | `forensic-taxonomy.js` (six canon-seeded maneuver families — neutralization / DARVO / thought-reform / defense / grooming — + role/basis enums + a `MANEUVER_GUIDE` of indicators/counter-indicators); `forensic-model.js` (`BehavioralFinding` + `ForensicBaseline`, the methodology rules enforced in code); `revision/*` edges on kind 30055. |
| **14.2** Capture UI | `forensic-modal.js` (`openFindingModal` + `openBaselineModal`) + the reader "Forensic findings" bar; tagged-entity subjects; selection-seeded ordered evidence chain; the maneuver's definition + counter-indicators shown inline. |
| **14.3** Wire + NIP | `buildBehavioralFindingEvent` (`30062`) + `parseBehavioralFindingEvent` + the kind-1985 maneuver mirror; `forensicPublishing` flag; `NIP_DRAFT.md` §30062/§30055 with the firewall + "structural-observation, not verdict" framing. |
| **14.3b** Publish wiring | `forensic-publish.js` selectors (subject-pubkey resolution via the entity registry; staleness/mirror gates) + a flag-gated reader publish batch (findings → mirrors → revision edges), folded into the publish summary. |
| **14.4** Portal lenses | Portal report surface for `30062`: `finding` facet + `Behavioral finding` label, `findings-block.js` with four lenses (evidentiary / executive / survivor / editor), `forensic-data.js` joins (`findingsForEntity`, `maneuverTally`), inspector finding section, reconciliation over the findings ledger. |
| **§Phase 14** | `SMOKE_TEST.md` manual walk (steps 14.1–14.27 incl. portal) + an Options **"Publish forensic findings"** toggle. |
| **14.5** (handoff only) | `docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md` — a Claude Code prompt to implement in-extension LLM-assist across **all** artifact types (entities / claims / assessments / relationships / findings / baselines / revision edges). Not built here. |

## Verification
**Full suite green** (forensic + portal-findings tests added), build + `web-ext lint --self-hosted` clean.

## Reviewer asks (the load-bearing bits)
1. **The wire format (`30062`)** — it's an outward-facing contract; the tag grammar, the recomputable `d`, and the person-labeling kind-1985 mirror's framing are the things hardest to change later.
2. **The taxonomy** (`forensic-taxonomy.js`) — every later slice inherits it.
3. **The reader publish-batch edit** (`src/reader/index.js`) — the largest single diff.

## Status / remaining
14.1–14.4 complete. **14.5** (LLM-assist) is documented as a handoff in `docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md` and intentionally left for a future session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNP9W147ZyGotfSBCViLCt