### PR TITLE
Phase 14.5 — LLM-assist (in-extension suggestion engine)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Added
 
+- **Phase 14.5 — LLM assist (in-extension suggestion engine).** A
+  user-invoked pass that calls the Anthropic Messages API **from the
+  background service worker** and proposes capture artifacts — entities,
+  claims, assessments, claim relationships, and forensic findings (plus
+  baselines and `revision/*` edges) — for human review in a grouped
+  Accept / Edit / Reject panel in the reader. Every accepted artifact is
+  created through the **existing models** with provenance
+  `suggested_by: 'llm:<model>'`; **nothing auto-saves or auto-publishes**
+  (publishing stays behind the existing publish flags). Gated by a new
+  **`llmAssist`** flag (default off) **and** a user-supplied API key (a
+  second consent gate, since the article text leaves the device). The
+  existing model validators are the firewall — findings keep the
+  no-verdict discipline (a required counter-note, ≥1 quoted anchor, no
+  intent/score). New: `shared/llm-prompts.js`, `shared/llm-client.js`,
+  `shared/llm-proposals.js`, `reader/llm-review.js`; the
+  `xray:llm:suggest` / `xray:llm:config` messages; an Options →
+  Advanced → "LLM assist" section (key / model / flag); and the
+  `https://api.anthropic.com/*` host permission. `ClaimModel` and
+  `EntityModel` gain a local-only `suggested_by` field (the kind-30040 /
+  kind-0 wire formats are unchanged).
 - **Phase 14.3 — forensic wire format (kind `30062`).** New
   `buildBehavioralFindingEvent` (kind 30062 BehavioralFinding) +
   `parseBehavioralFindingEvent` + a kind-1985 maneuver mirror, behind a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ extension approves in-context.
 **Message bus:** everything is `chrome.runtime` messages typed `xray:*`
 (e.g. `xray:capture`, `xray:capture:publish`, `xray:relay:publish`,
 `xray:relay:query`, `xray:sign`, `xray:youtube:fetch`,
-`xray:screenshot:capture`, `xray:flags:reload`). When adding a cross-context
+`xray:screenshot:capture`, `xray:flags:reload`, `xray:llm:suggest`). When adding a cross-context
 call, add an `xray:*` message rather than reaching across contexts directly.
 
 ### Shared layer (`src/shared/`)

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,51 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-20 — Phase 14.5: LLM-assist suggestions through the existing models
+
+**Tags:** design
+
+Phase 14.5 ([`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`](PHASE_14_5_LLM_ASSIST_KICKOFF.md))
+adds a user-invoked Anthropic call that *proposes* capture artifacts.
+Decisions worth recording:
+
+- **The fetch lives in the service worker** (`shared/llm-client.js`),
+  not the reader page — same reason the relay pool does: page CSP would
+  block the call. Browser-origin requests need the
+  `anthropic-dangerous-direct-browser-access: true` header (CORS is
+  enabled for it); the SW already has the `api.anthropic.com` host
+  permission, so the response is readable.
+- **Two consent gates, key never leaves the SW.** The feature is off
+  behind `llmAssist`, and even on it does nothing without a user-supplied
+  key. The key lives under its own `chrome.storage.local` key
+  (`xray:llm:key`), is added to the "erase all" sweep, is never echoed
+  back into the Options page (we report only *whether* one is set), never
+  logged, and never in any export. The reader learns flag+key state via a
+  thin `xray:llm:config` snapshot (booleans + model id), so the key stays
+  in the SW.
+- **The kickoff assumed every model carried `suggested_by`; claims and
+  entities did not.** Rather than touch the kind-30040 / kind-0 wire
+  format (compat consequences), I added a **local-only** `suggested_by`
+  field to `ClaimModel.create` / `EntityModel.create` (default `'user'`,
+  validated). Assessments / links / findings already had the full seam,
+  wire included.
+- **Validation is two-tier.** `llm-proposals.validateProposal` mirrors
+  the model validators using the *same* exported predicates so the review
+  panel can show "rejected-with-reason" without writing; the model's
+  `create()` is still the ultimate firewall at accept. A finding with no
+  counter-note or no quoted anchor fails both — by construction there is
+  no intent/score field anywhere to supply.
+- **Edit is an inline editor, not a modal pre-fill.** The kickoff
+  suggested "open the matching capture modal pre-filled," but the finding
+  modal has no non-edit seed path and the assess/link modals collect their
+  own candidates — pre-filling unsaved proposals would have meant either
+  modal surgery or reimplementing the pickers (a parallel capture UI the
+  conventions warn against). A compact, data-driven inline editor over the
+  proposal's editable fields keeps one save path (the real models) and
+  flips provenance to `'user'` on a substantive edit. Structural fields
+  with rich pickers (label sets, maneuver groups) stay as proposed; the
+  user rejects + captures manually via the existing bars to change those.
+
 ## 2026-06-14 — Phase 14: a behavior layer that deliberately renders no verdict
 
 **Tags:** design

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -73,7 +73,7 @@ Phase 13 ███████████░░░░░░░░░  in progre
                                 pending smoke-test
 Phase 14 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
                                 behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
-                                builds on Phase 13; 14.1–14.4 built, 14.5 pending
+                                builds on Phase 13; 14.1–14.5 built
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -1139,12 +1139,16 @@ Slices (one PR each):
   / survivor / editor) over the same findings, never averaged; `30062`
   joins `LEDGERED_KINDS` for reconciliation (the wire d-tag recorded at
   publish).
-- ⏳ **14.5** LLM assist (flag-gated, **in-extension Anthropic call**) — a
+- ✅ **14.5** LLM assist (flag-gated, **in-extension Anthropic call**) — a
   user-invoked pass that proposes **all** capture artifacts (entities,
   claims, assessments, relationships, findings — and baselines / revision
   edges) for human review, created with `suggested_by: llm:<model>`;
   enforces the anchor + counter-note + basis discipline; nothing
-  auto-saves or auto-publishes. Implementation prompt:
+  auto-saves or auto-publishes. Off by default behind the `llmAssist`
+  flag + a user-supplied API key (the article text leaves the device).
+  `shared/llm-{prompts,client,proposals}.js` + `reader/llm-review.js`;
+  the `xray:llm:suggest` / `xray:llm:config` messages; Options →
+  Advanced → "LLM assist". Implementation prompt:
   [`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`](PHASE_14_5_LLM_ASSIST_KICKOFF.md).
 
 Acceptance demo: the source video itself

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -622,6 +622,62 @@ Epistemic-audit bar** — three separate, firewalled blocks.
 
 ---
 
+## Phase 14.5 — LLM assist (in-extension suggestions)
+
+A user-invoked pass that asks Anthropic's Claude to **propose** capture
+artifacts (entities, claims, assessments, relationships, findings — and
+baselines / revision edges) for review. Two consent gates: the
+`llmAssist` flag (off by default) **and** a user-supplied API key. Every
+item is a draft — nothing saves without Accept, nothing publishes.
+Requires a real Anthropic API key (`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`).
+
+**Gating (no key / no flag = no calls)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.5.1 | Fresh profile, flag off. Open a captured article in the reader | ✅ **no "✨ Suggest…" button** in the chrome; with DevTools Network open, no request to `api.anthropic.com` is possible |
+| 14.5.2 | Settings → Advanced → **LLM assist**: confirm the toggle is **unchecked** and "No key saved yet." | ✅ default off, no key |
+| 14.5.3 | Check **Enable LLM-assisted suggestions**, leave the key blank, Save → reopen the reader | ✅ the **✨ Suggest…** button is present but **disabled**, tooltip points to the key field; still zero network |
+| 14.5.4 | Paste an Anthropic key + pick a **Model**, Save. Confirm the key field clears and status reads "A key is saved." | ✅ key stored; reader's Suggest button now **enabled** |
+
+**Run a pass + review**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.5.5 | On an op-ed / debate with named people, click **✨ Suggest…** | ✅ button shows "✨ Thinking…", then a **Suggestions** modal opens grouped by Entities / Claims / Assessments / Relationships / Findings (and Baselines/Revisions if any); a model badge shows the model id |
+| 14.5.6 | Inspect a **Claim** proposal | ✅ summary shows the claim text + the about-entities it links; Accept / Edit / Reject buttons |
+| 14.5.7 | Inspect a **Finding** proposal | ✅ shows subject + maneuver + role/basis + a quoted lead + the **counter-read** (`↔ …`); **no stance/score/confidence anywhere** |
+| 14.5.8 | **Accept** an entity, then its claim, then a finding (or click **Accept all valid**) | ✅ rows flip to "✓ accepted"; the **claims bar** and **Forensic findings bar** gain the artifacts |
+| 14.5.9 | DevTools: `chrome.storage.local.get(['article_claims','behavioral_findings','entities'], console.log)` | ✅ accepted records carry `suggested_by: "llm:<model>"`; the finding has `counter_note`, `anchors[].quote`, and **no** `stance`/`intent`/`score` field |
+| 14.5.10 | Click a claim's tagged passage / a finding's evidence in the article body | ✅ the LLM's verbatim quote resolved to a real anchor (the span highlights / jumps) |
+
+**The firewall + Edit/Reject**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.5.11 | If the model returned a finding with a missing/empty counter-note (or no quoted anchor), find its row | ✅ shows **"✗ …counter-note / anchor"** rejected-with-reason, Accept **disabled** — it can never save in that state |
+| 14.5.12 | **Edit** a finding row → clear the **Counter-read** → Apply | ✅ the row re-validates to ✗ rejected (Accept disabled) |
+| 14.5.13 | **Edit** a claim's text → Apply | ✅ the row gains a **"✎ edited (you)"** badge; on Accept the stored claim is `suggested_by: "user"` (honest provenance) |
+| 14.5.14 | **Reject** a proposal | ✅ row dims to "✕ rejected"; nothing is stored for it |
+| 14.5.15 | Publishing is unaffected: with `assessmentPublishing` / `forensicPublishing` **off**, Publish | ✅ accepted LLM artifacts are **not** published (suggestion never publishes) |
+
+**Secret hygiene + errors**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.5.16 | Export entities / a case bundle (Options → Keypair registry / case export) | ✅ the export JSON contains **no** `xray:llm:key` and no key value |
+| 14.5.17 | With debug logging on, run a pass | ✅ console logs counts/model only — **never** the API key |
+| 14.5.18 | Temporarily set a bad key, run a pass | ✅ a clear toast ("the key was rejected (401/403)…"), no crash |
+| 14.5.19 | Options → Advanced → **Clear key**, then **Erase all** | ✅ "Key cleared."; after erase-all, `chrome.storage.local.get('xray:llm:key', console.log)` is empty and the flag is reset |
+
+**Firefox**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 14.5.20 | Repeat 14.5.4, 14.5.5, 14.5.8, 14.5.11 on Firefox ≥128 | ✅ identical behavior (the fetch runs in the SW; `anthropic-dangerous-direct-browser-access` header is sent) |
+
+---
+
 ## Phase 6 — Entity sync
 
 Run on **Device A** (your normal profile) and **Device B** (a

--- a/manifest.json
+++ b/manifest.json
@@ -50,7 +50,8 @@
     "declarativeNetRequest"
   ],
   "host_permissions": [
-    "<all_urls>"
+    "<all_urls>",
+    "https://api.anthropic.com/*"
   ],
   "content_scripts": [
     {

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -26,7 +26,7 @@ import { NostrClient } from '../shared/nostr-client.js';
 import { EventBuilder } from '../shared/event-builder.js';
 import { fetchSubstackPost, fetchSubstackComments } from '../shared/platforms/substack-api.js';
 import { handleScreenshotCapture } from '../shared/screenshot.js';
-import { runSuggestionPass } from '../shared/llm-client.js';
+import { runSuggestionPass, getLlmConfig } from '../shared/llm-client.js';
 
 // Pull the debug preference on SW startup. MV3 service workers sleep
 // and wake, so this runs each time the SW reloads. A chrome.storage
@@ -353,6 +353,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         runSuggestionPass(message.request || {}).then(
             (result) => sendResponse(result),
             (err) => sendResponse({ ok: false, error: (err && err.message) || 'LLM pass failed' })
+        );
+        return true; // async sendResponse
+    }
+
+    // Reader page → worker: LLM-assist gating snapshot — whether the flag
+    // is on, whether a key is present (NEVER the key value), and the
+    // chosen model. The reader uses it to show/enable the Suggest control.
+    if (message.type === 'xray:llm:config') {
+        getLlmConfig().then(
+            (cfg) => sendResponse({ ok: true, ...cfg }),
+            () => sendResponse({ ok: false, enabled: false, hasKey: false })
         );
         return true; // async sendResponse
     }

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -26,6 +26,7 @@ import { NostrClient } from '../shared/nostr-client.js';
 import { EventBuilder } from '../shared/event-builder.js';
 import { fetchSubstackPost, fetchSubstackComments } from '../shared/platforms/substack-api.js';
 import { handleScreenshotCapture } from '../shared/screenshot.js';
+import { runSuggestionPass } from '../shared/llm-client.js';
 
 // Pull the debug preference on SW startup. MV3 service workers sleep
 // and wake, so this runs each time the SW reloads. A chrome.storage
@@ -338,6 +339,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         handleCapturePublish(id, event).then(
             (result) => sendResponse(result),
             (err) => sendResponse({ ok: false, error: err && err.message })
+        );
+        return true; // async sendResponse
+    }
+
+    // Reader page → worker: run an LLM-assist suggestion pass against
+    // the open article. The Anthropic call lives here (not the reader
+    // page) because the SW is outside page CSP, and the key never leaves
+    // the SW. Gated by the `llmAssist` flag + a user-supplied key inside
+    // runSuggestionPass; returns validated-shape proposals only — nothing
+    // is saved or published here.
+    if (message.type === 'xray:llm:suggest') {
+        runSuggestionPass(message.request || {}).then(
+            (result) => sendResponse(result),
+            (err) => sendResponse({ ok: false, error: (err && err.message) || 'LLM pass failed' })
         );
         return true; // async sendResponse
     }

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -8,6 +8,7 @@ import { Storage } from '../shared/storage.js';
 import { Crypto } from '../shared/crypto.js';
 import { NSecBunkerClient } from '../shared/nsecbunker-client.js';
 import { loadFlags, isEnabled, setOverride, resetOverrides } from '../shared/metadata/feature-flags.js';
+import { LLM_MODELS, DEFAULT_LLM_MODEL, resolveModel, LLM_KEY_STORAGE, LLM_MODEL_STORAGE } from '../shared/llm-prompts.js';
 import { importAuditJson } from '../shared/audit/import.js';
 import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
 import { listRuns, listPredictions, listResolutions } from '../shared/audit/audit-cache.js';
@@ -50,10 +51,40 @@ function storageClearExtension() {
     const keys = [
         'publications', 'people', 'organizations',
         'preferences', 'keypair_registry',
-        'local_primary_identity', 'xr_signing_state'
+        'local_primary_identity', 'xr_signing_state',
+        // Phase 14.5: the LLM-assist secret key + model preference. The
+        // key is a secret, so "erase all" must clear it too.
+        LLM_KEY_STORAGE, LLM_MODEL_STORAGE
     ];
     return new Promise((resolve) => {
         browserApi.storage.local.remove(keys, () => resolve());
+    });
+}
+
+// ------------------------------------------------------------------
+// LLM assist — raw (un-wrapped) storage for the secret key + model.
+// The SW client reads these as PLAIN strings (not JSON), so write them
+// the same way. The key value is never echoed back into the page.
+// ------------------------------------------------------------------
+
+function llmRawGet(key) {
+    return new Promise((resolve) => {
+        browserApi.storage.local.get([key], (res) => {
+            const v = res ? res[key] : undefined;
+            resolve(typeof v === 'string' ? v : '');
+        });
+    });
+}
+
+function llmRawSet(key, value) {
+    return new Promise((resolve) => {
+        browserApi.storage.local.set({ [key]: value }, () => resolve());
+    });
+}
+
+function llmRawRemove(key) {
+    return new Promise((resolve) => {
+        browserApi.storage.local.remove([key], () => resolve());
     });
 }
 
@@ -525,6 +556,22 @@ async function loadAdvanced() {
     document.getElementById('pref-forensic-publishing').checked =
         isEnabled('forensicPublishing');
 
+    // LLM assist (Phase 14.5). The flag lives in feature-flags; the key
+    // + model live under their own chrome.storage.local keys. We never
+    // load the key VALUE back into the DOM — only whether one is set.
+    document.getElementById('pref-llm-assist').checked = isEnabled('llmAssist');
+    populateLlmModels();
+    const savedModel = resolveModel(await llmRawGet(LLM_MODEL_STORAGE));
+    document.getElementById('pref-llm-model').value = savedModel;
+    const hasKey = (await llmRawGet(LLM_KEY_STORAGE)).length > 0;
+    const keyStatus = document.getElementById('llm-key-status');
+    if (keyStatus) {
+        keyStatus.textContent = hasKey
+            ? 'A key is saved on this device.'
+            : 'No key saved yet.';
+    }
+    document.getElementById('pref-llm-key').value = '';
+
     const overrides = prefs.config_overrides || {};
     document.getElementById('pref-cache-enabled').checked =
         overrides.article_cache_enabled !== false;
@@ -563,7 +610,40 @@ async function saveAdvanced() {
     const publishFindings = document.getElementById('pref-forensic-publishing').checked;
     await setOverride('forensicPublishing', publishFindings ? true : null);
 
+    // LLM assist: flag + model preference always; the key only when the
+    // user typed a new one (blank leaves the saved key untouched).
+    const llmOn = document.getElementById('pref-llm-assist').checked;
+    await setOverride('llmAssist', llmOn ? true : null);
+    await llmRawSet(LLM_MODEL_STORAGE, document.getElementById('pref-llm-model').value || DEFAULT_LLM_MODEL);
+    const keyField = document.getElementById('pref-llm-key');
+    const typedKey = (keyField.value || '').trim();
+    if (typedKey) {
+        await llmRawSet(LLM_KEY_STORAGE, typedKey);
+        keyField.value = '';
+        const keyStatus = document.getElementById('llm-key-status');
+        if (keyStatus) keyStatus.textContent = 'A key is saved on this device.';
+    }
+
     flash(document.getElementById('advanced-status'), 'Saved.');
+}
+
+function populateLlmModels() {
+    const sel = document.getElementById('pref-llm-model');
+    if (!sel || sel.options.length > 0) return;
+    for (const m of LLM_MODELS) {
+        const opt = document.createElement('option');
+        opt.value = m.id;
+        opt.textContent = m.label;
+        sel.appendChild(opt);
+    }
+}
+
+async function clearLlmKey() {
+    await llmRawRemove(LLM_KEY_STORAGE);
+    const keyStatus = document.getElementById('llm-key-status');
+    if (keyStatus) keyStatus.textContent = 'No key saved yet.';
+    document.getElementById('pref-llm-key').value = '';
+    flash(document.getElementById('llm-status'), 'Key cleared.');
 }
 
 async function clearAll() {
@@ -653,6 +733,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
     document.getElementById('advanced-save').addEventListener('click', saveAdvanced);
+    document.getElementById('llm-key-clear').addEventListener('click', clearLlmKey);
     document.getElementById('clear-all').addEventListener('click', clearAll);
 });
 // Re-export for tests / debugging.

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -283,6 +283,40 @@
       </p>
 
       <hr />
+      <h3 class="xr-opt__subhead">LLM assist</h3>
+      <label class="xr-opt__field xr-opt__field--inline">
+        <input type="checkbox" id="pref-llm-assist" />
+        <span>Enable LLM-assisted suggestions in the reader</span>
+      </label>
+      <p class="xr-opt__hint" style="margin-top:-8px">
+        Off by default. When on <strong>and</strong> an API key is set, the
+        reader gains a <strong>✨ Suggest…</strong> control that asks Anthropic's
+        Claude to propose entities, claims, assessments, relationships, and
+        forensic findings from the open article. <strong>The article text is
+        sent to Anthropic</strong> when you run a pass. Every suggestion is a
+        <strong>draft you review and confirm</strong> — nothing is saved or
+        published automatically, and publishing still requires the
+        experimental publish switches above.
+      </p>
+      <label class="xr-opt__field">
+        <span class="xr-opt__label">Anthropic API key</span>
+        <input type="password" id="pref-llm-key" autocomplete="off" spellcheck="false"
+               placeholder="sk-ant-… (leave blank to keep the saved key)" />
+      </label>
+      <p class="xr-opt__hint" style="margin-top:-8px">
+        Stored locally on this device, never published, never included in any
+        export, and never logged. <span id="llm-key-status"></span>
+      </p>
+      <label class="xr-opt__field">
+        <span class="xr-opt__label">Model</span>
+        <select id="pref-llm-model"></select>
+      </label>
+      <div class="xr-opt__actions">
+        <button class="xr-opt__btn" id="llm-key-clear">Clear key</button>
+        <span class="xr-opt__status" id="llm-status"></span>
+      </div>
+
+      <hr />
       <h3 class="xr-opt__subhead">Power user</h3>
 
       <label class="xr-opt__field xr-opt__field--inline">

--- a/src/reader/index.css
+++ b/src/reader/index.css
@@ -2144,3 +2144,81 @@ body {
   color: var(--xr-text-dim);
   font-family: ui-monospace, SF Mono, Menlo, monospace;
 }
+
+/* ==================================================================
+   LLM assist (Phase 14.5) — review panel + Suggest control
+   ================================================================== */
+
+.xr-llm { position: fixed; inset: 0; z-index: 1000; display: flex;
+  align-items: center; justify-content: center; font-family: var(--xr-reader-sans); }
+.xr-llm__backdrop { position: absolute; inset: 0; background: rgba(0, 0, 0, 0.6); }
+.xr-llm__card { position: relative; width: min(860px, 94vw); max-height: 88vh;
+  display: flex; flex-direction: column; background: var(--xr-surface);
+  border: 1px solid var(--xr-border); border-radius: 12px; overflow: hidden;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5); color: var(--xr-text); }
+
+.xr-llm__head { display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px; border-bottom: 1px solid var(--xr-border); }
+.xr-llm__title { margin: 0; font-size: 18px; }
+.xr-llm__model { font-family: ui-monospace, SF Mono, Menlo, monospace;
+  font-size: 11px; color: var(--xr-text-dim); border: 1px solid var(--xr-border);
+  border-radius: 6px; padding: 2px 6px; }
+.xr-llm__gap { flex: 1; }
+.xr-llm__close { background: none; border: none; color: var(--xr-text-dim);
+  font-size: 18px; cursor: pointer; }
+.xr-llm__close:hover { color: var(--xr-text); }
+
+.xr-llm__disclosure { margin: 0; padding: 10px 18px; font-size: 12.5px;
+  color: var(--xr-text-dim); background: var(--xr-surface-2);
+  border-bottom: 1px solid var(--xr-border); }
+.xr-llm__disclosure code { font-size: 11px; color: var(--xr-accent); }
+
+.xr-llm__body { padding: 8px 18px 4px; overflow-y: auto; }
+.xr-llm__empty { color: var(--xr-text-dim); padding: 20px 0; text-align: center; }
+.xr-llm__section { margin: 12px 0; }
+.xr-llm__section-title { margin: 0 0 6px; font-size: 13px; text-transform: uppercase;
+  letter-spacing: 0.04em; color: var(--xr-text-dim); }
+.xr-llm__dim { color: var(--xr-text-dim); font-weight: normal; }
+
+.xr-llm__row { display: flex; gap: 12px; align-items: flex-start;
+  padding: 10px; border: 1px solid var(--xr-border); border-radius: 8px;
+  margin-bottom: 6px; background: var(--xr-surface-2); }
+.xr-llm__row--accepted { opacity: 0.7; border-color: var(--xr-success); }
+.xr-llm__row--rejected { opacity: 0.45; }
+.xr-llm__row-main { flex: 1; min-width: 0; }
+.xr-llm__summary { font-size: 14px; line-height: 1.45; word-wrap: break-word; }
+.xr-llm__man { color: var(--xr-accent); font-family: ui-monospace, SF Mono, Menlo, monospace; font-size: 12.5px; }
+.xr-llm__quote { margin: 6px 0 2px; padding-left: 10px; border-left: 2px solid var(--xr-border);
+  color: var(--xr-text-dim); font-style: italic; font-size: 12.5px; }
+.xr-llm__counter { display: block; margin-top: 4px; color: var(--xr-warning); font-size: 12px; }
+
+.xr-llm__badge { display: inline-block; margin-top: 6px; font-size: 11px;
+  padding: 2px 7px; border-radius: 10px; }
+.xr-llm__badge--ok  { background: rgba(52, 211, 153, 0.15); color: var(--xr-success); }
+.xr-llm__badge--rej { background: rgba(154, 154, 154, 0.15); color: var(--xr-text-dim); }
+.xr-llm__badge--bad { background: rgba(248, 113, 113, 0.15); color: var(--xr-danger); }
+.xr-llm__badge--edit { background: rgba(139, 92, 246, 0.18); color: var(--xr-primary); }
+.xr-llm__msg { margin-top: 6px; font-size: 12px; color: var(--xr-danger); }
+
+.xr-llm__row-actions { display: flex; flex-direction: column; gap: 6px; flex: 0 0 auto; }
+.xr-llm__btn { font: inherit; font-size: 13px; padding: 6px 12px; cursor: pointer;
+  border: 1px solid var(--xr-border); border-radius: 7px; background: var(--xr-surface);
+  color: var(--xr-text); white-space: nowrap; }
+.xr-llm__btn:hover:not(:disabled) { border-color: var(--xr-text-dim); }
+.xr-llm__btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.xr-llm__btn--primary { background: var(--xr-primary); border-color: var(--xr-primary); color: #fff; }
+.xr-llm__btn--primary:hover:not(:disabled) { background: var(--xr-primary-hover); }
+.xr-llm__btn--ghost { background: none; }
+
+.xr-llm__editor { margin-top: 8px; padding: 8px; border-top: 1px dashed var(--xr-border);
+  display: flex; flex-direction: column; gap: 6px; }
+.xr-llm__f { display: flex; flex-direction: column; gap: 3px; font-size: 12px; color: var(--xr-text-dim); }
+.xr-llm__f--inline { flex-direction: row; align-items: center; gap: 6px; }
+.xr-llm__f input[type="text"], .xr-llm__f textarea, .xr-llm__f select {
+  font: inherit; font-size: 13px; padding: 5px 7px; border: 1px solid var(--xr-border);
+  border-radius: 6px; background: var(--xr-bg); color: var(--xr-text); width: 100%; }
+.xr-llm__editor-actions { display: flex; justify-content: flex-end; gap: 6px; }
+
+.xr-llm__foot { display: flex; align-items: center; gap: 10px;
+  padding: 12px 18px; border-top: 1px solid var(--xr-border); }
+.xr-llm__status { color: var(--xr-text-dim); font-size: 13px; }

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -17,6 +17,12 @@
       <button class="xr-reader__mode-btn"                              data-mode="preview"  role="tab" aria-selected="false">Preview</button>
     </nav>
     <div class="xr-reader__chrome-right">
+      <!-- LLM-assist (Phase 14.5): hidden unless the llmAssist flag is on.
+           Sends the article text to Anthropic and opens a review panel of
+           draft suggestions — nothing saves or publishes without Accept. -->
+      <button class="xr-reader__btn xr-reader__btn--ghost" id="xr-suggest" title="Suggest capture artifacts with an LLM" hidden>
+        ✨ Suggest…
+      </button>
       <button class="xr-reader__btn xr-reader__btn--ghost" id="xr-entities" title="Open entity browser in the side panel">
         👤 Entities
       </button>

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -30,6 +30,7 @@ import { loadFlags, isEnabled } from '../shared/metadata/feature-flags.js';
 import { ForensicModel } from '../shared/forensic-model.js';
 import { openFindingModal, openBaselineModal } from '../shared/forensic-modal.js';
 import { renderFindingsBar } from './findings-section.js';
+import { openLlmReview } from './llm-review.js';
 import { captureFromRange } from '../shared/metadata/anchor-capture.js';
 import { normalize as normalizeUrl } from '../shared/metadata/url-normalizer.js';
 import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
@@ -996,6 +997,91 @@ async function refreshFindingsBar() {
             toast('Finding removed', 'success', 1500);
             await refreshFindingsBar();
         });
+    });
+}
+
+// ------------------------------------------------------------------
+// LLM assist (Phase 14.5) — Suggest control + review handoff
+// ------------------------------------------------------------------
+
+/**
+ * The article body text we both send to the model and resolve quotes
+ * against — same string, so the model's verbatim quotes anchor cleanly.
+ */
+function articleBodyText() {
+    const body = $('.xr-article__body');
+    const text = body ? (body.textContent || '') : '';
+    return text.trim() ? text : (state.markdownDraft || '');
+}
+
+/**
+ * Configure the Suggest control from the SW's gating snapshot. Absent
+ * when the flag is off; visible-but-disabled when on with no key — so
+ * either condition guarantees no network call is reachable from here.
+ */
+async function setupSuggestControl() {
+    const btn = $('#xr-suggest');
+    if (!btn) return;
+    let cfg = {};
+    try { cfg = await browserApi.runtime.sendMessage({ type: 'xray:llm:config' }) || {}; }
+    catch (_) { cfg = {}; }
+
+    if (!cfg.enabled) { btn.hidden = true; return; }   // flag off ⇒ absent
+    btn.hidden = false;
+    if (!cfg.hasKey) {
+        btn.disabled = true;
+        btn.title = 'Set an Anthropic API key in Options → Advanced → LLM assist';
+        return;
+    }
+    btn.disabled = false;
+    btn.title = 'Suggest capture artifacts with an LLM (sends the article text to Anthropic)';
+    btn.addEventListener('click', runSuggestPass);
+}
+
+async function runSuggestPass() {
+    const btn = $('#xr-suggest');
+    if (!btn || btn.disabled || !state.article) return;
+    const articleText = articleBodyText();
+    if (!articleText.trim()) { toast('Nothing to analyze yet.', 'error'); return; }
+
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = '✨ Thinking…';
+    let resp;
+    try {
+        resp = await browserApi.runtime.sendMessage({
+            type: 'xray:llm:suggest',
+            request: {
+                task: 'all',
+                articleText,
+                articleUrl: state.article.url || '',
+                articleTitle: state.article.title || ''
+            }
+        });
+    } catch (err) {
+        resp = { ok: false, error: (err && err.message) || String(err) };
+    }
+    btn.textContent = original;
+    btn.disabled = false;
+
+    if (!resp || !resp.ok) {
+        toast('Suggest failed: ' + ((resp && resp.error) || 'unknown error'), 'error', 6000);
+        return;
+    }
+    if (!Array.isArray(resp.proposals) || resp.proposals.length === 0) {
+        toast('The model returned no suggestions for this article.', 'success', 4000);
+        return;
+    }
+    await openLlmReview({
+        proposals:  resp.proposals,
+        model:      resp.model,
+        articleText,
+        sourceUrl:  state.article.url || '',
+        sourceRef:  { url: state.article.url || '', title: state.article.title || '' },
+        onAccepted: async () => {
+            await refreshClaimsBar().catch(() => {});
+            await refreshFindingsBar().catch(() => {});
+        }
     });
 }
 
@@ -3267,6 +3353,11 @@ async function init() {
     $('#xr-comments-include').addEventListener('change', (ev) => {
         state.comments.includeInPublish = ev.target.checked;
     });
+
+    // LLM-assist Suggest control (Phase 14.5). Absent unless the flag is
+    // on; disabled (with a hint) when on but no key — so flag-off OR
+    // no-key means zero network calls are possible from here.
+    setupSuggestControl().catch((err) => console.warn('[X-Ray Reader] suggest setup failed:', err));
 
     // Epistemic-audit import (13.5): button → hidden file input →
     // importAuditJson with the RQ1 gate (re-hash + schema-validate +

--- a/src/reader/llm-review.js
+++ b/src/reader/llm-review.js
@@ -1,0 +1,396 @@
+// LLM-assist review panel — Phase 14.5.3
+// (docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md).
+//
+// The human-in-the-loop surface. It takes the raw proposals from a
+// `xray:llm:suggest` pass, groups + validates them (llm-proposals), and
+// renders a modal grouped by artifact type. For each proposal the user
+// can Accept / Edit / Reject:
+//
+//   - Accept funnels the proposal through the EXISTING capture model
+//     (EntityModel / ClaimModel / AssessmentModel / EvidenceLinker /
+//     ForensicModel / ForensicBaseline) with provenance
+//     `suggested_by: 'llm:<model>'`. The model's create() is the real
+//     validation firewall.
+//   - Edit toggles a compact inline form over the proposal's editable
+//     fields; applying an edit flips that proposal's provenance to
+//     'user' (honest record-keeping) and re-validates.
+//   - Reject discards it.
+//
+// Nothing here saves without an explicit Accept, and nothing publishes —
+// publishing stays behind assessmentPublishing / forensicPublishing.
+// Invalid proposals render "rejected-with-reason" and cannot be accepted
+// until fixed.
+
+import { EntityModel } from '../shared/entity-model.js';
+import { ClaimModel } from '../shared/claim-model.js';
+import { AssessmentModel } from '../shared/assessment-model.js';
+import { EvidenceLinker } from '../shared/evidence-linker.js';
+import { ForensicModel, ForensicBaseline } from '../shared/forensic-model.js';
+import { ENTITY_TYPES } from '../shared/entity-model.js';
+import { STANCE_VALUES, STANCE_LABELS, CLAIM_RELATIONSHIPS, REVISION_RELATIONSHIPS } from '../shared/assessment-taxonomy.js';
+import { ROLES, BASIS_VALUES } from '../shared/forensic-taxonomy.js';
+import {
+    normalizeProposals, validateProposal, subjectLabelOf, PROPOSAL_ORDER,
+    buildEntityInput, buildClaimInput, buildAssessmentInput, buildLinkInput,
+    buildFindingInput, buildBaselineInput
+} from '../shared/llm-proposals.js';
+
+const KIND_TITLES = {
+    entity: 'Entities', claim: 'Claims', assessment: 'Assessments',
+    relationship: 'Relationships', revision: 'Revisions',
+    finding: 'Findings', baseline: 'Baselines'
+};
+
+// Compact, data-driven inline editor — the editable fields per kind.
+// Anchors / labels stay as proposed (the full pickers live in the +
+// capture modals); reject + capture manually to change those.
+const EDIT_FIELDS = {
+    entity: [
+        { key: 'name', label: 'Name', type: 'text' },
+        { key: 'entity_type', label: 'Type', type: 'select', options: ENTITY_TYPES }
+    ],
+    claim: [
+        { key: 'text', label: 'Claim text', type: 'textarea' },
+        { key: 'is_key', label: 'Key claim', type: 'checkbox' }
+    ],
+    assessment: [
+        { key: 'stance', label: 'Stance', type: 'stance' },
+        { key: 'rationale', label: 'Rationale', type: 'textarea' }
+    ],
+    relationship: [
+        { key: 'relationship', label: 'Relationship', type: 'select', options: CLAIM_RELATIONSHIPS },
+        { key: 'note', label: 'Note', type: 'text' }
+    ],
+    revision: [
+        { key: 'relationship', label: 'Revision', type: 'select', options: REVISION_RELATIONSHIPS },
+        { key: 'note', label: 'Note', type: 'text' }
+    ],
+    finding: [
+        { key: 'role', label: 'Role', type: 'select', options: ROLES },
+        { key: 'maneuver', label: 'Maneuver', type: 'text' },
+        { key: 'basis', label: 'Basis', type: 'select', options: BASIS_VALUES },
+        { key: 'note', label: 'Note', type: 'textarea' },
+        { key: 'counter_note', label: 'Counter-read (required)', type: 'textarea' }
+    ],
+    baseline: [
+        { key: 'subject_label', label: 'Subject', type: 'text' },
+        { key: 'note', label: 'Note', type: 'textarea' }
+    ]
+};
+
+function escapeHtml(s) {
+    return String(s ?? '').replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+}
+
+function truncate(s, n) {
+    const str = String(s || '');
+    return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+}
+
+/**
+ * Open the review modal.
+ *
+ * @param {object} opts
+ * @param {Array<object>} opts.proposals  raw proposals from the SW pass
+ * @param {string} opts.model             the model id used (for provenance)
+ * @param {string} opts.articleText       body text, for quote→anchor resolution
+ * @param {string} opts.sourceUrl
+ * @param {object} [opts.sourceRef]        { url, title }
+ * @param {function} [opts.onAccepted]     called after each accept (refresh bars)
+ * @returns {Promise<{accepted: number}>}
+ */
+export function openLlmReview(opts) {
+    const { proposals, model, articleText = '', sourceUrl = '', sourceRef = {}, onAccepted } = opts;
+    const suggestedByLlm = `llm:${model}`;
+    const norm = normalizeProposals(proposals);
+    const ctx = { claimRefs: norm.claimRefs, entityRefs: norm.entityRefs, entityLabelByRef: norm.entityLabelByRef };
+
+    // Nice summaries: claim text by ref.
+    const claimTextByRef = {};
+    for (const c of norm.byKind.claim) if (c.ref) claimTextByRef[c.ref] = c.text;
+
+    // Accept-time maps, filled as the user accepts in dependency order.
+    const entityIdByRef = {};
+    const claimIdByRef = {};
+
+    // One mutable row per proposal.
+    const rows = norm.all.map((p) => ({
+        pid: p.pid, kind: p.kind, ref: p.ref,
+        prop: { ...p },
+        status: 'pending',         // pending | accepted | rejected
+        suggestedBy: suggestedByLlm,
+        editing: false,
+        message: ''
+    }));
+    const rowByPid = new Map(rows.map((r) => [r.pid, r]));
+
+    return new Promise((resolve) => {
+        const host = document.createElement('div');
+        host.className = 'xr-llm';
+        document.body.appendChild(host);
+        let acceptedCount = 0;
+
+        const close = () => {
+            document.removeEventListener('keydown', onKey);
+            if (host.parentNode) host.parentNode.removeChild(host);
+            resolve({ accepted: acceptedCount });
+        };
+        const onKey = (ev) => { if (ev.key === 'Escape') close(); };
+        document.addEventListener('keydown', onKey);
+
+        function validityOf(row) {
+            return validateProposal(row.prop, ctx);
+        }
+
+        function summarize(row) {
+            const p = row.prop;
+            switch (row.kind) {
+                case 'entity':
+                    return `${escapeHtml(p.name || '(unnamed)')} <span class="xr-llm__dim">· ${escapeHtml(p.entity_type || '?')}</span>`;
+                case 'claim': {
+                    const about = (p.about || []).map((r) => norm.entityLabelByRef[r]).filter(Boolean);
+                    const star = p.is_key ? '⭐ ' : '';
+                    const ab = about.length ? ` <span class="xr-llm__dim">about ${escapeHtml(about.join(', '))}</span>` : '';
+                    return `${star}${escapeHtml(truncate(p.text, 160))}${ab}`;
+                }
+                case 'assessment': {
+                    const st = (p.stance === null || p.stance === undefined) ? '' : `stance: ${escapeHtml(STANCE_LABELS[String(p.stance)] || String(p.stance))}`;
+                    const labels = (p.labels || []).map((l) => l.label).filter(Boolean);
+                    const lb = labels.length ? `labels: ${escapeHtml(labels.join(', '))}` : '';
+                    return `<span class="xr-llm__dim">on</span> ${escapeHtml(truncate(claimTextByRef[p.claim_ref] || p.claim_ref, 90))}<br><small>${[st, lb].filter(Boolean).join(' · ')}</small>`;
+                }
+                case 'relationship':
+                case 'revision':
+                    return `${escapeHtml(truncate(claimTextByRef[p.source_claim_ref] || p.source_claim_ref, 60))} <strong>${escapeHtml(p.relationship)}</strong> ${escapeHtml(truncate(claimTextByRef[p.target_claim_ref] || p.target_claim_ref, 60))}`;
+                case 'finding': {
+                    const lead = (p.anchors && p.anchors[0] && p.anchors[0].quote) || '';
+                    return `<strong>${escapeHtml(subjectLabelOf(p, ctx) || '(subject)')}</strong> — <span class="xr-llm__man">${escapeHtml(p.maneuver || '?')}</span> <span class="xr-llm__dim">(${escapeHtml(p.role || '?')}, ${escapeHtml(p.basis || '?')})</span>${lead ? `<blockquote class="xr-llm__quote">${escapeHtml(truncate(lead, 140))}</blockquote>` : ''}<small class="xr-llm__counter">↔ ${escapeHtml(truncate(p.counter_note || '(no counter-read)', 140))}</small>`;
+                }
+                case 'baseline':
+                    return `<strong>${escapeHtml(subjectLabelOf(p, ctx) || '(subject)')}</strong> — ${escapeHtml(truncate(p.note, 160))}`;
+                default:
+                    return escapeHtml(row.kind);
+            }
+        }
+
+        function editorHtml(row) {
+            const fields = EDIT_FIELDS[row.kind] || [];
+            const p = row.prop;
+            const inputs = fields.map((f) => {
+                const id = `${row.pid}__${f.key}`;
+                if (f.type === 'textarea') {
+                    return `<label class="xr-llm__f"><span>${escapeHtml(f.label)}</span><textarea data-k="${f.key}" rows="2">${escapeHtml(p[f.key] || '')}</textarea></label>`;
+                }
+                if (f.type === 'checkbox') {
+                    return `<label class="xr-llm__f xr-llm__f--inline"><input type="checkbox" data-k="${f.key}" ${p[f.key] ? 'checked' : ''}/><span>${escapeHtml(f.label)}</span></label>`;
+                }
+                if (f.type === 'select') {
+                    const opts = f.options.map((o) => `<option value="${escapeHtml(o)}" ${p[f.key] === o ? 'selected' : ''}>${escapeHtml(o)}</option>`).join('');
+                    return `<label class="xr-llm__f"><span>${escapeHtml(f.label)}</span><select data-k="${f.key}">${opts}</select></label>`;
+                }
+                if (f.type === 'stance') {
+                    const cur = (p.stance === undefined ? null : p.stance);
+                    const opts = [`<option value="" ${cur === null ? 'selected' : ''}>(no stance)</option>`]
+                        .concat(STANCE_VALUES.map((v) => `<option value="${v}" ${cur === v ? 'selected' : ''}>${escapeHtml(STANCE_LABELS[String(v)])}</option>`)).join('');
+                    return `<label class="xr-llm__f"><span>${escapeHtml(f.label)}</span><select data-k="stance">${opts}</select></label>`;
+                }
+                // text
+                return `<label class="xr-llm__f"><span>${escapeHtml(f.label)}</span><input type="text" data-k="${f.key}" value="${escapeHtml(p[f.key] || '')}"/></label>`;
+            }).join('');
+            return `<div class="xr-llm__editor">${inputs}
+                <div class="xr-llm__editor-actions">
+                  <button type="button" class="xr-llm__btn" data-act="edit-cancel">Cancel</button>
+                  <button type="button" class="xr-llm__btn xr-llm__btn--primary" data-act="edit-apply">Apply edits</button>
+                </div></div>`;
+        }
+
+        function rowHtml(row) {
+            const v = validityOf(row);
+            let badge = '';
+            if (row.status === 'accepted') badge = `<span class="xr-llm__badge xr-llm__badge--ok">✓ accepted</span>`;
+            else if (row.status === 'rejected') badge = `<span class="xr-llm__badge xr-llm__badge--rej">✕ rejected</span>`;
+            else if (!v.ok) badge = `<span class="xr-llm__badge xr-llm__badge--bad" title="${escapeHtml(v.reason)}">✗ ${escapeHtml(v.reason)}</span>`;
+            else if (row.suggestedBy === 'user') badge = `<span class="xr-llm__badge xr-llm__badge--edit">✎ edited (you)</span>`;
+
+            const actions = (row.status === 'pending') ? `
+                <div class="xr-llm__row-actions">
+                  <button type="button" class="xr-llm__btn xr-llm__btn--primary" data-act="accept" ${v.ok ? '' : 'disabled'}>Accept</button>
+                  <button type="button" class="xr-llm__btn" data-act="edit">Edit</button>
+                  <button type="button" class="xr-llm__btn xr-llm__btn--ghost" data-act="reject">Reject</button>
+                </div>` : '';
+
+            return `<div class="xr-llm__row xr-llm__row--${row.status}" data-pid="${row.pid}">
+                <div class="xr-llm__row-main">
+                  <div class="xr-llm__summary">${summarize(row)}</div>
+                  ${badge}
+                  ${row.message ? `<div class="xr-llm__msg">${escapeHtml(row.message)}</div>` : ''}
+                  ${row.editing ? editorHtml(row) : ''}
+                </div>
+                ${actions}
+              </div>`;
+        }
+
+        function sectionsHtml() {
+            const parts = [];
+            for (const kind of PROPOSAL_ORDER) {
+                const list = rows.filter((r) => r.kind === kind);
+                if (list.length === 0) continue;
+                const pending = list.filter((r) => r.status === 'pending').length;
+                parts.push(`<section class="xr-llm__section">
+                    <h3 class="xr-llm__section-title">${escapeHtml(KIND_TITLES[kind] || kind)} <span class="xr-llm__dim">(${list.length})</span></h3>
+                    ${list.map(rowHtml).join('')}
+                  </section>`);
+            }
+            return parts.join('') || `<p class="xr-llm__empty">The model returned no proposals for this article.</p>`;
+        }
+
+        function render() {
+            const total = rows.length;
+            const acc = rows.filter((r) => r.status === 'accepted').length;
+            const pendingValid = rows.filter((r) => r.status === 'pending' && validityOf(r).ok).length;
+            host.innerHTML = `
+              <div class="xr-llm__backdrop"></div>
+              <div class="xr-llm__card" role="dialog" aria-label="LLM suggestions">
+                <header class="xr-llm__head">
+                  <h2 class="xr-llm__title">✨ Suggestions <span class="xr-llm__dim">(${total})</span></h2>
+                  <span class="xr-llm__model" title="Model used">${escapeHtml(model)}</span>
+                  <span class="xr-llm__gap"></span>
+                  <button type="button" class="xr-llm__close" aria-label="Close">✕</button>
+                </header>
+                <p class="xr-llm__disclosure">These are <strong>drafts</strong> — nothing is saved until you Accept, and nothing is published. Accepted items appear in the claims / findings bars, tagged <code>suggested_by: ${escapeHtml(suggestedByLlm)}</code>.</p>
+                <div class="xr-llm__body">${sectionsHtml()}</div>
+                <footer class="xr-llm__foot">
+                  <span class="xr-llm__status">${acc} accepted</span>
+                  <span class="xr-llm__gap"></span>
+                  <button type="button" class="xr-llm__btn" data-act="accept-all" ${pendingValid ? '' : 'disabled'}>Accept all valid (${pendingValid})</button>
+                  <button type="button" class="xr-llm__btn xr-llm__btn--primary" data-act="done">Done</button>
+                </footer>
+              </div>`;
+            wire();
+        }
+
+        function wire() {
+            host.querySelector('.xr-llm__close').addEventListener('click', close);
+            host.querySelector('.xr-llm__backdrop').addEventListener('click', close);
+            host.querySelector('[data-act="done"]').addEventListener('click', close);
+            host.querySelector('[data-act="accept-all"]').addEventListener('click', acceptAllValid);
+
+            host.querySelectorAll('.xr-llm__row').forEach((el) => {
+                const row = rowByPid.get(el.dataset.pid);
+                if (!row) return;
+                const on = (act, fn) => { const b = el.querySelector(`[data-act="${act}"]`); if (b) b.addEventListener('click', fn); };
+                on('accept', () => acceptRow(row));
+                on('reject', () => { row.status = 'rejected'; render(); });
+                on('edit', () => { row.editing = true; render(); });
+                on('edit-cancel', () => { row.editing = false; row.message = ''; render(); });
+                on('edit-apply', () => applyEdit(row, el));
+            });
+        }
+
+        function applyEdit(row, el) {
+            const fields = EDIT_FIELDS[row.kind] || [];
+            for (const f of fields) {
+                const input = el.querySelector(`[data-k="${f.key === 'stance' ? 'stance' : f.key}"]`);
+                if (!input) continue;
+                if (f.type === 'checkbox') row.prop[f.key] = input.checked;
+                else if (f.type === 'stance') row.prop.stance = input.value === '' ? null : Number(input.value);
+                else row.prop[f.key] = input.value;
+            }
+            // A substantive human edit ⇒ honest provenance.
+            row.suggestedBy = 'user';
+            row.editing = false;
+            row.message = '';
+            render();
+        }
+
+        // Accept gating: an item can only be created once the items it
+        // references have been accepted (their ids are in the maps).
+        function blockedReason(row) {
+            const p = row.prop;
+            if (row.kind === 'assessment' && !claimIdByRef[p.claim_ref]) return 'Accept its claim first.';
+            if ((row.kind === 'relationship' || row.kind === 'revision')
+                && (!claimIdByRef[p.source_claim_ref] || !claimIdByRef[p.target_claim_ref])) {
+                return 'Accept both linked claims first.';
+            }
+            return '';
+        }
+
+        async function acceptRow(row) {
+            if (row.status !== 'pending') return;
+            const v = validityOf(row);
+            if (!v.ok) { row.message = v.reason; render(); return; }
+            const blocked = blockedReason(row);
+            if (blocked) { row.message = blocked; render(); return; }
+            try {
+                await createFor(row);
+                row.status = 'accepted';
+                row.message = '';
+                acceptedCount += 1;
+                if (typeof onAccepted === 'function') { try { await onAccepted(row.kind); } catch (_) { /* refresh best-effort */ } }
+            } catch (err) {
+                // The model is the ultimate firewall — surface its reason.
+                row.message = (err && err.message) || String(err);
+            }
+            render();
+        }
+
+        async function acceptAllValid() {
+            // Dependency order so refs resolve as we go.
+            for (const kind of PROPOSAL_ORDER) {
+                for (const row of rows.filter((r) => r.kind === kind && r.status === 'pending')) {
+                    if (!validityOf(row).ok) continue;
+                    if (blockedReason(row)) continue;
+                    try {
+                        await createFor(row);
+                        row.status = 'accepted';
+                        row.message = '';
+                        acceptedCount += 1;
+                    } catch (err) {
+                        row.message = (err && err.message) || String(err);
+                    }
+                }
+            }
+            if (typeof onAccepted === 'function') { try { await onAccepted('all'); } catch (_) { /* best-effort */ } }
+            render();
+        }
+
+        // Funnel one accepted proposal through the real model.
+        async function createFor(row) {
+            const p = row.prop;
+            const sb = row.suggestedBy;
+            switch (row.kind) {
+                case 'entity': {
+                    const e = await EntityModel.create(buildEntityInput(p, { suggestedBy: sb }));
+                    if (row.ref) entityIdByRef[row.ref] = e.id;
+                    return;
+                }
+                case 'claim': {
+                    const c = await ClaimModel.create(buildClaimInput(p, { entityIdByRef, articleText, sourceUrl, suggestedBy: sb }));
+                    if (row.ref) claimIdByRef[row.ref] = c.id;
+                    return;
+                }
+                case 'assessment':
+                    await AssessmentModel.create(buildAssessmentInput(p, { claimIdByRef, articleText, suggestedBy: sb }));
+                    return;
+                case 'relationship':
+                case 'revision':
+                    await EvidenceLinker.create(buildLinkInput(p, { claimIdByRef, suggestedBy: sb }));
+                    return;
+                case 'finding':
+                    await ForensicModel.create(buildFindingInput(p, {
+                        articleText, sourceRef, suggestedBy: sb, subjectLabel: subjectLabelOf(p, ctx)
+                    }));
+                    return;
+                case 'baseline':
+                    await ForensicBaseline.create(buildBaselineInput(p, { sourceRef, subjectLabel: subjectLabelOf(p, ctx) }));
+                    return;
+                default:
+                    throw new Error(`Unknown kind: ${row.kind}`);
+            }
+        }
+
+        render();
+    });
+}

--- a/src/shared/claim-model.js
+++ b/src/shared/claim-model.js
@@ -23,6 +23,7 @@
 import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
 import { Utils } from './utils.js';
+import { isValidSuggestedBy } from './assessment-taxonomy.js';
 
 // ------------------------------------------------------------------
 // Enums — retained for rendering legacy + foreign (others') claims that
@@ -125,6 +126,14 @@ function cleanAbout(about) {
     return [...new Set(about.filter((id) => typeof id === 'string' && id))];
 }
 
+// Provenance seam ('user' | 'llm:<model>'). Phase 14.5 LLM-assist stamps
+// 'llm:<model>' on suggested claims; this is a LOCAL record field only —
+// the kind-30040 claim wire format is unchanged.
+function cleanSuggestedBy(value) {
+    const v = value === undefined || value === null ? 'user' : value;
+    return isValidSuggestedBy(v) ? v : 'user';
+}
+
 // Backfill thin fields for records written before slice 10.1, so old
 // claims render in the thin UI. Non-destructive (read-time only).
 function normalizeClaim(record) {
@@ -205,6 +214,7 @@ export const ClaimModel = {
             anchor:           fields.anchor || null,
             source_url:       sourceUrl,
             context:          fields.context || '',
+            suggested_by:     cleanSuggestedBy(fields.suggested_by),
             created:          now,
             updated:          now,
             publishedAt:      null,

--- a/src/shared/entity-model.js
+++ b/src/shared/entity-model.js
@@ -32,6 +32,7 @@ import { Storage } from './storage.js';
 import { Crypto } from './crypto.js';
 import { Utils } from './utils.js';
 import { LocalKeyManager } from './local-key-manager.js';
+import { isValidSuggestedBy } from './assessment-taxonomy.js';
 
 // `case` (Phase 11.1) models a real-world story under assessment —
 // "John Dehlin excommunication", "Bricks & Minifigs scandal" — so the
@@ -99,6 +100,14 @@ function assertValidName(name) {
     if (!trimmed) throw new Error('Entity name is required');
     if (trimmed.length > 200) throw new Error('Entity name too long (max 200 chars)');
     return trimmed;
+}
+
+// Provenance seam ('user' | 'llm:<model>'). Phase 14.5 LLM-assist stamps
+// 'llm:<model>' on suggested entities; this is a LOCAL record field only
+// — the kind-0 profile wire format is unchanged.
+function cleanSuggestedBy(value) {
+    const v = value === undefined || value === null ? 'user' : value;
+    return isValidSuggestedBy(v) ? v : 'user';
 }
 
 export const EntityModel = {
@@ -194,6 +203,7 @@ export const EntityModel = {
             nip05:        fields.nip05 || '',
             canonical_id: fields.canonical_id || null,
             keyName,
+            suggested_by: cleanSuggestedBy(fields.suggested_by),
             created: now,
             updated: now
         };

--- a/src/shared/llm-client.js
+++ b/src/shared/llm-client.js
@@ -1,0 +1,217 @@
+// LLM-assist client — Phase 14.5 (docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md).
+//
+// The ONLY module that talks to the Anthropic Messages API. It runs in
+// the background service worker (page CSP can't open this; the relay
+// pool lives here for the same reason), reached via the
+// `xray:llm:suggest` message. Everything downstream consumes the
+// validated PROPOSALS this returns — it never saves or publishes.
+//
+// Consent gates (both must pass before any network call):
+//   1. the `llmAssist` feature flag is on, AND
+//   2. a user-supplied API key is present under the dedicated secret
+//      key `xray:llm:key` (NEVER `preferences`, NEVER exported, NEVER
+//      logged).
+//
+// The key is read fresh on each pass (MV3 SWs sleep/wake) and is never
+// passed to Utils.log / Utils.error.
+
+import { Utils } from './utils.js';
+import { loadFlags, isEnabled } from './metadata/feature-flags.js';
+import {
+    ANTHROPIC_API_URL, ANTHROPIC_VERSION, resolveModel,
+    LLM_KEY_STORAGE, LLM_MODEL_STORAGE,
+    buildSuggestTool, buildSystemPrompt, buildUserPrompt
+} from './llm-prompts.js';
+
+// Re-exported for callers that wrote against the client (the keys are
+// defined in the pure prompts module so the Options page can share them).
+export { LLM_KEY_STORAGE, LLM_MODEL_STORAGE };
+
+// Bound the article we send, so a pathologically long capture can't
+// balloon the request. ~120k chars ≈ well within context for one pass.
+const MAX_ARTICLE_CHARS = 120000;
+// Output cap for the structured tool call. Generous enough for a rich
+// proposal set; if the model still hits it we surface a clear error
+// rather than feeding truncated JSON to the validators.
+const MAX_OUTPUT_TOKENS = 8192;
+
+// ------------------------------------------------------------------
+// Storage helpers (callback → promise; SW-safe)
+// ------------------------------------------------------------------
+
+function storageGetRaw(keys) {
+    return new Promise((resolve) => {
+        try {
+            const area = (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local)
+                || (typeof browser !== 'undefined' && browser.storage && browser.storage.local);
+            if (!area) return resolve({});
+            area.get(keys, (res) => resolve(res || {}));
+        } catch (_) { resolve({}); }
+    });
+}
+
+/** Read the secret key. Returns '' when unset. Never logged by callers. */
+async function readApiKey() {
+    const res = await storageGetRaw([LLM_KEY_STORAGE]);
+    const raw = res[LLM_KEY_STORAGE];
+    return typeof raw === 'string' ? raw.trim() : '';
+}
+
+async function readModel() {
+    const res = await storageGetRaw([LLM_MODEL_STORAGE]);
+    return resolveModel(res[LLM_MODEL_STORAGE]);
+}
+
+/**
+ * Non-secret config snapshot for gating UIs — reports WHETHER a key is
+ * present, never its value, plus the chosen model and flag state.
+ */
+export async function getLlmConfig() {
+    await loadFlags();
+    const [key, model] = await Promise.all([readApiKey(), readModel()]);
+    return { enabled: isEnabled('llmAssist'), hasKey: key.length > 0, model };
+}
+
+// ------------------------------------------------------------------
+// Error mapping
+// ------------------------------------------------------------------
+
+function mapHttpError(status, bodyText) {
+    if (status === 401 || status === 403) {
+        return 'The Anthropic API key was rejected (401/403). Check the key in Options → Advanced → LLM assist.';
+    }
+    if (status === 429) {
+        return 'Anthropic rate limit hit (429). Wait a moment and try again.';
+    }
+    if (status >= 500) {
+        return `Anthropic service error (${status}). Try again shortly.`;
+    }
+    // Surface a trimmed message for 400-class issues without dumping the
+    // whole body (which echoes the request).
+    let detail = '';
+    try {
+        const parsed = JSON.parse(bodyText);
+        detail = parsed && parsed.error && parsed.error.message ? `: ${parsed.error.message}` : '';
+    } catch (_) { /* ignore */ }
+    return `Anthropic request failed (${status})${detail}.`;
+}
+
+// ------------------------------------------------------------------
+// Public entry point
+// ------------------------------------------------------------------
+
+/**
+ * Run one user-invoked suggestion pass.
+ *
+ * @param {object} req
+ * @param {string} [req.task='all']     one of SUGGEST_TASKS
+ * @param {string} req.articleText      the captured article body text
+ * @param {string} [req.articleUrl]
+ * @param {string} [req.articleTitle]
+ * @param {string} [req.context]        optional extra context
+ * @returns {Promise<{ok:true, model:string, proposals:Array, usage?:object}
+ *                  | {ok:false, error:string, status?:number}>}
+ */
+export async function runSuggestionPass(req = {}) {
+    await loadFlags();
+    if (!isEnabled('llmAssist')) {
+        return { ok: false, error: 'LLM assist is off. Enable it in Options → Advanced → LLM assist.' };
+    }
+
+    const apiKey = await readApiKey();
+    if (!apiKey) {
+        return { ok: false, error: 'No Anthropic API key set. Add one in Options → Advanced → LLM assist.' };
+    }
+
+    const articleText = String(req.articleText || '').slice(0, MAX_ARTICLE_CHARS);
+    if (!articleText.trim()) {
+        return { ok: false, error: 'No article text to analyze.' };
+    }
+
+    const model = await readModel();
+    const task  = req.task || 'all';
+    const system = buildSystemPrompt({ task, url: req.articleUrl || '', title: req.articleTitle || '' });
+    const userContent = buildUserPrompt({ articleText, context: req.context || '' });
+    const tool = buildSuggestTool();
+
+    const payload = {
+        model,
+        max_tokens: MAX_OUTPUT_TOKENS,
+        system,
+        tools: [tool],
+        // Force the structured tool so we always get parseable JSON.
+        tool_choice: { type: 'tool', name: tool.name },
+        messages: [{ role: 'user', content: userContent }]
+    };
+
+    Utils.log('[X-Ray LLM] suggestion pass:', { task, model, chars: articleText.length });
+
+    let resp;
+    try {
+        resp = await fetch(ANTHROPIC_API_URL, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'x-api-key': apiKey,
+                'anthropic-version': ANTHROPIC_VERSION,
+                // Browser-origin calls require this opt-in; CORS is enabled
+                // for it. The fetch runs in the SW, not a page with site CSP.
+                'anthropic-dangerous-direct-browser-access': 'true'
+            },
+            body: JSON.stringify(payload)
+        });
+    } catch (err) {
+        // Network failure — DO NOT include the key or request body.
+        Utils.error('[X-Ray LLM] network error:', err && err.message);
+        return { ok: false, error: 'Could not reach the Anthropic API (network error). Check your connection and host permissions.' };
+    }
+
+    if (!resp.ok) {
+        let bodyText = '';
+        try { bodyText = await resp.text(); } catch (_) { /* ignore */ }
+        const error = mapHttpError(resp.status, bodyText);
+        Utils.error('[X-Ray LLM] HTTP', resp.status, error);
+        return { ok: false, error, status: resp.status };
+    }
+
+    let data;
+    try {
+        data = await resp.json();
+    } catch (_) {
+        return { ok: false, error: 'Anthropic returned an unreadable response.' };
+    }
+
+    if (data && data.stop_reason === 'max_tokens') {
+        return { ok: false, error: 'The model hit its output limit before finishing. Try a shorter article or fewer tasks.' };
+    }
+
+    const proposals = extractProposals(data);
+    if (proposals === null) {
+        return { ok: false, error: 'The model did not return a structured proposal set. Try again.' };
+    }
+
+    Utils.log('[X-Ray LLM] proposals:', proposals.length);
+    return {
+        ok: true,
+        model: (data && data.model) || model,
+        proposals,
+        usage: data && data.usage ? data.usage : undefined
+    };
+}
+
+/**
+ * Pull the `propose_capture` tool_use input out of a Messages response.
+ * Returns the proposals array, or null if no usable tool call was found.
+ * Exported for unit tests (no network involved).
+ */
+export function extractProposals(data) {
+    const blocks = (data && Array.isArray(data.content)) ? data.content : [];
+    for (const block of blocks) {
+        if (block && block.type === 'tool_use' && block.name === 'propose_capture') {
+            const input = block.input || {};
+            if (Array.isArray(input.proposals)) return input.proposals;
+            return [];
+        }
+    }
+    return null;
+}

--- a/src/shared/llm-prompts.js
+++ b/src/shared/llm-prompts.js
@@ -1,0 +1,353 @@
+// LLM-assist prompts + tool schema — Phase 14.5
+// (docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md).
+//
+// PURE module: no network, no chrome, no DOM. It defines (1) the model
+// roster the Options picker offers, (2) the single `propose_capture`
+// tool whose JSON-Schema maps onto the existing model `create()` inputs,
+// and (3) the system prompt — built from the SAME taxonomy modules the
+// validators read, so the embedded vocabulary can never drift from what
+// the firewall accepts.
+//
+// The suggestion engine returns VERBATIM quotes (so the reader can
+// resolve them to anchors) and stamps nothing itself: provenance
+// (`suggested_by: 'llm:<model>'`) is applied at accept-time by the
+// reader, against the model id actually used.
+
+import {
+    ASSESSMENT_LABEL_GROUPS, STANCE_LABELS, STANCE_VALUES,
+    CLAIM_RELATIONSHIPS, REVISION_RELATIONSHIPS
+} from './assessment-taxonomy.js';
+import {
+    FORENSIC_MANEUVER_GROUPS, MANEUVER_GUIDE, ROLES, BASIS_VALUES
+} from './forensic-taxonomy.js';
+import { ENTITY_TYPES } from './entity-model.js';
+
+// ------------------------------------------------------------------
+// Model roster — exact ids only (no date suffixes). Default to the
+// latest capable Claude; the Options picker renders these.
+// ------------------------------------------------------------------
+
+export const LLM_MODELS = Object.freeze([
+    { id: 'claude-opus-4-8',   label: 'Claude Opus 4.8 (most capable)' },
+    { id: 'claude-opus-4-7',   label: 'Claude Opus 4.7' },
+    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6 (balanced)' },
+    { id: 'claude-haiku-4-5',  label: 'Claude Haiku 4.5 (fastest / cheapest)' }
+]);
+
+export const DEFAULT_LLM_MODEL = 'claude-opus-4-8';
+
+// Dedicated chrome.storage.local keys. The API key is a SECRET (its own
+// key, never `preferences`, never exported, never logged); the model is
+// a plain preference. Defined here (pure module) so the Options page and
+// the SW client share them without the page importing the fetch client.
+export const LLM_KEY_STORAGE   = 'xray:llm:key';
+export const LLM_MODEL_STORAGE = 'xray:llm:model';
+
+export function isKnownModel(id) {
+    return LLM_MODELS.some((m) => m.id === id);
+}
+
+/** Map an arbitrary stored value to a real model id (defaulting). */
+export function resolveModel(id) {
+    return isKnownModel(id) ? id : DEFAULT_LLM_MODEL;
+}
+
+// The Anthropic Messages API surface this module targets. The client
+// (src/shared/llm-client.js) is the only thing that reads these.
+export const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+export const ANTHROPIC_VERSION = '2023-06-01';
+
+// The set of artifact kinds a pass can request. 'all' covers them all.
+export const SUGGEST_TASKS = Object.freeze([
+    'all', 'entities', 'claims', 'assessments', 'relationships', 'findings'
+]);
+
+// ------------------------------------------------------------------
+// Tool schema — one discriminated-union tool keyed by `kind`. We do NOT
+// use strict mode: the real firewall is each model's create() at accept
+// time, so the schema stays permissive and human-readable. Every field
+// is optional; `kind` selects which ones matter.
+// ------------------------------------------------------------------
+
+const PROPOSAL_KINDS = Object.freeze([
+    'entity', 'claim', 'assessment', 'relationship', 'finding', 'baseline', 'revision'
+]);
+
+export function buildSuggestTool() {
+    return {
+        name: 'propose_capture',
+        description:
+            'Propose capture artifacts extracted from the article for HUMAN REVIEW. '
+            + 'Every item is a draft a person will confirm, edit, or reject — you never '
+            + 'save or publish anything. Use local string refs (e.g. "E1", "C1") to link '
+            + 'claims to their about-entities and relationships/findings to their claims.',
+        input_schema: {
+            type: 'object',
+            properties: {
+                proposals: {
+                    type: 'array',
+                    description: 'The proposed artifacts, in any order.',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            kind: {
+                                type: 'string',
+                                enum: PROPOSAL_KINDS,
+                                description: 'Which artifact this is.'
+                            },
+                            ref: {
+                                type: 'string',
+                                description: 'A short local id you assign to an entity ("E1") '
+                                    + 'or claim ("C1"), so other proposals can reference it.'
+                            },
+                            // entity
+                            name: { type: 'string', description: 'Entity display name (kind=entity).' },
+                            entity_type: {
+                                type: 'string', enum: ENTITY_TYPES,
+                                description: 'Entity type (kind=entity).'
+                            },
+                            // claim
+                            text: {
+                                type: 'string',
+                                description: 'The atomized assertion, in your own words (kind=claim).'
+                            },
+                            quote: {
+                                type: 'string',
+                                description: 'A VERBATIM span from the article that the claim is drawn '
+                                    + 'from — copied exactly so it can be located on the page (kind=claim).'
+                            },
+                            about: {
+                                type: 'array', items: { type: 'string' },
+                                description: 'Entity refs ("E1") this claim concerns (kind=claim).'
+                            },
+                            is_key: {
+                                type: 'boolean',
+                                description: 'True if this is a central/load-bearing claim (kind=claim).'
+                            },
+                            // assessment
+                            claim_ref: {
+                                type: 'string',
+                                description: 'The claim ref ("C1") this assessment is about (kind=assessment).'
+                            },
+                            stance: {
+                                type: ['integer', 'null'], enum: [...STANCE_VALUES, null],
+                                description: 'Your graded agree↔disagree on the claim, -2..2, or null '
+                                    + 'for a label-only assessment (kind=assessment). A PERSONAL judgment, '
+                                    + 'not a fact verdict.'
+                            },
+                            labels: {
+                                type: 'array',
+                                description: 'Issue labels on the claim (kind=assessment).',
+                                items: {
+                                    type: 'object',
+                                    properties: {
+                                        label: { type: 'string', description: 'A taxonomy label or custom token.' },
+                                        quote: { type: 'string', description: 'Verbatim span the label points at.' }
+                                    },
+                                    required: ['label']
+                                }
+                            },
+                            rationale: { type: 'string', description: 'Free-text reasoning (kind=assessment).' },
+                            // relationship + revision (both ride kind-30055)
+                            source_claim_ref: {
+                                type: 'string',
+                                description: 'Source claim ref (kind=relationship/revision). For revisions, '
+                                    + 'this is the EARLIER statement.'
+                            },
+                            target_claim_ref: {
+                                type: 'string',
+                                description: 'Target claim ref (kind=relationship/revision). For revisions, '
+                                    + 'the LATER statement.'
+                            },
+                            relationship: {
+                                type: 'string',
+                                enum: [...CLAIM_RELATIONSHIPS, ...REVISION_RELATIONSHIPS],
+                                description: 'The typed link (kind=relationship uses contradicts/supports/'
+                                    + 'updates/duplicates; kind=revision uses narrative-patch/recharacterizes/walks-back).'
+                            },
+                            note: {
+                                type: 'string',
+                                description: 'A short note (relationship/revision/finding/baseline).'
+                            },
+                            // finding + baseline
+                            subject_ref: {
+                                type: 'string',
+                                description: 'Entity ref ("E1") of the subject performing the maneuver '
+                                    + '(kind=finding/baseline).'
+                            },
+                            subject_label: {
+                                type: 'string',
+                                description: 'Subject display name, when not one of the proposed entities '
+                                    + '(kind=finding/baseline).'
+                            },
+                            role: {
+                                type: 'string', enum: ROLES,
+                                description: 'The subject’s role in this exchange (kind=finding).'
+                            },
+                            maneuver: {
+                                type: 'string',
+                                description: 'The named maneuver, lowercase, one optional "family/" prefix '
+                                    + '(kind=finding). Prefer a standard maneuver from the guide.'
+                            },
+                            basis: {
+                                type: 'string', enum: BASIS_VALUES,
+                                description: 'HOW you know — "quoted" only when the evidence is a verbatim '
+                                    + 'span; otherwise "paraphrased" / "behavioral-cue" / "structural-inference" '
+                                    + '(kind=finding).'
+                            },
+                            counter_note: {
+                                type: 'string',
+                                description: 'REQUIRED for a finding: the exonerating / alternative reading — '
+                                    + 'what would make this NOT the maneuver. A finding with no counter-read '
+                                    + 'is rejected.'
+                            },
+                            anchors: {
+                                type: 'array',
+                                description: 'The ordered evidence chain (kind=finding) — at least one, each '
+                                    + 'with a VERBATIM quote.',
+                                items: {
+                                    type: 'object',
+                                    properties: {
+                                        quote: { type: 'string', description: 'A verbatim span from the article.' },
+                                        note:  { type: 'string', description: 'Optional note on this step.' }
+                                    },
+                                    required: ['quote']
+                                }
+                            }
+                        },
+                        required: ['kind']
+                    }
+                }
+            },
+            required: ['proposals']
+        }
+    };
+}
+
+// ------------------------------------------------------------------
+// System prompt — assembled from the live taxonomy so the embedded
+// vocabulary always matches the validators.
+// ------------------------------------------------------------------
+
+function labelMenu() {
+    return Object.entries(ASSESSMENT_LABEL_GROUPS)
+        .map(([group, labels]) => `  - ${group}: ${labels.join(', ')}`)
+        .join('\n');
+}
+
+function maneuverGuideText() {
+    const lines = [];
+    for (const [family, maneuvers] of Object.entries(FORENSIC_MANEUVER_GROUPS)) {
+        lines.push(`  ${family}:`);
+        for (const m of maneuvers) {
+            const g = MANEUVER_GUIDE[m] || {};
+            const def = g.definition || '';
+            const ind = (g.indicators || []).join('; ');
+            const counter = (g.counterIndicators || []).join('; ');
+            lines.push(`    - ${m} — ${def}`);
+            if (ind) lines.push(`        indicators: ${ind}`);
+            if (counter) lines.push(`        counter-indicators (what would make it NOT this): ${counter}`);
+        }
+    }
+    return lines.join('\n');
+}
+
+function stanceMenu() {
+    return STANCE_VALUES.map((v) => `${v} = ${STANCE_LABELS[String(v)]}`).join(', ');
+}
+
+const RULES_ALL = `
+GROUND RULES (non-negotiable):
+- You PROPOSE; a human confirms every item. Nothing you return is saved or published automatically.
+- Quote VERBATIM. Every quote must be copied exactly from the article text, character for character, so it can be located on the page. Do not paraphrase inside a quote, do not add ellipses you didn't see, do not fix typos.
+- Be conservative. Prefer a few high-quality, well-anchored proposals over many weak ones. If the article does not support an artifact, omit it.
+- Use the propose_capture tool and nothing else.`;
+
+const RULES_ENTITIES = `
+ENTITIES (people / organizations / places / things / cases named in the text):
+- Give each a short local ref ("E1", "E2", …) so claims and findings can point at it.
+- type must be one of: ${ENTITY_TYPES.join(', ')}.`;
+
+function rulesClaims() {
+    return `
+CLAIMS (atomized assertions the article makes or reports):
+- text is the assertion in clear, standalone form. quote is the VERBATIM span it is drawn from.
+- about lists the entity refs the claim concerns (link to your entity proposals).
+- Give each claim a ref ("C1", "C2", …) so assessments and relationships can point at it.`;
+}
+
+function rulesAssessments() {
+    return `
+ASSESSMENTS (your judgment on a claim — a PERSONAL stance, never a fact verdict):
+- claim_ref points at the claim. stance is your graded agree↔disagree: ${stanceMenu()}, or null for label-only.
+- labels flag issues with the claim. Prefer these standard labels (custom lowercase tokens allowed):
+${labelMenu()}
+  Attach a verbatim quote to each label where you can.
+- Provide at least one of stance or labels. A stance is an opinion to be debated, not a truth ruling.`;
+}
+
+function rulesRelationships() {
+    return `
+RELATIONSHIPS (typed links between two of your proposed claims):
+- relationship is one of: ${CLAIM_RELATIONSHIPS.join(', ')}.
+- source_claim_ref and target_claim_ref both reference claims you proposed above.`;
+}
+
+function rulesFindings() {
+    return `
+FINDINGS (the criminology layer — name a structural MANEUVER a subject performs around the truth):
+- A finding describes a MOVE, never a verdict. There is NO field for intent, honesty, lying, or a score, by design — do not assert any.
+- subject_ref (or subject_label) identifies who. role is one of: ${ROLES.join(', ')}.
+- maneuver names the move. Prefer a standard maneuver from the guide below; a lowercase custom token is allowed.
+- anchors is the evidence chain: at least ONE anchor, each with a VERBATIM quote. A finding with no quoted evidence is rejected.
+- counter_note is REQUIRED: the strongest alternative / exonerating reading — what would make this NOT the maneuver. A finding with no counter-read is rejected.
+- basis records how you know: use "quoted" ONLY when the evidence is a verbatim span; otherwise "paraphrased", "behavioral-cue", or "structural-inference".
+- Run this symmetrically — apply the same scrutiny to every party, not just one side.
+
+MANEUVER GUIDE (definition / indicators / counter-indicators):
+${maneuverGuideText()}`;
+}
+
+function rulesRevisionsBaselines() {
+    return `
+REVISIONS (a subject's self-serving story-change between two of your claims — secondary):
+- relationship is one of: ${REVISION_RELATIONSHIPS.join(', ')}. source is the EARLIER statement, target the LATER.
+
+BASELINES (a subject's established register — secondary, descriptive prose, no score):
+- subject_ref/subject_label + a descriptive note. Never a rating.`;
+}
+
+/**
+ * Build the system prompt for a pass. `task` ('all' by default) selects
+ * which artifact rules to embed; the heavy maneuver guide is only
+ * included when findings are in scope, to bound tokens.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.task='all']
+ * @param {string} [opts.url]
+ * @param {string} [opts.title]
+ */
+export function buildSystemPrompt({ task = 'all', url = '', title = '' } = {}) {
+    const t = SUGGEST_TASKS.includes(task) ? task : 'all';
+    const wants = (kind) => t === 'all' || t === kind;
+
+    const head = `You are X-Ray's capture assistant. You read an article a person has captured and propose structured "capture artifacts" — entities, claims, assessments, relationships, and forensic findings — for that person to review and confirm. X-Ray is an evidence tool: it records WHAT was said and the STRUCTURE of how it was argued, and it renders no automated verdicts on truth or intent.`;
+
+    const meta = (title || url)
+        ? `\nArticle: ${title ? `"${title}"` : ''}${url ? ` <${url}>` : ''}`
+        : '';
+
+    const parts = [head + meta, RULES_ALL];
+    if (wants('entities'))      parts.push(RULES_ENTITIES);
+    if (wants('claims'))        parts.push(rulesClaims());
+    if (wants('assessments'))   parts.push(rulesAssessments());
+    if (wants('relationships')) parts.push(rulesRelationships());
+    if (wants('findings'))    { parts.push(rulesFindings()); parts.push(rulesRevisionsBaselines()); }
+    return parts.join('\n');
+}
+
+/** The user-turn content: the article text the model extracts from. */
+export function buildUserPrompt({ articleText = '', context = '' } = {}) {
+    const ctx = context ? `\n\nAdditional context:\n${context}` : '';
+    return `Here is the captured article text. Propose capture artifacts via propose_capture.\n\n---\n${articleText}\n---${ctx}`;
+}

--- a/src/shared/llm-proposals.js
+++ b/src/shared/llm-proposals.js
@@ -1,0 +1,293 @@
+// LLM-assist proposal layer — Phase 14.5
+// (docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md).
+//
+// PURE module (no network, no chrome, no DOM). It sits between the raw
+// tool output of llm-client and the existing capture models:
+//
+//   1. normalizeProposals() — group the model's flat proposal list into
+//      dependency-ordered buckets, each item stamped with a stable pid.
+//   2. validateProposal()   — the pre-display firewall. It MIRRORS the
+//      model validators using the SAME exported predicates
+//      (isValidManeuver / isValidRole / isValidBasis / isValidLabel /
+//      isValidStance / ENTITY_TYPES / CLAIM_RELATIONSHIPS / …) so a bad
+//      proposal renders "rejected-with-reason" instead of being silently
+//      dropped. The ULTIMATE firewall is still each model's create(),
+//      which the reader calls at accept time.
+//   3. resolveQuoteToSelectors() — turn a verbatim quote into a W3C
+//      TextQuoteSelector array against the article body, so accepted
+//      claims/findings carry real anchors.
+//   4. build*Input() — map a proposal onto the exact create() input for
+//      its model, given the accept-time ref→id maps.
+//
+// Findings keep the no-verdict discipline by construction: there is no
+// intent/score field in the schema or the mapping, a counter_note is
+// required, and at least one anchor must carry a non-empty quote.
+
+import { buildSelectors } from './metadata/anchor-capture.js';
+import { ENTITY_TYPES } from './entity-model.js';
+import {
+    isValidLabel, isValidStance, isValidSuggestedBy,
+    CLAIM_RELATIONSHIPS, REVISION_RELATIONSHIPS
+} from './assessment-taxonomy.js';
+import {
+    isValidManeuver, isValidRole, isValidBasis, BASIS_VALUES
+} from './forensic-taxonomy.js';
+
+// Dependency order: a kind is only ever accepted after the kinds it can
+// reference. Entities → claims → (assessments / relationships / revisions)
+// → findings → baselines.
+export const PROPOSAL_ORDER = Object.freeze([
+    'entity', 'claim', 'assessment', 'relationship', 'revision', 'finding', 'baseline'
+]);
+
+const PREFIX_SUFFIX = 40; // buildSelectors trims to 32; give it headroom.
+
+// ------------------------------------------------------------------
+// Quote → anchor
+// ------------------------------------------------------------------
+
+/**
+ * Resolve a verbatim quote to a W3C selector array against the article
+ * body text. Exact match yields a prefix+exact+suffix TextQuoteSelector;
+ * a miss yields a quote-only selector (still resolvable when the exact
+ * text is unique on the page). Pure.
+ *
+ * @param {string} quote
+ * @param {string} articleText
+ * @returns {{selectors: Array<object>, found: boolean}}
+ */
+export function resolveQuoteToSelectors(quote, articleText) {
+    const exact = String(quote || '').trim();
+    if (!exact) return { selectors: [], found: false };
+    const text = String(articleText || '');
+    const idx = text.indexOf(exact);
+    if (idx < 0) {
+        return { selectors: buildSelectors({ exact }).selectors, found: false };
+    }
+    const prefix = text.slice(Math.max(0, idx - PREFIX_SUFFIX), idx);
+    const suffix = text.slice(idx + exact.length, idx + exact.length + PREFIX_SUFFIX);
+    return { selectors: buildSelectors({ exact, prefix, suffix }).selectors, found: true };
+}
+
+// ------------------------------------------------------------------
+// Normalization
+// ------------------------------------------------------------------
+
+/**
+ * Group the raw proposal list into dependency-ordered buckets. Each
+ * item keeps its raw fields plus a stable `pid` (p0, p1, …) and `ref`
+ * (the model's local key, if any). Unknown kinds are dropped.
+ *
+ * @param {Array<object>} raw
+ * @returns {{ byKind: Record<string, Array<object>>, all: Array<object>,
+ *             entityRefs: Set<string>, claimRefs: Set<string>,
+ *             entityLabelByRef: Record<string,string> }}
+ */
+export function normalizeProposals(raw) {
+    const list = Array.isArray(raw) ? raw : [];
+    const byKind = {};
+    for (const k of PROPOSAL_ORDER) byKind[k] = [];
+    const all = [];
+    const entityRefs = new Set();
+    const claimRefs = new Set();
+    const entityLabelByRef = {};
+
+    list.forEach((p, i) => {
+        if (!p || typeof p !== 'object') return;
+        const kind = String(p.kind || '').trim();
+        if (!PROPOSAL_ORDER.includes(kind)) return;
+        const item = { ...p, kind, pid: `p${i}`, ref: p.ref ? String(p.ref) : '' };
+        byKind[kind].push(item);
+        all.push(item);
+        if (kind === 'entity' && item.ref) {
+            entityRefs.add(item.ref);
+            entityLabelByRef[item.ref] = String(p.name || '').trim();
+        }
+        if (kind === 'claim' && item.ref) claimRefs.add(item.ref);
+    });
+
+    return { byKind, all, entityRefs, claimRefs, entityLabelByRef };
+}
+
+// ------------------------------------------------------------------
+// Validation firewall (mirrors the model validators)
+// ------------------------------------------------------------------
+
+function fail(reason) { return { ok: false, reason }; }
+const OK = { ok: true };
+
+/** Subject label a finding/baseline answers to (proposal-time). */
+export function subjectLabelOf(prop, ctx = {}) {
+    const byRef = ctx.entityLabelByRef || {};
+    return String(
+        prop.subject_label || (prop.subject_ref && byRef[prop.subject_ref]) || prop.subject_ref || ''
+    ).trim();
+}
+
+/**
+ * Validate a normalized proposal. `ctx` carries the sets of known
+ * entity/claim refs (for dependency checks) and entityLabelByRef.
+ *
+ * @returns {{ok: true} | {ok: false, reason: string}}
+ */
+export function validateProposal(prop, ctx = {}) {
+    if (!prop || typeof prop !== 'object') return fail('Empty proposal');
+    const claimRefs = ctx.claimRefs || new Set();
+    switch (prop.kind) {
+        case 'entity': {
+            if (!String(prop.name || '').trim()) return fail('Entity needs a name');
+            if (!ENTITY_TYPES.includes(prop.entity_type)) {
+                return fail(`Entity type must be one of: ${ENTITY_TYPES.join(', ')}`);
+            }
+            return OK;
+        }
+        case 'claim': {
+            if (!String(prop.text || '').trim()) return fail('Claim needs text');
+            if (String(prop.text).trim().length > 2000) return fail('Claim text too long (max 2000)');
+            return OK;
+        }
+        case 'assessment': {
+            if (!claimRefs.has(prop.claim_ref)) return fail('Assessment references an unknown claim');
+            const stance = prop.stance === undefined ? null : prop.stance;
+            if (stance !== null && !isValidStance(stance)) return fail('Stance must be an integer -2..2 or null');
+            const labels = Array.isArray(prop.labels) ? prop.labels : [];
+            for (const l of labels) {
+                if (!isValidLabel(l && l.label)) return fail(`Invalid label: ${l && l.label}`);
+            }
+            if (stance === null && labels.length === 0) return fail('Assessment needs a stance or at least one label');
+            return OK;
+        }
+        case 'relationship': {
+            if (!CLAIM_RELATIONSHIPS.includes(prop.relationship)) {
+                return fail(`Relationship must be one of: ${CLAIM_RELATIONSHIPS.join(', ')}`);
+            }
+            return validateLink(prop, claimRefs);
+        }
+        case 'revision': {
+            if (!REVISION_RELATIONSHIPS.includes(prop.relationship)) {
+                return fail(`Revision must be one of: ${REVISION_RELATIONSHIPS.join(', ')}`);
+            }
+            return validateLink(prop, claimRefs);
+        }
+        case 'finding': {
+            if (!subjectLabelOf(prop, ctx)) return fail('Finding needs a subject');
+            if (!isValidRole(prop.role)) return fail(`Role must be one of: apologist, critic, institution, witness, survivor, other`);
+            if (!isValidManeuver(prop.maneuver)) return fail(`Invalid maneuver: ${prop.maneuver}`);
+            const basis = prop.basis || 'structural-inference';
+            if (!isValidBasis(basis)) return fail(`Basis must be one of: ${BASIS_VALUES.join(', ')}`);
+            const anchors = Array.isArray(prop.anchors) ? prop.anchors : [];
+            const quoted = anchors.filter((a) => a && String(a.quote || '').trim());
+            if (quoted.length === 0) return fail('Finding needs at least one evidence anchor with a verbatim quote');
+            // Rule 6 — the falsifiability discipline.
+            if (!String(prop.counter_note || '').trim()) {
+                return fail('Finding needs a counter-note (the alternative reading)');
+            }
+            return OK;
+        }
+        case 'baseline': {
+            if (!subjectLabelOf(prop, ctx)) return fail('Baseline needs a subject');
+            if (!String(prop.note || '').trim()) return fail('Baseline needs a descriptive note');
+            return OK;
+        }
+        default:
+            return fail(`Unknown kind: ${prop.kind}`);
+    }
+}
+
+function validateLink(prop, claimRefs) {
+    if (!claimRefs.has(prop.source_claim_ref)) return fail('Source claim is unknown');
+    if (!claimRefs.has(prop.target_claim_ref)) return fail('Target claim is unknown');
+    if (prop.source_claim_ref === prop.target_claim_ref) return fail('A link needs two different claims');
+    return OK;
+}
+
+// ------------------------------------------------------------------
+// Mapping → model create() inputs
+//
+// Each builder is pure: it takes the proposal plus the accept-time
+// resolver maps and returns the exact object the model's create()
+// expects. The reader calls the real model with the result.
+// ------------------------------------------------------------------
+
+function selectorsOrNull(quote, articleText) {
+    const sels = resolveQuoteToSelectors(quote, articleText).selectors;
+    return sels.length ? sels : null;
+}
+
+export function buildEntityInput(prop, { suggestedBy = 'user' } = {}) {
+    return { name: String(prop.name || '').trim(), type: prop.entity_type, suggested_by: suggestedBy };
+}
+
+export function buildClaimInput(prop, { entityIdByRef = {}, articleText = '', sourceUrl = '', suggestedBy = 'user' } = {}) {
+    const about = (Array.isArray(prop.about) ? prop.about : [])
+        .map((ref) => entityIdByRef[ref])
+        .filter(Boolean);
+    return {
+        text:         String(prop.text || '').trim(),
+        source_url:   sourceUrl,
+        anchor:       selectorsOrNull(prop.quote, articleText),
+        about,
+        is_key:       prop.is_key === true,
+        suggested_by: suggestedBy
+    };
+}
+
+export function buildAssessmentInput(prop, { claimIdByRef = {}, articleText = '', suggestedBy = 'user' } = {}) {
+    const labels = (Array.isArray(prop.labels) ? prop.labels : []).map((l) => ({
+        label:        l.label,
+        anchor:       l && l.quote ? selectorsOrNull(l.quote, articleText) : null,
+        suggested_by: suggestedBy
+    }));
+    return {
+        claim_ref:    { claim_id: claimIdByRef[prop.claim_ref] },
+        stance:       prop.stance === undefined ? null : prop.stance,
+        labels,
+        rationale:    String(prop.rationale || ''),
+        suggested_by: suggestedBy
+    };
+}
+
+export function buildLinkInput(prop, { claimIdByRef = {}, suggestedBy = 'user' } = {}) {
+    return {
+        source_claim_id: claimIdByRef[prop.source_claim_ref],
+        target_claim_id: claimIdByRef[prop.target_claim_ref],
+        relationship:    prop.relationship,
+        note:            String(prop.note || ''),
+        suggested_by:    suggestedBy
+    };
+}
+
+export function buildFindingInput(prop, { articleText = '', sourceRef = {}, suggestedBy = 'user', subjectLabel = '' } = {}) {
+    const label = subjectLabel || '';
+    const anchors = (Array.isArray(prop.anchors) ? prop.anchors : [])
+        .filter((a) => a && String(a.quote || '').trim())
+        .map((a) => ({
+            quote:      String(a.quote).trim(),
+            selector:   selectorsOrNull(a.quote, articleText),
+            source_ref: (sourceRef && sourceRef.url) ? { url: sourceRef.url, title: sourceRef.title || null } : null,
+            step_note:  String(a.note || '')
+        }));
+    return {
+        subject_ref:  { label },
+        role:         prop.role,
+        maneuver:     prop.maneuver,
+        anchors,
+        note:         String(prop.note || ''),
+        counter_note: String(prop.counter_note || ''),
+        basis:        prop.basis || 'structural-inference',
+        suggested_by: suggestedBy
+    };
+}
+
+export function buildBaselineInput(prop, { sourceRef = {}, subjectLabel = '' } = {}) {
+    return {
+        subject_ref: { label: subjectLabel || '' },
+        note:        String(prop.note || ''),
+        source_url:  (sourceRef && sourceRef.url) || ''
+    };
+}
+
+/** Defensive helper used by the reader before stamping provenance. */
+export function assertSuggestedBy(value) {
+    return isValidSuggestedBy(value) ? value : 'user';
+}

--- a/src/shared/metadata/feature-flags.js
+++ b/src/shared/metadata/feature-flags.js
@@ -51,7 +51,17 @@ export const FLAGS_DEFAULTS = Object.freeze({
   // kind 30062 behavioral findings, their kind-1985 maneuver mirror, and
   // the `revision/*` story-change edges on kind 30055. Local capture /
   // baselines / rollups are never gated — they're the product.
-  forensicPublishing: false
+  forensicPublishing: false,
+
+  // Phase 14.5 (docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md): gates the
+  // in-extension LLM-assist suggestion pass — the reader "Suggest…"
+  // control + the `xray:llm:suggest` background call to the Anthropic
+  // Messages API. Off by default, AND requires a user-supplied API key
+  // (a second consent gate, since the article text leaves the device).
+  // The feature only ever PROPOSES artifacts for human review; nothing
+  // auto-saves and nothing auto-publishes — publishing stays behind the
+  // existing assessmentPublishing / forensicPublishing flags.
+  llmAssist: false
 });
 
 /**

--- a/tests/llm-proposals.test.mjs
+++ b/tests/llm-proposals.test.mjs
@@ -1,0 +1,380 @@
+// LLM-assist proposal-layer tests — Phase 14.5
+// (docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md).
+//
+// Pure validators + quote→anchor resolution + the create()-input
+// mapping, plus an end-to-end "mock client" pass: a canned proposal set
+// (no network) is funnelled through the real capture models, proving
+// every accepted artifact lands tagged `suggested_by: 'llm:<model>'`,
+// and that the no-verdict / counter-note discipline holds for findings.
+//
+// Same chrome.storage.local shim pattern as forensic-model.test.mjs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const _stateStore = new Map();
+globalThis.chrome = {
+    storage: {
+        local: {
+            get(keys, cb) {
+                const out = {};
+                for (const k of Array.isArray(keys) ? keys : [keys]) {
+                    if (_stateStore.has(k)) out[k] = _stateStore.get(k);
+                }
+                cb(out);
+            },
+            set(obj, cb) {
+                for (const [k, v] of Object.entries(obj)) _stateStore.set(k, v);
+                cb && cb();
+            },
+            remove(keys, cb) {
+                for (const k of Array.isArray(keys) ? keys : [keys]) _stateStore.delete(k);
+                cb && cb();
+            }
+        }
+    }
+};
+
+const P = await import('../src/shared/llm-proposals.js');
+const { buildSuggestTool, buildSystemPrompt, resolveModel, DEFAULT_LLM_MODEL } =
+    await import('../src/shared/llm-prompts.js');
+const { extractProposals } = await import('../src/shared/llm-client.js');
+const { EntityModel } = await import('../src/shared/entity-model.js');
+const { ClaimModel } = await import('../src/shared/claim-model.js');
+const { AssessmentModel } = await import('../src/shared/assessment-model.js');
+const { EvidenceLinker } = await import('../src/shared/evidence-linker.js');
+const { ForensicModel, ForensicBaseline } = await import('../src/shared/forensic-model.js');
+
+function reset() { _stateStore.clear(); }
+
+const MODEL = 'claude-opus-4-8';
+const SUGGESTED_BY = `llm:${MODEL}`;
+const URL = 'https://example.com/article';
+
+// An article body that contains every quote verbatim, so anchoring
+// resolves. The mock "LLM response" quotes from exactly this text.
+const ARTICLE_TEXT = [
+    'Jacob Hansen spoke at length about the controversy.',
+    '"I care about the truth, not what the church says," he insisted.',
+    'Later he added, "It does not matter whether it happened — it bears good fruit."',
+    'The Church declined to comment.'
+].join('\n');
+
+// The canned tool output — this stands in for a live API call.
+function mockProposals() {
+    return [
+        { kind: 'entity', ref: 'E1', name: 'Jacob Hansen', entity_type: 'person' },
+        { kind: 'entity', ref: 'E2', name: 'The Church', entity_type: 'organization' },
+        {
+            kind: 'claim', ref: 'C1',
+            text: 'Hansen cares about truth over institutional approval.',
+            quote: '"I care about the truth, not what the church says," he insisted.',
+            about: ['E1', 'E2'], is_key: true
+        },
+        {
+            kind: 'claim', ref: 'C2',
+            text: 'Whether the event happened does not matter, only its fruits.',
+            quote: 'It does not matter whether it happened — it bears good fruit.',
+            about: ['E1']
+        },
+        {
+            kind: 'assessment', claim_ref: 'C2', stance: -1,
+            labels: [{ label: 'misleading', quote: 'it bears good fruit' }],
+            rationale: 'Swaps a truth question for a utility one.'
+        },
+        {
+            kind: 'relationship', source_claim_ref: 'C1', target_claim_ref: 'C2',
+            relationship: 'contradicts', note: 'Truth-first vs utility-first.'
+        },
+        {
+            kind: 'revision', source_claim_ref: 'C1', target_claim_ref: 'C2',
+            relationship: 'walks-back', note: 'Retreats from the truth framing.'
+        },
+        {
+            kind: 'finding', subject_ref: 'E1', role: 'apologist',
+            maneuver: 'defense/usefulness-pivot', basis: 'quoted',
+            note: 'Shifts is-it-true to is-it-useful.',
+            counter_note: 'He may be conceding utility alongside, not instead of, the truth claim.',
+            anchors: [{ quote: 'It does not matter whether it happened — it bears good fruit.' }]
+        },
+        {
+            kind: 'baseline', subject_ref: 'E1',
+            note: 'Speaks in measured, rhetorical register throughout.'
+        }
+    ];
+}
+
+// ---------------------------------------------------------------------
+// normalizeProposals
+// ---------------------------------------------------------------------
+
+test('normalizeProposals: groups by kind, tracks refs + labels', () => {
+    const n = P.normalizeProposals(mockProposals());
+    assert.equal(n.byKind.entity.length, 2);
+    assert.equal(n.byKind.claim.length, 2);
+    assert.equal(n.byKind.finding.length, 1);
+    assert.ok(n.entityRefs.has('E1') && n.entityRefs.has('E2'));
+    assert.ok(n.claimRefs.has('C1') && n.claimRefs.has('C2'));
+    assert.equal(n.entityLabelByRef.E1, 'Jacob Hansen');
+    // Stable pids assigned in order.
+    assert.equal(n.byKind.entity[0].pid, 'p0');
+});
+
+test('normalizeProposals: drops unknown kinds', () => {
+    const n = P.normalizeProposals([{ kind: 'wormhole', ref: 'X' }, { kind: 'entity', name: 'A', entity_type: 'person' }]);
+    assert.equal(n.all.length, 1);
+    assert.equal(n.byKind.entity.length, 1);
+});
+
+// ---------------------------------------------------------------------
+// validateProposal — accepts
+// ---------------------------------------------------------------------
+
+test('validateProposal: every kind in the canned set is valid', () => {
+    const n = P.normalizeProposals(mockProposals());
+    const ctx = { claimRefs: n.claimRefs, entityRefs: n.entityRefs, entityLabelByRef: n.entityLabelByRef };
+    for (const item of n.all) {
+        const v = P.validateProposal(item, ctx);
+        assert.ok(v.ok, `${item.kind} ${item.pid} should be valid: ${v.reason || ''}`);
+    }
+});
+
+// ---------------------------------------------------------------------
+// validateProposal — rejects (the firewall)
+// ---------------------------------------------------------------------
+
+test('validateProposal: rejects a bad entity type', () => {
+    const v = P.validateProposal({ kind: 'entity', name: 'X', entity_type: 'alien' });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /type/i);
+});
+
+test('validateProposal: rejects an empty claim', () => {
+    const v = P.validateProposal({ kind: 'claim', text: '   ' });
+    assert.equal(v.ok, false);
+});
+
+test('validateProposal: rejects an assessment with no stance and no labels', () => {
+    const ctx = { claimRefs: new Set(['C1']) };
+    const v = P.validateProposal({ kind: 'assessment', claim_ref: 'C1', stance: null, labels: [] }, ctx);
+    assert.equal(v.ok, false);
+});
+
+test('validateProposal: rejects an assessment pointing at an unknown claim', () => {
+    const v = P.validateProposal({ kind: 'assessment', claim_ref: 'CZ', stance: 1 }, { claimRefs: new Set(['C1']) });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /unknown claim/i);
+});
+
+test('validateProposal: rejects a relationship with a bad type or missing endpoint', () => {
+    const ctx = { claimRefs: new Set(['C1', 'C2']) };
+    assert.equal(P.validateProposal({ kind: 'relationship', relationship: 'rhymes-with', source_claim_ref: 'C1', target_claim_ref: 'C2' }, ctx).ok, false);
+    assert.equal(P.validateProposal({ kind: 'relationship', relationship: 'contradicts', source_claim_ref: 'C1', target_claim_ref: 'CZ' }, ctx).ok, false);
+    assert.equal(P.validateProposal({ kind: 'relationship', relationship: 'contradicts', source_claim_ref: 'C1', target_claim_ref: 'C1' }, ctx).ok, false);
+});
+
+test('validateProposal: a finding WITHOUT a counter-note is rejected', () => {
+    const v = P.validateProposal({
+        kind: 'finding', subject_label: 'X', role: 'critic',
+        maneuver: 'darvo/deny', basis: 'quoted',
+        anchors: [{ quote: 'something said' }], counter_note: ''
+    });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /counter/i);
+});
+
+test('validateProposal: a finding WITHOUT a quoted anchor is rejected', () => {
+    const v = P.validateProposal({
+        kind: 'finding', subject_label: 'X', role: 'critic',
+        maneuver: 'darvo/deny', basis: 'structural-inference',
+        anchors: [{ quote: '' }], counter_note: 'maybe innocent'
+    });
+    assert.equal(v.ok, false);
+    assert.match(v.reason, /anchor|quote/i);
+});
+
+test('validateProposal: a finding with a bad maneuver / role is rejected', () => {
+    assert.equal(P.validateProposal({ kind: 'finding', subject_label: 'X', role: 'apologist', maneuver: 'Bad Maneuver!', basis: 'quoted', anchors: [{ quote: 'q' }], counter_note: 'c' }).ok, false);
+    assert.equal(P.validateProposal({ kind: 'finding', subject_label: 'X', role: 'wizard', maneuver: 'darvo/deny', basis: 'quoted', anchors: [{ quote: 'q' }], counter_note: 'c' }).ok, false);
+});
+
+// ---------------------------------------------------------------------
+// quote → anchor
+// ---------------------------------------------------------------------
+
+test('resolveQuoteToSelectors: verbatim match yields a prefix/suffix TextQuoteSelector', () => {
+    const r = P.resolveQuoteToSelectors('I care about the truth', ARTICLE_TEXT);
+    assert.equal(r.found, true);
+    const tqs = r.selectors.find((s) => s.type === 'TextQuoteSelector');
+    assert.ok(tqs && tqs.exact === 'I care about the truth');
+    assert.ok(tqs.prefix && tqs.suffix); // surrounding context captured
+});
+
+test('resolveQuoteToSelectors: a miss still yields a quote-only selector', () => {
+    const r = P.resolveQuoteToSelectors('this phrase is absent', ARTICLE_TEXT);
+    assert.equal(r.found, false);
+    const tqs = r.selectors.find((s) => s.type === 'TextQuoteSelector');
+    assert.ok(tqs && tqs.exact === 'this phrase is absent');
+    assert.ok(!tqs.prefix && !tqs.suffix);
+});
+
+test('resolveQuoteToSelectors: empty quote yields no selectors', () => {
+    assert.deepEqual(P.resolveQuoteToSelectors('', ARTICLE_TEXT), { selectors: [], found: false });
+});
+
+// ---------------------------------------------------------------------
+// No verdict / no intent — by construction
+// ---------------------------------------------------------------------
+
+test('tool schema + finding mapping carry no intent/score/confidence field', () => {
+    const tool = buildSuggestTool();
+    const props = Object.keys(tool.input_schema.properties.proposals.items.properties);
+    for (const banned of ['intent', 'score', 'confidence', 'lying', 'verdict']) {
+        assert.ok(!props.includes(banned), `schema must not expose "${banned}"`);
+    }
+    const input = P.buildFindingInput(
+        { role: 'apologist', maneuver: 'darvo/deny', counter_note: 'c', anchors: [{ quote: 'q' }] },
+        { articleText: ARTICLE_TEXT, sourceRef: { url: URL }, suggestedBy: SUGGESTED_BY, subjectLabel: 'X' }
+    );
+    for (const banned of ['intent', 'score', 'confidence', 'lying', 'verdict', 'stance']) {
+        assert.ok(!(banned in input), `finding input must not carry "${banned}"`);
+    }
+});
+
+// ---------------------------------------------------------------------
+// extractProposals (llm-client, pure)
+// ---------------------------------------------------------------------
+
+test('extractProposals: pulls the propose_capture tool input', () => {
+    const data = {
+        content: [
+            { type: 'text', text: 'here you go' },
+            { type: 'tool_use', name: 'propose_capture', input: { proposals: [{ kind: 'entity', name: 'A', entity_type: 'person' }] } }
+        ]
+    };
+    const out = extractProposals(data);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].name, 'A');
+});
+
+test('extractProposals: null when no tool call present', () => {
+    assert.equal(extractProposals({ content: [{ type: 'text', text: 'no tool' }] }), null);
+});
+
+// ---------------------------------------------------------------------
+// prompt invariants
+// ---------------------------------------------------------------------
+
+test('system prompt embeds the maneuver guide, label taxonomy, and no-verdict discipline', () => {
+    const sys = buildSystemPrompt({ task: 'all', url: URL, title: 'Test' });
+    assert.match(sys, /defense\/usefulness-pivot/);          // a maneuver from the guide
+    assert.match(sys, /counter-indicators/);                  // falsifiability discipline
+    assert.match(sys, /misleading/);                          // an assessment label
+    assert.match(sys, /never a fact verdict|never a verdict|PERSONAL/i);
+    assert.match(sys, /VERBATIM/);                            // anchoring instruction
+});
+
+test('resolveModel defaults unknown ids to the latest capable model', () => {
+    assert.equal(resolveModel('totally-made-up'), DEFAULT_LLM_MODEL);
+    assert.equal(resolveModel('claude-sonnet-4-6'), 'claude-sonnet-4-6');
+});
+
+// ---------------------------------------------------------------------
+// End-to-end "mock client" pass through the REAL models
+// ---------------------------------------------------------------------
+
+// Mirror the reader's dependency-ordered accept, calling the real models.
+async function acceptAll(proposals) {
+    const n = P.normalizeProposals(proposals);
+    const entityIdByRef = {};
+    const claimIdByRef = {};
+    const created = { entity: [], claim: [], assessment: [], relationship: [], revision: [], finding: [], baseline: [] };
+
+    for (const p of n.byKind.entity) {
+        const e = await EntityModel.create(P.buildEntityInput(p, { suggestedBy: SUGGESTED_BY }));
+        if (p.ref) entityIdByRef[p.ref] = e.id;
+        created.entity.push(e);
+    }
+    for (const p of n.byKind.claim) {
+        const c = await ClaimModel.create(P.buildClaimInput(p, { entityIdByRef, articleText: ARTICLE_TEXT, sourceUrl: URL, suggestedBy: SUGGESTED_BY }));
+        if (p.ref) claimIdByRef[p.ref] = c.id;
+        created.claim.push(c);
+    }
+    for (const p of n.byKind.assessment) {
+        created.assessment.push(await AssessmentModel.create(P.buildAssessmentInput(p, { claimIdByRef, articleText: ARTICLE_TEXT, suggestedBy: SUGGESTED_BY })));
+    }
+    for (const p of n.byKind.relationship) {
+        created.relationship.push(await EvidenceLinker.create(P.buildLinkInput(p, { claimIdByRef, suggestedBy: SUGGESTED_BY })));
+    }
+    for (const p of n.byKind.revision) {
+        created.revision.push(await EvidenceLinker.create(P.buildLinkInput(p, { claimIdByRef, suggestedBy: SUGGESTED_BY })));
+    }
+    for (const p of n.byKind.finding) {
+        const label = P.subjectLabelOf(p, { entityLabelByRef: n.entityLabelByRef });
+        created.finding.push(await ForensicModel.create(P.buildFindingInput(p, { articleText: ARTICLE_TEXT, sourceRef: { url: URL, title: 'Test' }, suggestedBy: SUGGESTED_BY, subjectLabel: label })));
+    }
+    for (const p of n.byKind.baseline) {
+        const label = P.subjectLabelOf(p, { entityLabelByRef: n.entityLabelByRef });
+        created.baseline.push(await ForensicBaseline.create(P.buildBaselineInput(p, { sourceRef: { url: URL }, subjectLabel: label })));
+    }
+    return { created, entityIdByRef, claimIdByRef };
+}
+
+test('end-to-end: a canned pass creates every artifact tagged llm:<model>', async () => {
+    reset();
+    const { created, entityIdByRef, claimIdByRef } = await acceptAll(mockProposals());
+
+    assert.equal(created.entity.length, 2);
+    assert.equal(created.claim.length, 2);
+    assert.equal(created.entity[0].suggested_by, SUGGESTED_BY);
+
+    // Claims carry resolved about-entities + a real anchor.
+    const c1 = created.claim[0];
+    assert.equal(c1.suggested_by, SUGGESTED_BY);
+    assert.deepEqual(c1.about.sort(), [entityIdByRef.E1, entityIdByRef.E2].sort());
+    assert.ok(Array.isArray(c1.anchor) && c1.anchor.some((s) => s.type === 'TextQuoteSelector'));
+    assert.equal(c1.is_key, true);
+
+    // Assessment, relationship, revision all tagged + linked.
+    assert.equal(created.assessment[0].suggested_by, SUGGESTED_BY);
+    assert.equal(created.assessment[0].stance, -1);
+    assert.equal(created.assessment[0].labels[0].label, 'misleading');
+    assert.equal(created.relationship[0].relationship, 'contradicts');
+    assert.equal(created.relationship[0].suggested_by, SUGGESTED_BY);
+    assert.equal(created.revision[0].relationship, 'walks-back');
+
+    // Finding: tagged, counter-note present, ≥1 quoted anchor, NO verdict fields.
+    const f = created.finding[0];
+    assert.equal(f.suggested_by, SUGGESTED_BY);
+    assert.ok(f.counter_note.length > 0);
+    assert.ok(f.anchors.length >= 1 && f.anchors[0].quote.length > 0);
+    assert.equal(f.subject_ref.label, 'Jacob Hansen');
+    for (const banned of ['intent', 'score', 'confidence', 'lying', 'verdict', 'stance']) {
+        assert.ok(!(banned in f), `stored finding must not carry "${banned}"`);
+    }
+
+    // Baseline created, no score.
+    assert.ok(created.baseline[0].note.length > 0);
+    assert.ok(!('score' in created.baseline[0]));
+
+    // Sanity: the claim ids the linker stored match what we created.
+    assert.ok(claimIdByRef.C1 && claimIdByRef.C2);
+});
+
+test('end-to-end: a counter-note-less finding is rejected by the model firewall too', async () => {
+    reset();
+    const bad = P.buildFindingInput(
+        { role: 'apologist', maneuver: 'darvo/deny', counter_note: '', anchors: [{ quote: 'x' }] },
+        { articleText: ARTICLE_TEXT, sourceRef: { url: URL }, suggestedBy: SUGGESTED_BY, subjectLabel: 'X' }
+    );
+    await assert.rejects(() => ForensicModel.create(bad), /counter_note/);
+});
+
+test('end-to-end: a finding with no quoted anchor is rejected by the model firewall', async () => {
+    reset();
+    const bad = P.buildFindingInput(
+        { role: 'apologist', maneuver: 'darvo/deny', counter_note: 'maybe ok', anchors: [] },
+        { articleText: ARTICLE_TEXT, sourceRef: { url: URL }, suggestedBy: SUGGESTED_BY, subjectLabel: 'X' }
+    );
+    await assert.rejects(() => ForensicModel.create(bad), /anchor/);
+});

--- a/tests/llm-proposals.test.mjs
+++ b/tests/llm-proposals.test.mjs
@@ -279,6 +279,27 @@ test('resolveModel defaults unknown ids to the latest capable model', () => {
     assert.equal(resolveModel('claude-sonnet-4-6'), 'claude-sonnet-4-6');
 });
 
+test('llmAssist flag defaults OFF', async () => {
+    const { FLAGS_DEFAULTS } = await import('../src/shared/metadata/feature-flags.js');
+    assert.equal(FLAGS_DEFAULTS.llmAssist, false);
+});
+
+test('system prompt scopes by task: findings-only embeds the guide; entities-only does not', () => {
+    const findings = buildSystemPrompt({ task: 'findings' });
+    assert.match(findings, /MANEUVER GUIDE/);
+    const entities = buildSystemPrompt({ task: 'entities' });
+    assert.doesNotMatch(entities, /MANEUVER GUIDE/);
+    assert.match(entities, /people \/ organizations/i);
+});
+
+test('tool schema exposes every artifact kind', () => {
+    const tool = buildSuggestTool();
+    const kinds = tool.input_schema.properties.proposals.items.properties.kind.enum;
+    for (const k of ['entity', 'claim', 'assessment', 'relationship', 'finding', 'baseline', 'revision']) {
+        assert.ok(kinds.includes(k), `schema kind enum must include ${k}`);
+    }
+});
+
 // ---------------------------------------------------------------------
 // End-to-end "mock client" pass through the REAL models
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Implements **Phase 14.5** per `docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`: a user-invoked pass that calls the Anthropic Messages API **from the background service worker** and proposes capture artifacts — entities, claims, assessments, claim relationships, and forensic findings (plus baselines and `revision/*` edges) — for human review. Every accepted artifact is created through the **existing models** with provenance `suggested_by: 'llm:<model>'`. **Nothing auto-saves; nothing auto-publishes.**

Built as the four-slice train from the kickoff (one commit per slice).

### What it does
- **✨ Suggest…** in the reader chrome runs a pass over the open article and opens a grouped **review panel** (Entities / Claims / Assessments / Relationships / Findings / …). Per proposal: **Accept** (creates the real artifact, tagged `suggested_by: 'llm:<model>'`), **Edit** (compact inline editor; flips provenance to `user`), **Reject**. "Accept all valid" runs in dependency order so refs resolve. Accepted items land in the existing claims / findings bars.
- The model returns **verbatim quotes**; the reader resolves them to real W3C anchors against the same body text it sent.

### Two consent gates (kickoff requirement)
1. `llmAssist` feature flag — **default off**.
2. A user-supplied Anthropic API key. The Suggest control is **absent** when the flag is off and **disabled** when on with no key, so either state ⇒ **zero network calls**.

### The firewall + the no-verdict discipline
- The **existing model validators are the firewall**. `llm-proposals.validateProposal` mirrors them (same exported predicates) for the review-panel "rejected-with-reason" badges; each model's `create()` is the ultimate gate at accept.
- **Findings** keep the discipline by construction: a required **counter-note**, **≥1 quoted anchor**, and **no intent/score field anywhere** in the schema or mapping. A finding missing either is shown rejected and never saved.

### Secret handling
- Key stored under its own `chrome.storage.local` key (`xray:llm:key`); **never** logged, **never** exported (entity/case bundles), never read back into the Options page (we report only *whether* one is set), and added to the "erase all" sweep.

### New / changed
- `src/shared/llm-prompts.js` (pure: model roster, `propose_capture` tool schema, taxonomy-derived system prompt with the MANEUVER_GUIDE), `src/shared/llm-client.js` (SW-only Anthropic fetch + error mapping), `src/shared/llm-proposals.js` (pure validators + quote→anchor + create()-input mapping), `src/reader/llm-review.js` (the review modal).
- `xray:llm:suggest` / `xray:llm:config` background messages; Options → Advanced → **LLM assist** (key / model / flag); `https://api.anthropic.com/*` host permission.
- `ClaimModel` / `EntityModel` gain a **local-only** `suggested_by` field — the kind-30040 / kind-0 **wire formats are unchanged** (no relay-compat consequences). Assessments / links / findings already had the full seam.

### Gotchas handled
- `anthropic-dangerous-direct-browser-access: true` header; the fetch runs in the SW (outside page CSP); flag/key re-read on each SW wake.
- Quote anchoring is tolerant (verbatim → prefix/suffix selector; miss → quote-only selector).

### Testing
- `npm test` — **920 pass** (+25 new cases in `tests/llm-proposals.test.mjs`: validators accept/reject, anchoring hit/miss, the no-intent/no-score invariant, prompt/schema invariants, and an **end-to-end mock-client pass** that funnels a canned proposal set through the *real* models and asserts every artifact lands tagged `llm:<model>` — plus that a counter-note-less / unquoted finding is rejected by the model firewall).
- `npm run build` clean; `web-ext lint --self-hosted` **0 errors** (the 151 warnings are the repo's pre-existing innerHTML notices).
- `docs/SMOKE_TEST.md` §Phase 14.5 added (needs a real API key to run end-to-end).

Model default is `claude-opus-4-8` (picker also offers Opus 4.7 / Sonnet 4.6 / Haiku 4.5), per the `claude-api` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B)_