### PR TITLE
feat(audit): in-extension LLM auditor — quick + thorough modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,14 +32,20 @@ Sections per release: **Added** (new features), **Changed**
   `https://api.anthropic.com/*` host permission. `ClaimModel` and
   `EntityModel` gain a local-only `suggested_by` field (the kind-30040 /
   kind-0 wire formats are unchanged).
-- **In-extension epistemic auditor (the LLM execution path).** A
-  user-invoked **"Run audit"** button in the reader scores the open
-  capture against all eight epistemic-audit dimensions in a single forced
-  tool call to the Anthropic Messages API **from the background service
-  worker** (`runAuditPass`, `xray:audit:run`), then ingests the result
-  through the **existing `importAuditJson` firewall** — re-hashed against
-  the capture, every module schema-validated, the per-module failure
-  posture preserved. The LLM tool schema is **built from the validator's
+- **In-extension epistemic auditor (the LLM execution path).** Two
+  user-invoked reader buttons score the open capture against all eight
+  epistemic-audit dimensions via the Anthropic Messages API **from the
+  background service worker** (`runAuditPass`, `xray:audit:run`), then
+  ingest the result through the **existing `importAuditJson` firewall** —
+  re-hashed against the capture, every module schema-validated, the
+  per-module failure posture preserved. **Quick audit** is one forced
+  tool call (single-shot, cheaper); **Thorough audit** runs one
+  independent call per dimension in parallel, each with its **full
+  vendored methodology prompt** (`shared/audit/module-prompts.js`,
+  generated verbatim from `docs/auditor-prototype/prompts/01-08`) and its
+  own output budget — the orchestrator doc's production recommendation,
+  ~8× the cost. Single-shot runs carry a standing "lower rigor" caveat;
+  thorough runs do not. The LLM tool schema is **built from the validator's
   `PAYLOADS`** (one source of truth, so a clean pass can't drift out of
   schema), and the aggregate (weights, knowability ceiling, confidence
   stacking) is **computed in code, never taken from the model**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,20 @@ Sections per release: **Added** (new features), **Changed**
   second consent gate, since the article text leaves the device). The
   existing model validators are the firewall — findings keep the
   no-verdict discipline (a required counter-note, ≥1 quoted anchor, no
-  intent/score). New: `shared/llm-prompts.js`, `shared/llm-client.js`,
-  `shared/llm-proposals.js`, `reader/llm-review.js`; the
-  `xray:llm:suggest` / `xray:llm:config` messages; an Options →
-  Advanced → "LLM assist" section (key / model / flag); and the
-  `https://api.anthropic.com/*` host permission. `ClaimModel` and
-  `EntityModel` gain a local-only `suggested_by` field (the kind-30040 /
-  kind-0 wire formats are unchanged).
+  intent/score). **Which artifact types a pass proposes is configurable**
+  (Options → Advanced → LLM assist), defaulting to **Entities + Claims
+  only** — the extraction kinds the model does reliably. Relationships,
+  assessments, and forensic findings are **opt-in** judgments (higher
+  false-positive rate; auto-judgments are the thing X-Ray refuses to
+  render): the pass both scopes its prompt to the enabled kinds and
+  filters the result to them. New: `shared/llm-prompts.js`,
+  `shared/llm-client.js`, `shared/llm-proposals.js`,
+  `reader/llm-review.js`; the `xray:llm:suggest` / `xray:llm:config`
+  messages; an Options → Advanced → "LLM assist" section (key / model /
+  flag / per-kind toggles); and the `https://api.anthropic.com/*` host
+  permission. `ClaimModel` and `EntityModel` gain a local-only
+  `suggested_by` field (the kind-30040 / kind-0 wire formats are
+  unchanged).
 - **In-extension epistemic auditor (the LLM execution path).** Two
   user-invoked reader buttons score the open capture against all eight
   epistemic-audit dimensions via the Anthropic Messages API **from the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ Sections per release: **Added** (new features), **Changed**
   `https://api.anthropic.com/*` host permission. `ClaimModel` and
   `EntityModel` gain a local-only `suggested_by` field (the kind-30040 /
   kind-0 wire formats are unchanged).
+- **In-extension epistemic auditor (the LLM execution path).** A
+  user-invoked **"Run audit"** button in the reader scores the open
+  capture against all eight epistemic-audit dimensions in a single forced
+  tool call to the Anthropic Messages API **from the background service
+  worker** (`runAuditPass`, `xray:audit:run`), then ingests the result
+  through the **existing `importAuditJson` firewall** — re-hashed against
+  the capture, every module schema-validated, the per-module failure
+  posture preserved. The LLM tool schema is **built from the validator's
+  `PAYLOADS`** (one source of truth, so a clean pass can't drift out of
+  schema), and the aggregate (weights, knowability ceiling, confidence
+  stacking) is **computed in code, never taken from the model**
+  (PHILOSOPHY §4); every run carries a standing "single-shot
+  orchestration — lower rigor" caveat (P12). Gated by the same
+  **`llmAssist`** flag + API key as Suggest; running and importing are
+  local-only, and **publishing stays behind `epistemicAuditing`**. No
+  PHILOSOPHY amendment — §8 already makes a model a first-class auditor
+  and the methodology version stays `1.0` (the findings schemas are
+  unchanged). New: `shared/audit/audit-prompt.js`; `runAuditPass` /
+  `extractToolInput` in `shared/llm-client.js`; the `xray:audit:run`
+  message; and a "Run audit" control in the reader's audit bar.
 - **Phase 14.3 — forensic wire format (kind `30062`).** New
   `buildBehavioralFindingEvent` (kind 30062 BehavioralFinding) +
   `parseBehavioralFindingEvent` + a kind-1985 maneuver mirror, behind a

--- a/docs/EPISTEMIC_AUDIT_DESIGN.md
+++ b/docs/EPISTEMIC_AUDIT_DESIGN.md
@@ -413,6 +413,17 @@ architecture, not a stopgap.)*
     (P12). No constitutional change: §8 already admits a model auditor,
     and methodology version stays `1.0` (findings schemas unchanged).
     Publishing remains slice 13.8, behind `epistemicAuditing`.
+    - **Thorough (per-module) mode (2026-06-21).** The rigor upgrade: a
+      second reader button runs **one independent call per dimension**
+      (parallelized), each with the dimension's *full* methodology
+      vendored from `prompts/01-08` into `shared/audit/module-prompts.js`
+      — the orchestrator doc's production recommendation, ~8× the cost.
+      The eight outputs collect into the same `assembleAudit` +
+      `importAuditJson`, so only the *acquisition* changes; the firewall,
+      hash gate, and deterministic aggregate are identical. No standing
+      single-shot caveat (this is the rigorous path). The rigor ladder
+      above single-shot then continues: multi-run / model-ensemble
+      side-by-side (never averaged), then the human Audit tier (c).
 - **(c) manual tier — the first post-v1 slice (RQ3).** The recovered
   tier spec (delivered with the RQ3 answer; `PHILOSOPHY.md` itself
   carries only §8's weight-follows-track-record mechanic) is five

--- a/docs/EPISTEMIC_AUDIT_DESIGN.md
+++ b/docs/EPISTEMIC_AUDIT_DESIGN.md
@@ -394,6 +394,25 @@ architecture, not a stopgap.)*
   enforced in the model layer. (Sizing: two slices — key custody +
   consent UI, then the runner — staged behind the CLI path, not ridden
   into a v1 slice.)
+  - **Implemented (2026-06-20): the in-extension single-shot auditor.**
+    The runner now exists, riding the Phase-14.5 key custody + consent
+    gate (the `llmAssist` flag + the `xray:llm:key` secret) rather than a
+    second one. A reader **"Run audit"** button → `xray:audit:run` →
+    `runAuditPass` in the SW makes **one** forced tool call that scores
+    all eight modules (the orchestrator methodology), then
+    `assembleAudit` (`shared/audit/audit-prompt.js`) builds the canonical
+    `{article, module_results, predictions, aggregate}` and the reader
+    feeds it to the **same `importAuditJson`** the CLI path uses — the
+    RQ1 hash gate and per-module validation are reused verbatim. Two
+    invariants are load-bearing: the LLM tool schema is **built from
+    `findings-schemas.js`'s `PAYLOADS`** so a clean pass can't drift out
+    of schema, and the **aggregate is computed in code** (weights +
+    ceiling heuristic ported from the scorer), never taken from the
+    model (§4 / P4). Single-shot is the orchestrator's documented
+    lower-rigor tradeoff, so every module carries a standing caveat
+    (P12). No constitutional change: §8 already admits a model auditor,
+    and methodology version stays `1.0` (findings schemas unchanged).
+    Publishing remains slice 13.8, behind `epistemicAuditing`.
 - **(c) manual tier — the first post-v1 slice (RQ3).** The recovered
   tier spec (delivered with the RQ3 answer; `PHILOSOPHY.md` itself
   carries only §8's weight-follows-track-record mechanic) is five

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,46 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-21 — Thorough (per-module) audit: the rigor upgrade
+
+Tags: `design`.
+
+Follow-up to the single-shot auditor: a **Thorough audit** mode that
+runs the orchestrator doc's recommended production path — **one
+independent model call per dimension**, each with the dimension's *full*
+methodology, instead of all eight sharing one pass. This is the answer to
+"how do we get maximum rigor" within the extension.
+
+- **Why it's more rigorous.** Single-shot spreads one context window and
+  one ~16k output budget across eight dimensions (attention dilution,
+  cross-contamination, truncation, a *condensed* methodology). Per-module
+  gives each dimension its own call, its own budget, the real
+  step-numbered methodology, and blindness to the others' judgments.
+- **Vendored prompts.** The methodology lives in
+  `docs/auditor-prototype/prompts/01-08`, which the extension can't read
+  at runtime, so `tools/gen-module-prompts.mjs` slices each at its
+  `# ARTICLE` marker (exactly the CLI's `loadPrompt`) and emits
+  `src/shared/audit/module-prompts.js` verbatim. Imported only by the SW
+  bundle (confirmed: 0 occurrences in the reader/content bundles), so the
+  reader stays lean.
+- **One aggregation path.** The eight per-module tool outputs are
+  collected into the same `{modules}` shape and handed to the SAME
+  `assembleAudit` + `importAuditJson` — the firewall, hash gate, and
+  deterministic aggregate are unchanged. A failed module call simply
+  leaves its module absent → recorded FAILED, the rest still aggregate.
+- **`standingCaveat` is now a parameter.** Single-shot passes its
+  lower-rigor disclosure; thorough passes `null` (nothing to apologize
+  for). The model's own per-module caveats flow in both modes.
+- **Tradeoffs.** ~8× cost and 8× article tokens; calls run in parallel so
+  latency stays ~one call, at the risk of a 429 on a tight key (a 429
+  fails that one module, not the run). A reader `confirm()` gates the
+  thorough button so the spend is never a surprise.
+
+Files: `shared/audit/module-prompts.js` (generated) + `tools/gen-module-prompts.mjs`,
+`buildSingleModuleTool` / `buildModuleSystemPrompt` + the `standingCaveat`
+param in `audit-prompt.js`, `runPerModuleAudit` in `llm-client.js`, the
+reader's two-button control, `tests/audit-llm.test.mjs`.
+
 ## 2026-06-20 — In-extension epistemic auditor (LLM execution path) — design
 
 Tags: `design`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,36 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-21 — Suggest defaults: extraction ON, judgment opt-in
+
+Tags: `design`.
+
+The Suggest pass used to always request `task: 'all'` — every artifact
+kind in one go. We now default to **Entities + Claims only**, with
+relationships, assessments, and forensic findings opt-in via Options
+checkboxes.
+
+The line is **extraction vs judgment**. The model is reliable and
+on-mission extracting what the article *contains* (who's named, what's
+asserted, each with a verbatim quote); it's unreliable and off-mission
+rendering *judgments* (a stance, a maneuver). The cost of a false
+positive is asymmetric: a wrong entity is a one-click reject, but a wrong
+*assessment* (an auto-suggested agree/disagree stance) or *finding* is the
+tool manufacturing the very verdict X-Ray exists not to render — and it
+biases the reviewer by pre-filling an opinion they're supposed to own.
+Relationships are held too: on a single captured article there are few
+real inter-claim links, so the yield is low while the FP surface is real;
+their value is cross-article (not yet wired), so they flip on later.
+
+Mechanism: `SUGGEST_DEFAULT_KINDS` + `normalizeSuggestKinds` /
+`categoryOfProposalKind` in `llm-prompts.js`; the pass both SCOPES the
+prompt to the enabled kinds (fewer off-target proposals, and the heavy
+maneuver guide is dropped when findings are off) and FILTERS the result
+(defense in depth). Stored under `xray:llm:suggest_kinds`; an explicit
+empty array is honored ("suggest nothing"), an absent key falls back to
+the defaults. Forensic findings stay reachable (a power-user can opt in)
+but are off by default until their definitions/guardrails mature.
+
 ## 2026-06-21 — Thorough (per-module) audit: the rigor upgrade
 
 Tags: `design`.

--- a/docs/JOURNAL.md
+++ b/docs/JOURNAL.md
@@ -19,6 +19,57 @@ or files, and the "so-what" for future readers.
 
 ---
 
+## 2026-06-20 — In-extension epistemic auditor (LLM execution path) — design
+
+Tags: `design`.
+
+Phase 13 shipped two audit paths: the out-of-band CLI scorer
+(`docs/auditor-prototype/scorer/scorer.js`) and the in-extension
+**import** firewall (`shared/audit/import.js`, slice 13.5). This adds a
+third — a **"Run audit"** button that runs the audit *inside* the
+extension via the 14.5 LLM plumbing — without loosening any invariant.
+
+Decisions worth second-guessing later:
+
+- **Single-shot, not eight calls.** One forced tool call emits all eight
+  modules (the orchestrator methodology,
+  `prompts/00-orchestrator-single-shot.md`). Cheaper and simpler, lower
+  rigor — so every module result carries a standing caveat saying so
+  (P12). The orchestrator's own JSON shape is a *simplified* `dimensions`
+  block that does **not** match `validateFindings`; using it directly
+  would import every module as FAILED. So the in-extension prompt drives
+  the **canonical per-module findings** instead, via a tool schema
+  **built from `findings-schemas.js`'s `PAYLOADS`** (now exported). One
+  source of truth: the model is guided by the exact shapes the validator
+  enforces.
+- **The aggregate is computed in code, never the model's.** `MODULE_WEIGHTS`,
+  the source-quality knowability-ceiling heuristic, and confidence
+  stacking are ported verbatim from the CLI scorer into
+  `shared/audit/audit-prompt.js`'s `buildAggregate`. The model supplies
+  only per-dimension score/confidence/findings (PHILOSOPHY §4: the
+  weights are public constants, not a model's opinion). The tool schema
+  deliberately has **no** aggregate field to fill.
+- **Reuse the firewall, don't fork it.** `assembleAudit` produces the
+  exact `{article, module_results, predictions, aggregate}` shape, and the
+  reader feeds it to the **same `importAuditJson`** the file importer
+  uses — same RQ1 hash gate (we send the SAME markdown we hash, so both
+  halves agree), same per-module schema validation, same failure posture.
+  `module`/`version` are injected at assembly (never model-supplied) and
+  wrapper score/version are set equal to findings' so import's tamper
+  check passes. An absent or malformed module imports as a FAILED result,
+  not a rejection.
+- **No constitution change.** §8 already makes a model a first-class
+  auditor (identity `anthropic/<model>`); methodology version stays `1.0`
+  because the findings schemas are unchanged. Running/importing are
+  local-only and ungated; **publishing stays behind `epistemicAuditing`**
+  (slice 13.8). Gating reuses the `llmAssist` flag + key, so flag-off or
+  no-key means no network call is reachable.
+
+Files: `shared/audit/audit-prompt.js` (new), `runAuditPass` /
+`extractToolInput` in `shared/llm-client.js`, `xray:audit:run` in the SW,
+the reader's `setupAuditRunControl` / `runAuditFromReader`,
+`tests/audit-llm.test.mjs`.
+
 ## 2026-06-20 — Phase 14.5: LLM-assist suggestions through the existing models
 
 **Tags:** design

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -526,9 +526,10 @@ everything before 13.13 below must work with the flag off.
 |---|---|---|
 | 13.7a | `llmAssist` **off** → reader audit bar | ✅ **no** "Run audit" button (only "Import audit JSON…") — no network call is reachable |
 | 13.7b | Enable `llmAssist` + save a key (Settings ▸ Advanced ▸ LLM assist), reopen the reader | ✅ "Run audit" appears enabled; with the flag on but **no** key it is **disabled** with a key hint |
-| 13.7c | Click **Run audit** on a fresh capture | ✅ button shows "⏳ Auditing…", then a summary toast (modules valid/failed, predictions); the audit panel fills exactly as an imported run does |
+| 13.7c | Click **Quick audit** on a fresh capture | ✅ button shows "⏳ Auditing…", then a summary toast (modules valid/failed, predictions); the audit panel fills exactly as an imported run does |
 | 13.7d | Expand the module rows | ✅ each carries the standing **"single-shot orchestration — lower rigor"** caveat; auditor reads `model · anthropic/<model>`; the aggregate's ceiling-source is `heuristic:source-quality/1.0` |
-| 13.7e | Edit one character of the body → **Run audit** again | ✅ binds to the edited text's hash (no capture-mismatch error); the prior run stays side-by-side, **never averaged** |
+| 13.7e | Edit one character of the body → **Quick audit** again | ✅ binds to the edited text's hash (no capture-mismatch error); the prior run stays side-by-side, **never averaged** |
+| 13.7f | Click **Thorough audit** → confirm the cost prompt | ✅ both audit buttons disable during the run; on completion the toast says "thorough"; module rows do **not** carry the single-shot caveat (per-dimension methodology); a module whose call fails shows as **failed**, the rest still produce an aggregate |
 
 **Display rules (PHILOSOPHY — check, don't skip)**
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -636,11 +636,13 @@ Epistemic-audit bar** — three separate, firewalled blocks.
 ## Phase 14.5 — LLM assist (in-extension suggestions)
 
 A user-invoked pass that asks Anthropic's Claude to **propose** capture
-artifacts (entities, claims, assessments, relationships, findings — and
-baselines / revision edges) for review. Two consent gates: the
-`llmAssist` flag (off by default) **and** a user-supplied API key. Every
-item is a draft — nothing saves without Accept, nothing publishes.
-Requires a real Anthropic API key (`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`).
+artifacts for review. Which artifact types it proposes is configurable
+(Options → Advanced → LLM assist), defaulting to **Entities + Claims**;
+relationships, assessments, and forensic findings are opt-in. Two consent
+gates: the `llmAssist` flag (off by default) **and** a user-supplied API
+key. Every item is a draft — nothing saves without Accept, nothing
+publishes. Requires a real Anthropic API key
+(`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`).
 
 **Gating (no key / no flag = no calls)**
 
@@ -650,12 +652,14 @@ Requires a real Anthropic API key (`docs/PHASE_14_5_LLM_ASSIST_KICKOFF.md`).
 | 14.5.2 | Settings → Advanced → **LLM assist**: confirm the toggle is **unchecked** and "No key saved yet." | ✅ default off, no key |
 | 14.5.3 | Check **Enable LLM-assisted suggestions**, leave the key blank, Save → reopen the reader | ✅ the **✨ Suggest…** button is present but **disabled**, tooltip points to the key field; still zero network |
 | 14.5.4 | Paste an Anthropic key + pick a **Model**, Save. Confirm the key field clears and status reads "A key is saved." | ✅ key stored; reader's Suggest button now **enabled** |
+| 14.5.4b | In **Suggest these artifact types**, confirm the defaults | ✅ **Entities + Claims checked**, Relationships / Assessments / Forensic findings **unchecked** |
 
 **Run a pass + review**
 
 | # | Test | Pass criteria |
 |---|---|---|
-| 14.5.5 | On an op-ed / debate with named people, click **✨ Suggest…** | ✅ button shows "✨ Thinking…", then a **Suggestions** modal opens grouped by Entities / Claims / Assessments / Relationships / Findings (and Baselines/Revisions if any); a model badge shows the model id |
+| 14.5.5 | On an op-ed / debate with named people, click **✨ Suggest…** (defaults) | ✅ button shows "✨ Thinking…", then a **Suggestions** modal opens with **only Entities + Claims** sections (no Assessments / Relationships / Findings); a model badge shows the model id |
+| 14.5.5b | Enable **Forensic findings** in Options, Save, re-run a pass | ✅ the modal now also shows a Findings section (and Baselines/Revisions if any) — opt-in kinds appear only once enabled |
 | 14.5.6 | Inspect a **Claim** proposal | ✅ summary shows the claim text + the about-entities it links; Accept / Edit / Reject buttons |
 | 14.5.7 | Inspect a **Finding** proposal | ✅ shows subject + maneuver + role/basis + a quoted lead + the **counter-read** (`↔ …`); **no stance/score/confidence anywhere** |
 | 14.5.8 | **Accept** an entity, then its claim, then a finding (or click **Accept all valid**) | ✅ rows flip to "✓ accepted"; the **claims bar** and **Forensic findings bar** gain the artifacts |

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -520,6 +520,16 @@ everything before 13.13 below must work with the flag off.
 | 13.6 | Hand-edit the JSON body or hash → import | ✅ refused (re-hash mismatch); tamper with one module's top-level `score` so it diverges from `findings.score` → that module imports as **failed**, the rest survive |
 | 13.7 | Reader → the same article → audit panel | ✅ aggregate badge with score **and** confidence; binding ceiling shows its provenance; per-module rows expand with caveats; evidence quotes click-to-locate in the body |
 
+**Run audit — the in-extension LLM path (needs `llmAssist` on + an API key; see Phase 14.5 setup)**
+
+| # | Test | Pass criteria |
+|---|---|---|
+| 13.7a | `llmAssist` **off** → reader audit bar | ✅ **no** "Run audit" button (only "Import audit JSON…") — no network call is reachable |
+| 13.7b | Enable `llmAssist` + save a key (Settings ▸ Advanced ▸ LLM assist), reopen the reader | ✅ "Run audit" appears enabled; with the flag on but **no** key it is **disabled** with a key hint |
+| 13.7c | Click **Run audit** on a fresh capture | ✅ button shows "⏳ Auditing…", then a summary toast (modules valid/failed, predictions); the audit panel fills exactly as an imported run does |
+| 13.7d | Expand the module rows | ✅ each carries the standing **"single-shot orchestration — lower rigor"** caveat; auditor reads `model · anthropic/<model>`; the aggregate's ceiling-source is `heuristic:source-quality/1.0` |
+| 13.7e | Edit one character of the body → **Run audit** again | ✅ binds to the edited text's hash (no capture-mismatch error); the prior run stays side-by-side, **never averaged** |
+
 **Display rules (PHILOSOPHY — check, don't skip)**
 
 | # | Test | Pass criteria |

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -26,7 +26,7 @@ import { NostrClient } from '../shared/nostr-client.js';
 import { EventBuilder } from '../shared/event-builder.js';
 import { fetchSubstackPost, fetchSubstackComments } from '../shared/platforms/substack-api.js';
 import { handleScreenshotCapture } from '../shared/screenshot.js';
-import { runSuggestionPass, getLlmConfig } from '../shared/llm-client.js';
+import { runSuggestionPass, runAuditPass, getLlmConfig } from '../shared/llm-client.js';
 
 // Pull the debug preference on SW startup. MV3 service workers sleep
 // and wake, so this runs each time the SW reloads. A chrome.storage
@@ -353,6 +353,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         runSuggestionPass(message.request || {}).then(
             (result) => sendResponse(result),
             (err) => sendResponse({ ok: false, error: (err && err.message) || 'LLM pass failed' })
+        );
+        return true; // async sendResponse
+    }
+
+    // Reader page → worker: run an in-extension epistemic-audit pass
+    // against the open article. Same home as Suggest (SW outside page
+    // CSP, key never leaves the SW), gated identically inside
+    // runAuditPass. Returns the canonical scorer-export object only —
+    // the reader runs importAuditJson (re-hash + schema-validate) and
+    // nothing is published here (that stays behind `epistemicAuditing`).
+    if (message.type === 'xray:audit:run') {
+        runAuditPass(message.request || {}).then(
+            (result) => sendResponse(result),
+            (err) => sendResponse({ ok: false, error: (err && err.message) || 'Audit pass failed' })
         );
         return true; // async sendResponse
     }

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -8,7 +8,10 @@ import { Storage } from '../shared/storage.js';
 import { Crypto } from '../shared/crypto.js';
 import { NSecBunkerClient } from '../shared/nsecbunker-client.js';
 import { loadFlags, isEnabled, setOverride, resetOverrides } from '../shared/metadata/feature-flags.js';
-import { LLM_MODELS, DEFAULT_LLM_MODEL, resolveModel, LLM_KEY_STORAGE, LLM_MODEL_STORAGE } from '../shared/llm-prompts.js';
+import {
+    LLM_MODELS, DEFAULT_LLM_MODEL, resolveModel, LLM_KEY_STORAGE, LLM_MODEL_STORAGE,
+    LLM_SUGGEST_KINDS_STORAGE, SUGGEST_KIND_LABELS, normalizeSuggestKinds
+} from '../shared/llm-prompts.js';
 import { importAuditJson } from '../shared/audit/import.js';
 import { articleHash as canonicalArticleHash } from '../shared/audit/article-hash.js';
 import { listRuns, listPredictions, listResolutions } from '../shared/audit/audit-cache.js';
@@ -572,6 +575,18 @@ async function loadAdvanced() {
     }
     document.getElementById('pref-llm-key').value = '';
 
+    // Per-kind suggestion toggles (default: entities + claims).
+    populateLlmKinds();
+    const rawKinds = await new Promise((resolve) => {
+        browserApi.storage.local.get([LLM_SUGGEST_KINDS_STORAGE],
+            (res) => resolve(res ? res[LLM_SUGGEST_KINDS_STORAGE] : undefined));
+    });
+    const enabledKinds = normalizeSuggestKinds(rawKinds);
+    for (const { kind } of SUGGEST_KIND_LABELS) {
+        const cb = document.getElementById(`pref-llm-kind-${kind}`);
+        if (cb) cb.checked = enabledKinds.includes(kind);
+    }
+
     const overrides = prefs.config_overrides || {};
     document.getElementById('pref-cache-enabled').checked =
         overrides.article_cache_enabled !== false;
@@ -624,6 +639,16 @@ async function saveAdvanced() {
         if (keyStatus) keyStatus.textContent = 'A key is saved on this device.';
     }
 
+    // Enabled suggestion kinds — stored as an explicit array (an empty
+    // array is a valid "suggest nothing" choice; the pass surfaces that).
+    const checkedKinds = SUGGEST_KIND_LABELS
+        .map(({ kind }) => kind)
+        .filter((kind) => {
+            const cb = document.getElementById(`pref-llm-kind-${kind}`);
+            return cb && cb.checked;
+        });
+    await llmRawSet(LLM_SUGGEST_KINDS_STORAGE, checkedKinds);
+
     flash(document.getElementById('advanced-status'), 'Saved.');
 }
 
@@ -635,6 +660,29 @@ function populateLlmModels() {
         opt.value = m.id;
         opt.textContent = m.label;
         sel.appendChild(opt);
+    }
+}
+
+// Render the per-kind suggestion checkboxes from the single source of
+// truth (SUGGEST_KIND_LABELS). Built with DOM nodes (no innerHTML) so the
+// lint stays clean; labels/hints are static constants regardless.
+function populateLlmKinds() {
+    const host = document.getElementById('pref-llm-kinds');
+    if (!host || host.childElementCount > 0) return;
+    for (const { kind, label, hint } of SUGGEST_KIND_LABELS) {
+        const wrap = document.createElement('label');
+        wrap.className = 'xr-opt__field xr-opt__field--inline';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.id = `pref-llm-kind-${kind}`;
+        const span = document.createElement('span');
+        const strong = document.createElement('strong');
+        strong.textContent = label;
+        span.appendChild(strong);
+        span.appendChild(document.createTextNode(` — ${hint}`));
+        wrap.appendChild(cb);
+        wrap.appendChild(span);
+        host.appendChild(wrap);
     }
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -291,12 +291,11 @@
       <p class="xr-opt__hint" style="margin-top:-8px">
         Off by default. When on <strong>and</strong> an API key is set, the
         reader gains a <strong>✨ Suggest…</strong> control that asks Anthropic's
-        Claude to propose entities, claims, assessments, relationships, and
-        forensic findings from the open article. <strong>The article text is
-        sent to Anthropic</strong> when you run a pass. Every suggestion is a
-        <strong>draft you review and confirm</strong> — nothing is saved or
-        published automatically, and publishing still requires the
-        experimental publish switches above.
+        Claude to propose capture artifacts (choose which types below) from the
+        open article. <strong>The article text is sent to Anthropic</strong>
+        when you run a pass. Every suggestion is a <strong>draft you review and
+        confirm</strong> — nothing is saved or published automatically, and
+        publishing still requires the experimental publish switches above.
       </p>
       <label class="xr-opt__field">
         <span class="xr-opt__label">Anthropic API key</span>
@@ -311,6 +310,16 @@
         <span class="xr-opt__label">Model</span>
         <select id="pref-llm-model"></select>
       </label>
+      <div class="xr-opt__field">
+        <span class="xr-opt__label">Suggest these artifact types</span>
+        <div id="pref-llm-kinds"></div>
+      </div>
+      <p class="xr-opt__hint" style="margin-top:-8px">
+        Default: <strong>Entities</strong> + <strong>Claims</strong> — extraction
+        the model does reliably (high signal, low noise). Relationships,
+        assessments, and forensic findings are opt-in <em>judgments</em>:
+        higher false-positive rate, and X-Ray never renders them automatically.
+      </p>
       <div class="xr-opt__actions">
         <button class="xr-opt__btn" id="llm-key-clear">Clear key</button>
         <span class="xr-opt__status" id="llm-status"></span>

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -57,6 +57,8 @@
     <div class="xr-audit__bar">
       <span class="xr-audit__label">Epistemic audit</span>
       <span class="xr-audit__status" id="xr-audit-status">No audit imported for this capture.</span>
+      <!-- In-extension auditor (LLM): hidden unless the llmAssist flag is on. -->
+      <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-run" title="Run an epistemic audit with an LLM" hidden>Run audit</button>
       <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-import">Import audit JSON…</button>
       <input type="file" id="xr-audit-file" accept="application/json,.json" hidden />
     </div>

--- a/src/reader/index.html
+++ b/src/reader/index.html
@@ -58,7 +58,8 @@
       <span class="xr-audit__label">Epistemic audit</span>
       <span class="xr-audit__status" id="xr-audit-status">No audit imported for this capture.</span>
       <!-- In-extension auditor (LLM): hidden unless the llmAssist flag is on. -->
-      <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-run" title="Run an epistemic audit with an LLM" hidden>Run audit</button>
+      <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-run" title="Quick epistemic audit — one LLM pass (cheaper, lower rigor)" hidden>Quick audit</button>
+      <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-run-thorough" title="Thorough epistemic audit — one LLM call per dimension (higher rigor, ~8× the cost)" hidden>Thorough audit</button>
       <button type="button" class="xr-reader__btn xr-reader__btn--ghost" id="xr-audit-import">Import audit JSON…</button>
       <input type="file" id="xr-audit-file" accept="application/json,.json" hidden />
     </div>

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1085,6 +1085,100 @@ async function runSuggestPass() {
     });
 }
 
+/**
+ * In-extension epistemic auditor control (the LLM execution path beside
+ * "Import audit JSON…"). Same gating as Suggest: absent unless the
+ * llmAssist flag is on, disabled with a hint when on but keyless — so
+ * flag-off OR no-key means no network call is reachable from here.
+ */
+async function setupAuditRunControl() {
+    const btn = $('#xr-audit-run');
+    if (!btn) return;
+    let cfg = {};
+    try { cfg = await browserApi.runtime.sendMessage({ type: 'xray:llm:config' }) || {}; }
+    catch (_) { cfg = {}; }
+
+    if (!cfg.enabled) { btn.hidden = true; return; }   // flag off ⇒ absent
+    btn.hidden = false;
+    if (!cfg.hasKey) {
+        btn.disabled = true;
+        btn.title = 'Set an Anthropic API key in Options → Advanced → LLM assist';
+        return;
+    }
+    btn.disabled = false;
+    btn.title = 'Run an epistemic audit with an LLM (sends the article text to Anthropic)';
+    btn.addEventListener('click', runAuditFromReader);
+}
+
+/**
+ * Run the audit pass and ingest its result through the SAME firewall the
+ * file importer uses. The SW returns the canonical scorer-export object;
+ * importAuditJson re-hashes its body_markdown and matches it against this
+ * capture's hash, then schema-validates every module. We send the EXACT
+ * markdown we hash, so the gate binds the audit to the open text.
+ */
+async function runAuditFromReader() {
+    const btn = $('#xr-audit-run');
+    if (!btn || btn.disabled || !state.article) return;
+
+    const markdown = EventBuilder.assembleArticleBody(state.article);
+    if (!markdown || !markdown.trim()) { toast('Nothing to audit yet.', 'error'); return; }
+
+    // Hash the exact text we send; the SW hashes the same string, so both
+    // halves of the RQ1 gate (claimed-vs-body, capture-vs-audit) agree.
+    let localHash;
+    try { localHash = await canonicalArticleHash(markdown); }
+    catch (_) { localHash = state.articleHash; }
+    if (!localHash) {
+        toast('This view has no capture hash to verify against — open the capture this audit belongs to.', 'error', 7000);
+        return;
+    }
+
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = '⏳ Auditing…';
+    let resp;
+    try {
+        resp = await browserApi.runtime.sendMessage({
+            type: 'xray:audit:run',
+            request: {
+                markdown,
+                articleUrl: state.article.url || '',
+                articleTitle: state.article.title || '',
+                metadata: {
+                    url: state.article.url || null,
+                    headline: state.article.title || null,
+                    byline: state.article.author || state.article.byline || null,
+                    publication_date: state.article.date || state.article.publishedTime || null
+                }
+            }
+        });
+    } catch (err) {
+        resp = { ok: false, error: (err && err.message) || String(err) };
+    }
+    btn.textContent = original;
+    btn.disabled = false;
+
+    if (!resp || !resp.ok) {
+        toast('Audit failed: ' + ((resp && resp.error) || 'unknown error'), 'error', 7000);
+        return;
+    }
+
+    try {
+        const summary = await importAuditJson(resp.audit, { localArticleHash: localHash });
+        const bits = [`${summary.modulesValid} module${summary.modulesValid === 1 ? '' : 's'} valid`];
+        if (summary.modulesFailed) bits.push(`${summary.modulesFailed} failed validation`);
+        if (summary.predictionsImported) bits.push(`${summary.predictionsImported} prediction${summary.predictionsImported === 1 ? '' : 's'}`);
+        if (summary.predictionsSkipped) bits.push(`${summary.predictionsSkipped} skipped`);
+        toast(`Audit complete (${resp.model}) — ${bits.join(', ')}`,
+            summary.modulesFailed ? 'warning' : 'success', 6000);
+        await refreshAuditStatus();
+    } catch (err) {
+        // importAuditJson is the firewall — surface its reason verbatim.
+        toast('Audit import failed: ' + (err && err.message), 'error', 7000);
+    }
+}
+
 async function openLinkClaim(sourceId, allClaimsOnArticle) {
     const source = allClaimsOnArticle.find((c) => c.id === sourceId);
     if (!source) return;
@@ -3358,6 +3452,11 @@ async function init() {
     // on; disabled (with a hint) when on but no key — so flag-off OR
     // no-key means zero network calls are possible from here.
     setupSuggestControl().catch((err) => console.warn('[X-Ray Reader] suggest setup failed:', err));
+
+    // In-extension epistemic auditor (the LLM execution path). Same
+    // gating as Suggest; absent unless llmAssist is on. Publishing the
+    // resulting events stays behind `epistemicAuditing`.
+    setupAuditRunControl().catch((err) => console.warn('[X-Ray Reader] audit-run setup failed:', err));
 
     // Epistemic-audit import (13.5): button → hidden file input →
     // importAuditJson with the RQ1 gate (re-hash + schema-validate +

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1052,7 +1052,8 @@ async function runSuggestPass() {
         resp = await browserApi.runtime.sendMessage({
             type: 'xray:llm:suggest',
             request: {
-                task: 'all',
+                // Which artifact kinds to suggest is configured in Options
+                // (default: entities + claims); the SW reads it.
                 articleText,
                 articleUrl: state.article.url || '',
                 articleTitle: state.article.title || ''

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1086,40 +1086,58 @@ async function runSuggestPass() {
 }
 
 /**
- * In-extension epistemic auditor control (the LLM execution path beside
- * "Import audit JSON…"). Same gating as Suggest: absent unless the
- * llmAssist flag is on, disabled with a hint when on but keyless — so
- * flag-off OR no-key means no network call is reachable from here.
+ * In-extension epistemic auditor controls (the LLM execution path beside
+ * "Import audit JSON…"): a Quick (single-shot) and a Thorough (per-module)
+ * button. Same gating as Suggest: absent unless the llmAssist flag is on,
+ * disabled with a hint when on but keyless — so flag-off OR no-key means
+ * no network call is reachable from here.
  */
 async function setupAuditRunControl() {
-    const btn = $('#xr-audit-run');
-    if (!btn) return;
+    const quick = $('#xr-audit-run');
+    const thorough = $('#xr-audit-run-thorough');
+    if (!quick && !thorough) return;
     let cfg = {};
     try { cfg = await browserApi.runtime.sendMessage({ type: 'xray:llm:config' }) || {}; }
     catch (_) { cfg = {}; }
 
-    if (!cfg.enabled) { btn.hidden = true; return; }   // flag off ⇒ absent
-    btn.hidden = false;
-    if (!cfg.hasKey) {
-        btn.disabled = true;
-        btn.title = 'Set an Anthropic API key in Options → Advanced → LLM assist';
-        return;
+    for (const btn of [quick, thorough]) {
+        if (!btn) continue;
+        if (!cfg.enabled) { btn.hidden = true; continue; }   // flag off ⇒ absent
+        btn.hidden = false;
+        if (!cfg.hasKey) {
+            btn.disabled = true;
+            btn.title = 'Set an Anthropic API key in Options → Advanced → LLM assist';
+        } else {
+            btn.disabled = false;   // title stays as the HTML default
+        }
     }
-    btn.disabled = false;
-    btn.title = 'Run an epistemic audit with an LLM (sends the article text to Anthropic)';
-    btn.addEventListener('click', runAuditFromReader);
+    if (cfg.enabled && cfg.hasKey) {
+        if (quick) quick.addEventListener('click', () => runAuditFromReader('single'));
+        if (thorough) thorough.addEventListener('click', () => runAuditFromReader('per_module'));
+    }
 }
 
 /**
- * Run the audit pass and ingest its result through the SAME firewall the
+ * Run an audit pass and ingest its result through the SAME firewall the
  * file importer uses. The SW returns the canonical scorer-export object;
  * importAuditJson re-hashes its body_markdown and matches it against this
  * capture's hash, then schema-validates every module. We send the EXACT
  * markdown we hash, so the gate binds the audit to the open text.
+ *
+ * @param {'single'|'per_module'} mode  single-shot (quick) or per-module
+ *   (thorough, ~8 independent calls).
  */
-async function runAuditFromReader() {
-    const btn = $('#xr-audit-run');
-    if (!btn || btn.disabled || !state.article) return;
+async function runAuditFromReader(mode = 'single') {
+    const quick = $('#xr-audit-run');
+    const thorough = $('#xr-audit-run-thorough');
+    const active = mode === 'per_module' ? thorough : quick;
+    if (!active || active.disabled || !state.article) return;
+
+    // Thorough mode spends ~8× — confirm before committing the user's key.
+    if (mode === 'per_module'
+        && !confirm('Thorough audit runs one LLM call per dimension (about 8 API calls — higher cost) for more rigor. Continue?')) {
+        return;
+    }
 
     const markdown = EventBuilder.assembleArticleBody(state.article);
     if (!markdown || !markdown.trim()) { toast('Nothing to audit yet.', 'error'); return; }
@@ -1134,14 +1152,18 @@ async function runAuditFromReader() {
         return;
     }
 
-    const original = btn.textContent;
-    btn.disabled = true;
-    btn.textContent = '⏳ Auditing…';
+    // Disable BOTH controls during a run (no concurrent passes); label the
+    // active one.
+    const labels = new Map();
+    for (const b of [quick, thorough]) { if (b) { labels.set(b, b.textContent); b.disabled = true; } }
+    active.textContent = mode === 'per_module' ? '⏳ Auditing (thorough)…' : '⏳ Auditing…';
+
     let resp;
     try {
         resp = await browserApi.runtime.sendMessage({
             type: 'xray:audit:run',
             request: {
+                mode,
                 markdown,
                 articleUrl: state.article.url || '',
                 articleTitle: state.article.title || '',
@@ -1156,8 +1178,8 @@ async function runAuditFromReader() {
     } catch (err) {
         resp = { ok: false, error: (err && err.message) || String(err) };
     }
-    btn.textContent = original;
-    btn.disabled = false;
+
+    for (const b of [quick, thorough]) { if (b) { b.textContent = labels.get(b); b.disabled = false; } }
 
     if (!resp || !resp.ok) {
         toast('Audit failed: ' + ((resp && resp.error) || 'unknown error'), 'error', 7000);
@@ -1170,7 +1192,8 @@ async function runAuditFromReader() {
         if (summary.modulesFailed) bits.push(`${summary.modulesFailed} failed validation`);
         if (summary.predictionsImported) bits.push(`${summary.predictionsImported} prediction${summary.predictionsImported === 1 ? '' : 's'}`);
         if (summary.predictionsSkipped) bits.push(`${summary.predictionsSkipped} skipped`);
-        toast(`Audit complete (${resp.model}) — ${bits.join(', ')}`,
+        const how = mode === 'per_module' ? 'thorough' : 'quick';
+        toast(`Audit complete (${how}, ${resp.model}) — ${bits.join(', ')}`,
             summary.modulesFailed ? 'warning' : 'success', 6000);
         await refreshAuditStatus();
     } catch (err) {

--- a/src/shared/audit/audit-prompt.js
+++ b/src/shared/audit/audit-prompt.js
@@ -1,0 +1,393 @@
+// X-Ray — in-extension epistemic auditor: prompt + tool + assembly
+// (Phase 13.x, the LLM execution path alongside the CLI import).
+//
+// PURE module: no network, no chrome, no DOM. It mirrors the CLI
+// scorer's contract so the two paths cannot drift:
+//   - the single-shot orchestrator methodology
+//     (docs/auditor-prototype/prompts/00-orchestrator-single-shot.md),
+//     collapsed into ONE model call that emits all eight modules;
+//   - the deterministic aggregate (weights + knowability ceiling +
+//     confidence stacking) ported VERBATIM from
+//     docs/auditor-prototype/scorer/scorer.js — the model NEVER supplies
+//     the aggregate score (PHILOSOPHY §4: the weights are public
+//     constants in the codebase, not a model's opinion);
+//   - the canonical `{article, module_results, predictions, aggregate}`
+//     shape that importAuditJson's firewall accepts.
+//
+// The LLM tool schema is built FROM findings-schemas.js's PAYLOADS, so
+// the model is guided by the exact shapes validateFindings enforces.
+//
+// Single-shot is the orchestrator's documented tradeoff: faster/cheaper,
+// lower rigor than independent per-module runs. Every module result
+// carries a standing caveat saying so (P12 transparency); no PHILOSOPHY
+// amendment is needed — §8 already makes a model a first-class auditor,
+// and methodology version stays 1.0 because the findings schemas are
+// unchanged.
+
+import { articleHash, normalizeForHash } from './article-hash.js';
+import {
+    PAYLOADS, MODULE_NAMES, CURRENT_MODULE_VERSIONS, SCOREABLE_MODULES
+} from './findings-schemas.js';
+
+export const AUDIT_TOOL_NAME = 'emit_audit';
+
+// The standing transparency caveat stamped on every in-extension run.
+export const STANDING_SINGLE_SHOT_CAVEAT =
+    'Single-shot orchestration: all eight dimensions were scored in one model pass, '
+    + 'which is faster but less rigorous than independent per-module audits. '
+    + 'Treat scores as a screening signal, not a verdict.';
+
+// The documented dimension weights — the CLI scorer's MODULE_WEIGHTS,
+// verbatim. Public constants, not a model's choice (PHILOSOPHY §4).
+export const MODULE_WEIGHTS = Object.freeze({
+    headline_body_fidelity: 0.15,
+    asymmetric_language:     0.15,
+    number_hygiene:          0.10,
+    source_quality:          0.20,
+    internal_coherence:      0.10,
+    definitional_precision:  0.10,
+    omission:                0.20
+});
+
+// One-line orientation per module for the tool schema (the deep
+// structure rides on the imported PAYLOADS shapes).
+const MODULE_BLURBS = {
+    headline_body_fidelity:
+        'Do the headline/subhead accurately preview the body, with proportional emphasis?',
+    asymmetric_language:
+        'Are verbs, adjectives, epithets, and framing applied symmetrically to comparable parties?',
+    number_hygiene:
+        'Do numerical claims carry denominators, base rates, and comparison classes where relevant?',
+    source_quality:
+        'Are sources named where possible, anonymity justified, contested claims multi-sourced, documents cited?',
+    internal_coherence:
+        'Is the article internally consistent across paragraphs, captions, and between claim and evidence?',
+    definitional_precision:
+        'Are contested terms defined or smuggled (e.g. "extremist", "violence", "expert", "moderate")?',
+    omission:
+        'Who is quoted, who is referenced but unheard, and who is conspicuously absent given the topic?',
+    prediction_extraction:
+        'Extract testable predictions (explicit or implicit). NOT scored — this feeds the ledger.'
+};
+
+// ------------------------------------------------------------------
+// Tool schema — built from PAYLOADS so it matches the validator
+// ------------------------------------------------------------------
+
+// One module's tool schema = its payload schema + the envelope fields
+// the model supplies (score/confidence for 01-07; auditor_caveats on
+// all). `module` and `version` are NOT asked of the model — they are
+// deterministic and injected at assembly, so the model can't dangle the
+// wire address with a wrong version.
+function moduleToolSchema(name) {
+    const payload = PAYLOADS[name];
+    const properties = { ...payload.properties };
+    const required = [...payload.required];
+
+    properties.auditor_caveats = {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'What an outsider surface-scan could NOT determine for this dimension. '
+            + 'Honest limits, not filler.'
+    };
+    required.push('auditor_caveats');
+
+    if (name !== 'prediction_extraction') {
+        properties.score = {
+            type: 'integer', minimum: 0, maximum: 100,
+            description: '0-100 calibrated score for this dimension. 90-100 exemplary; '
+                + '75-89 solid; 60-74 acceptable; 40-59 significant problems; '
+                + '20-39 severe; 0-19 catastrophic.'
+        };
+        properties.confidence = {
+            type: 'number', minimum: 0, maximum: 1,
+            description: '0.0-1.0 confidence in this score given how much is evaluable from the '
+                + 'article alone. Lower it where surface evaluation is structurally limited.'
+        };
+        required.push('score', 'confidence');
+    }
+
+    return {
+        type: 'object',
+        description: MODULE_BLURBS[name] || name,
+        properties,
+        required
+    };
+}
+
+/**
+ * The single forced tool. Its input is one object per module under
+ * `modules`, each conforming to its findings schema. The aggregate is
+ * computed in code, never asked of the model.
+ */
+export function buildAuditTool() {
+    const moduleProps = {};
+    for (const name of MODULE_NAMES) moduleProps[name] = moduleToolSchema(name);
+    return {
+        name: AUDIT_TOOL_NAME,
+        description:
+            'Emit the complete eight-dimension epistemic audit of the article. Provide every '
+            + 'dimension under `modules`, each matching its schema. Quote VERBATIM from the '
+            + 'article in every evidence field. Do NOT compute an overall/aggregate score — the '
+            + 'pipeline derives it from your per-dimension scores using fixed public weights.',
+        input_schema: {
+            type: 'object',
+            properties: {
+                modules: {
+                    type: 'object',
+                    description: 'One object per dimension. All eight are required.',
+                    properties: moduleProps,
+                    required: MODULE_NAMES.slice()
+                }
+            },
+            required: ['modules']
+        }
+    };
+}
+
+// ------------------------------------------------------------------
+// Prompts — the orchestrator methodology, adapted for tool output
+// ------------------------------------------------------------------
+
+/**
+ * System prompt: the orchestrator's governing principles + scoring
+ * calibration, pointed at the emit_audit tool. The per-dimension
+ * definitions live in the tool schema descriptions, so they cannot
+ * drift from the shapes the validator enforces.
+ */
+export function buildAuditSystemPrompt({ url = '', title = '' } = {}) {
+    const meta = (title || url)
+        ? `\nArticle under audit: ${title ? `"${title}"` : ''}${url ? ` <${url}>` : ''}`
+        : '';
+    return `You are X-Ray's epistemic auditor. You evaluate a published news article against eight transparent dimensions of journalistic quality. You are an OUTSIDER applying surface-detectable standards — you cannot re-report the story, only examine the published artifact.${meta}
+
+GOVERNING PRINCIPLES (non-negotiable):
+- Evidence-bound. Every finding must quote specific text from the article, verbatim. Never paraphrase inside an evidence quote; copy it character for character so it can be located on the page.
+- Knowability-aware. If a dimension cannot be reliably evaluated from the article alone (e.g. source quality on a classified-intelligence story), say so in that dimension's auditor_caveats and lower its confidence rather than guessing.
+- Symmetric. Apply identical standards regardless of the article's political valence, subject, or author.
+- Calibrated. Express uncertainty honestly. A confident wrong score harms credibility more than a hedged one.
+- No reformulation. Do not rewrite the article into a charitable version before scoring. Score what was published.
+
+SCORING (dimensions 1-7 only; prediction_extraction is NOT scored):
+- 90-100 exemplary, affirmative best practice visible; 75-89 solid, minor issues; 60-74 acceptable with noticeable concerns; 40-59 significant problems; 20-39 severe; 0-19 catastrophic.
+- Each scored dimension also gets a confidence 0.0-1.0 reflecting how much is evaluable from the article alone.
+
+OUTPUT:
+- Use the ${AUDIT_TOOL_NAME} tool and nothing else. Fill every dimension under \`modules\`, each matching its schema.
+- For prediction_extraction, extract testable predictions and their resolution criteria; do NOT score it.
+- Do NOT compute an overall or aggregate score — the pipeline derives it from your per-dimension scores using fixed public weights and a knowability ceiling.`;
+}
+
+/** The user turn: the article markdown the auditor evaluates. */
+export function buildAuditUserPrompt({ articleText = '' } = {}) {
+    return `Audit the following article. Quote verbatim; be symmetric; lower confidence where surface evaluation is limited.\n\n---\n${articleText}\n---`;
+}
+
+// ------------------------------------------------------------------
+// Assembly: tool output → canonical scorer-export shape
+// ------------------------------------------------------------------
+
+/**
+ * Walk a findings object and collect every evidence_quote / _a / _b into
+ * a deduplicated list of {quote}. The CLI scorer's collectEvidenceQuotes,
+ * verbatim, so the reader's "Evidence quotes (click to locate)" strip is
+ * populated identically on both paths.
+ */
+export function collectEvidenceQuotes(findings) {
+    const quotes = new Set();
+    (function walk(node) {
+        if (node === null || typeof node !== 'object') return;
+        if (Array.isArray(node)) { node.forEach(walk); return; }
+        for (const [k, v] of Object.entries(node)) {
+            if ((k === 'evidence_quote' || k === 'evidence_quote_a' || k === 'evidence_quote_b')
+                && typeof v === 'string') {
+                quotes.add(v);
+            } else {
+                walk(v);
+            }
+        }
+    })(findings);
+    return [...quotes].map((quote) => ({ quote }));
+}
+
+// The deterministic aggregate — scorer.js aggregate(), ported. The
+// knowability ceiling is derived from source_quality's summary counts;
+// the weighted score uses only the scoreable modules; confidence stacks
+// (min × success fraction). The model contributes NONE of this.
+function buildAggregate({ hash, byModule, model, runAt }) {
+    const sourceResult = byModule.source_quality;
+    let knowabilityCeiling = 95;
+    let knowabilityNotes = 'Default ceiling; source_quality findings unavailable.';
+
+    if (sourceResult && !sourceResult._error && sourceResult.findings && sourceResult.findings.summary) {
+        const s = sourceResult.findings.summary;
+        const totalSources = s.total_sources || 0;
+        const namedRatio = totalSources > 0 ? (s.named_count || 0) / totalSources : 0;
+        const anonymousJustifiedRatio = totalSources > 0 ? (s.anonymous_justified_count || 0) / totalSources : 0;
+        const anonymousBareRatio = totalSources > 0
+            ? ((s.anonymous_count || 0) - (s.anonymous_justified_count || 0)) / totalSources
+            : 0;
+        const docsLinkedRatio = (s.documents_cited || 0) > 0
+            ? (s.documents_specifically_identified || 0) / s.documents_cited
+            : 1;
+        knowabilityCeiling = Math.round(
+            60 + 25 * namedRatio + 10 * docsLinkedRatio + 5 * anonymousJustifiedRatio - 15 * anonymousBareRatio
+        );
+        knowabilityCeiling = Math.max(40, Math.min(98, knowabilityCeiling));
+        knowabilityNotes =
+            `Ceiling derived from sourcing pattern: ${Math.round(namedRatio * 100)}% named, `
+            + `${Math.round(anonymousBareRatio * 100)}% bare anonymous, `
+            + `${Math.round(docsLinkedRatio * 100)}% of documents specifically identified.`;
+    }
+
+    let weightedSum = 0;
+    let totalWeightApplied = 0;
+    const moduleContributions = [];
+    for (const m of SCOREABLE_MODULES) {
+        const r = byModule[m];
+        const weight = MODULE_WEIGHTS[m];
+        if (!r || r._error || typeof r.score !== 'number') {
+            moduleContributions.push({ module: m, module_result_id: null, score: null, confidence: 0, weight: 0 });
+            continue;
+        }
+        weightedSum += r.score * weight;
+        totalWeightApplied += weight;
+        moduleContributions.push({
+            module: m, module_result_id: null,
+            score: r.score, confidence: typeof r.confidence === 'number' ? r.confidence : 0.5, weight
+        });
+    }
+
+    const rawWeighted = totalWeightApplied > 0 ? weightedSum / totalWeightApplied : 0;
+    const ceilingBinding = rawWeighted > knowabilityCeiling;
+    const finalScore = Math.min(rawWeighted, knowabilityCeiling);
+
+    const successful = moduleContributions.filter((c) => c.score !== null);
+    const minConfidence = successful.length ? Math.min(...successful.map((c) => c.confidence)) : 0;
+    const successFraction = successful.length / SCOREABLE_MODULES.length;
+    const overallConfidence = Number((minConfidence * successFraction).toFixed(2));
+
+    const topStrengths = [];
+    const topConcerns = [];
+    for (const m of SCOREABLE_MODULES) {
+        const r = byModule[m];
+        if (!r || r._error || typeof r.score !== 'number') continue;
+        if (r.score >= 85) topStrengths.push(`${m}: ${r.score}`);
+        if (r.score <= 55) topConcerns.push(`${m}: ${r.score}`);
+    }
+
+    return {
+        article_hash: hash,
+        auditor: {
+            kind: 'pipeline',
+            id: `xray-auditor-inext/anthropic/${model}`,
+            display_name: 'X-Ray Epistemic Auditor (in-extension, single-shot)',
+            constituents: SCOREABLE_MODULES.map((m) => ({ kind: 'model', id: `anthropic/${model}` }))
+        },
+        run_at: runAt,
+        module_contributions: moduleContributions,
+        knowability_ceiling: knowabilityCeiling,
+        knowability_notes: knowabilityNotes,
+        raw_weighted_score: Number(rawWeighted.toFixed(1)),
+        final_score: Number(finalScore.toFixed(1)),
+        ceiling_binding: ceilingBinding,
+        // The ceiling is derived from source_quality — name that provenance
+        // explicitly (importAuditJson would otherwise default it).
+        ceiling_source: 'heuristic:source-quality/1.0',
+        overall_confidence: overallConfidence,
+        top_strengths: topStrengths,
+        top_concerns: topConcerns,
+        disputes: []
+    };
+}
+
+/**
+ * Transform one emit_audit tool output into the canonical scorer-export
+ * object importAuditJson accepts: {article, module_results, predictions,
+ * aggregate}. Deterministic and async only because the article hash is.
+ *
+ * @param {object} params
+ * @param {object} params.toolInput  the emit_audit tool_use input
+ * @param {string} params.model      the model id used (provenance)
+ * @param {string} params.markdown   the article body markdown (the SAME
+ *                                   text the reader hashes — the hash
+ *                                   gate matches it against the capture)
+ * @param {object} [params.metadata] headline / byline / url / etc.
+ * @returns {Promise<{article, module_results, predictions, aggregate}>}
+ */
+export async function assembleAudit({ toolInput, model, markdown, metadata = {} }) {
+    const modulesIn = (toolInput && typeof toolInput.modules === 'object' && toolInput.modules) || {};
+    const normalized = normalizeForHash(markdown);
+    const hash = await articleHash(markdown);
+    const runAt = new Date().toISOString();
+    const auditorModel = { kind: 'model', id: `anthropic/${model}` };
+
+    const moduleResults = [];
+    for (const name of MODULE_NAMES) {
+        const version = CURRENT_MODULE_VERSIONS[name];
+        const raw = modulesIn[name];
+
+        // Absent module → a FAILED result so the run still imports and
+        // the gap is visible (the scorer's per-module failure posture).
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+            moduleResults.push({
+                article_hash: hash, module: name, module_version: version,
+                auditor: auditorModel, run_at: runAt, score: null, confidence: null,
+                findings: { error: 'module absent from model output' },
+                evidence_quotes: [],
+                auditor_caveats: [STANDING_SINGLE_SHOT_CAVEAT, 'module absent from model output'],
+                _error: true
+            });
+            continue;
+        }
+
+        // Build the findings envelope. module/version are injected (never
+        // model-supplied) so the wire address can't dangle.
+        const findings = { module: name, version, ...raw };
+        if (name === 'prediction_extraction') {
+            // 08 is unscored — score/confidence are forbidden in findings.
+            delete findings.score;
+            delete findings.confidence;
+        }
+
+        const caveats = Array.isArray(raw.auditor_caveats) ? raw.auditor_caveats.slice() : [];
+        if (!caveats.includes(STANDING_SINGLE_SHOT_CAVEAT)) caveats.unshift(STANDING_SINGLE_SHOT_CAVEAT);
+        findings.auditor_caveats = caveats;
+
+        const score = typeof findings.score === 'number' ? findings.score : null;
+        const confidence = typeof findings.confidence === 'number' ? findings.confidence : null;
+
+        moduleResults.push({
+            article_hash: hash, module: name, module_version: version,
+            auditor: auditorModel, run_at: runAt,
+            // Wrapper score/version are set EQUAL to findings' so import's
+            // tamper check (top-level vs findings) passes cleanly.
+            score, confidence, findings,
+            evidence_quotes: collectEvidenceQuotes(findings),
+            auditor_caveats: caveats
+        });
+    }
+
+    const byModule = Object.fromEntries(moduleResults.map((r) => [r.module, r]));
+
+    const predModule = modulesIn.prediction_extraction;
+    const predictions = (predModule && Array.isArray(predModule.predictions)) ? predModule.predictions : [];
+
+    const aggregate = buildAggregate({ hash, byModule, model, runAt });
+
+    const article = {
+        hash,
+        source_url: metadata.source_url || metadata.url || null,
+        headline: metadata.headline || metadata.title || null,
+        subhead: metadata.subhead || null,
+        byline_raw: metadata.byline || null,
+        author_ids: [],
+        publication_id: metadata.publication_id || null,
+        publication_date: metadata.publication_date || null,
+        language: metadata.language || 'en',
+        word_count: normalized.split(/\s+/).filter(Boolean).length,
+        body_markdown: normalized
+    };
+
+    return { article, module_results: moduleResults, predictions, aggregate };
+}

--- a/src/shared/audit/audit-prompt.js
+++ b/src/shared/audit/audit-prompt.js
@@ -28,6 +28,7 @@ import { articleHash, normalizeForHash } from './article-hash.js';
 import {
     PAYLOADS, MODULE_NAMES, CURRENT_MODULE_VERSIONS, SCOREABLE_MODULES
 } from './findings-schemas.js';
+import { MODULE_PROMPTS } from './module-prompts.js';
 
 export const AUDIT_TOOL_NAME = 'emit_audit';
 
@@ -184,6 +185,39 @@ export function buildAuditUserPrompt({ articleText = '' } = {}) {
 }
 
 // ------------------------------------------------------------------
+// Per-module ("thorough") path: one call per dimension, each with its
+// FULL vendored methodology prompt and its own output budget — the
+// orchestrator doc's production recommendation. Output shape is forced
+// by a single-module tool (built from the same PAYLOADS).
+// ------------------------------------------------------------------
+
+/** A tool that emits ONE module's findings (envelope + payload). */
+export function buildSingleModuleTool(name) {
+    return {
+        name: `emit_${name}`,
+        description: `Emit the ${name} audit findings for the article, matching the schema. `
+            + 'Quote VERBATIM from the article in every evidence field.',
+        input_schema: moduleToolSchema(name)
+    };
+}
+
+/**
+ * System prompt for one module: the vendored 01-08 methodology verbatim,
+ * pointed at that module's tool. This is the rigor the single-shot prompt
+ * trades away — the full step-numbered methodology, one dimension at a time.
+ */
+export function buildModuleSystemPrompt(name, { url = '', title = '' } = {}) {
+    const methodology = MODULE_PROMPTS[name] || '';
+    const meta = (title || url)
+        ? `\n\nArticle under audit: ${title ? `"${title}"` : ''}${url ? ` <${url}>` : ''}`
+        : '';
+    const scored = name === 'prediction_extraction'
+        ? 'This module is NOT scored — do not emit a score or confidence.'
+        : 'Provide the 0-100 score and 0.0-1.0 confidence the methodology describes.';
+    return `${methodology}${meta}\n\nOUTPUT: use the emit_${name} tool and nothing else; fill its fields to match the schema rather than returning prose or JSON. Quote VERBATIM from the article in every evidence field. ${scored}`;
+}
+
+// ------------------------------------------------------------------
 // Assembly: tool output → canonical scorer-export shape
 // ------------------------------------------------------------------
 
@@ -313,9 +347,12 @@ function buildAggregate({ hash, byModule, model, runAt }) {
  *                                   text the reader hashes — the hash
  *                                   gate matches it against the capture)
  * @param {object} [params.metadata] headline / byline / url / etc.
+ * @param {string|null} [params.standingCaveat] a caveat prepended to every
+ *   module (the single-shot path passes its lower-rigor disclosure; the
+ *   per-module path passes null — there is nothing to apologize for).
  * @returns {Promise<{article, module_results, predictions, aggregate}>}
  */
-export async function assembleAudit({ toolInput, model, markdown, metadata = {} }) {
+export async function assembleAudit({ toolInput, model, markdown, metadata = {}, standingCaveat = null }) {
     const modulesIn = (toolInput && typeof toolInput.modules === 'object' && toolInput.modules) || {};
     const normalized = normalizeForHash(markdown);
     const hash = await articleHash(markdown);
@@ -330,12 +367,15 @@ export async function assembleAudit({ toolInput, model, markdown, metadata = {} 
         // Absent module → a FAILED result so the run still imports and
         // the gap is visible (the scorer's per-module failure posture).
         if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+            const absentCaveats = standingCaveat
+                ? [standingCaveat, 'module absent from model output']
+                : ['module absent from model output'];
             moduleResults.push({
                 article_hash: hash, module: name, module_version: version,
                 auditor: auditorModel, run_at: runAt, score: null, confidence: null,
                 findings: { error: 'module absent from model output' },
                 evidence_quotes: [],
-                auditor_caveats: [STANDING_SINGLE_SHOT_CAVEAT, 'module absent from model output'],
+                auditor_caveats: absentCaveats,
                 _error: true
             });
             continue;
@@ -351,7 +391,7 @@ export async function assembleAudit({ toolInput, model, markdown, metadata = {} 
         }
 
         const caveats = Array.isArray(raw.auditor_caveats) ? raw.auditor_caveats.slice() : [];
-        if (!caveats.includes(STANDING_SINGLE_SHOT_CAVEAT)) caveats.unshift(STANDING_SINGLE_SHOT_CAVEAT);
+        if (standingCaveat && !caveats.includes(standingCaveat)) caveats.unshift(standingCaveat);
         findings.auditor_caveats = caveats;
 
         const score = typeof findings.score === 'number' ? findings.score : null;

--- a/src/shared/audit/findings-schemas.js
+++ b/src/shared/audit/findings-schemas.js
@@ -51,8 +51,13 @@ function obj(properties, required = []) { return { type: 'object', properties, r
 function strArr() { return arr(str()); }
 
 // --- per-module payload schemas (beyond the shared envelope) ----------------
+//
+// Exported so the in-extension auditor's LLM tool schema
+// (audit-prompt.js) is BUILT FROM these exact shapes — the model is
+// guided by the same definitions the validator enforces, so a clean
+// pass imports without failing. One source of truth, no drift.
 
-const PAYLOADS = {
+export const PAYLOADS = {
     headline_body_fidelity: obj({
         headline: quote(),
         subhead: nullableStr(),

--- a/src/shared/audit/module-prompts.js
+++ b/src/shared/audit/module-prompts.js
@@ -1,0 +1,770 @@
+// X-Ray — vendored per-module audit methodology prompts.
+//
+// GENERATED, verbatim, from docs/auditor-prototype/prompts/01-08 (the
+// instruction portion before each file's "# ARTICLE" marker — exactly the
+// CLI scorer's loadPrompt() slice). The extension can't read docs/ at
+// runtime, so the per-module ("thorough") auditor vendors them here. These
+// are the SAME methodology the findings schemas were derived from; the
+// single-shot orchestrator uses a condensed summary instead.
+//
+// To regenerate after editing a prompt: node tools/gen-module-prompts.mjs
+//
+// Imported only by the background service worker (the audit runner), so it
+// never weighs down the reader bundle.
+
+export const MODULE_PROMPTS = Object.freeze({
+    headline_body_fidelity:
+`# Module 01 — Headline-Body Fidelity
+
+**Purpose:** Determine whether the article's headline (and subhead, if present) accurately previews the body's actual content with proportional emphasis. This is the single most-cheated dimension in modern journalism and is detectable in seconds from the published artifact alone.
+
+**Input:** Article markdown including headline, subhead (if any), byline, and body.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Headline-Body Fidelity check on a news article.
+
+# Methodology
+
+1. **Read the headline (and subhead) ALONE.** Do not look at the body yet. List every claim or implication a reasonable reader would take from the headline. Categorize each as factual, causal, evaluative, or predictive. Mark whether the implied strength is definite, likely, or hedged.
+
+2. **Now read the body.** For each headline implication, locate the supporting (or contradicting) text and quote it exactly. If support is absent, say so.
+
+3. **Score each implication's support status:** \`supported\`, \`partially_supported\`, \`unsupported\`, or \`contradicted\`.
+
+4. **Identify structural issues:**
+   - Buried qualifications (key hedge appears in paragraph 8+)
+   - Inverted emphasis (the actual lead fact is buried)
+   - Clickbait framing (headline poses a question or makes a claim the body cannot deliver)
+   - Implicit-actor switching (headline ascribes action to one party, body reveals another)
+   - Tense or modality drift (headline asserts what body says was alleged, expected, or possible)
+
+5. **Compute an overall fidelity score 0–100:**
+   - **90–100:** Every implication is fully supported with proportional emphasis.
+   - **75–89:** Minor mismatches; small hedge gaps or proportional emphasis quibbles.
+   - **60–74:** Noticeable gaps; the headline overstates or compresses meaningfully.
+   - **40–59:** Significant mismatches; a careful reader of the body would not write this headline.
+   - **20–39:** Severe; the headline materially misleads.
+   - **0–19:** The headline contradicts or has no relationship to the body's actual claims.
+
+6. **Confidence (0.0–1.0):** Lower confidence if the body is truncated, paywalled, or relies on visual/multimedia content you cannot evaluate.
+
+# Output
+
+Return only this JSON, no preamble, no markdown fences:
+
+\`\`\`json
+{
+  "module": "headline_body_fidelity",
+  "version": "1.0",
+  "headline": "<exact headline>",
+  "subhead": "<exact subhead or null>",
+  "headline_implications": [
+    {
+      "id": 0,
+      "implication": "<what a reader takes from the headline>",
+      "type": "factual" | "causal" | "evaluative" | "predictive",
+      "implied_strength": "definite" | "likely" | "hedged"
+    }
+  ],
+  "body_findings": [
+    {
+      "implication_id": 0,
+      "support_status": "supported" | "partially_supported" | "unsupported" | "contradicted",
+      "evidence_quote": "<exact quote from body, or null>",
+      "notes": "<1-2 sentence assessment>"
+    }
+  ],
+  "structural_issues": [
+    {
+      "type": "buried_qualification" | "inverted_emphasis" | "clickbait_framing" | "actor_switching" | "modality_drift" | "other",
+      "description": "<what was found>",
+      "evidence_quote": "<exact quote>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this surface scan cannot determine>"]
+}
+\`\`\`
+
+---`,
+
+    asymmetric_language:
+`# Module 02 — Asymmetric Language Detection
+
+**Purpose:** Detect framing asymmetry — different verbs, adjectives, or rhetorical treatment applied to comparable parties or actions. This is almost always invisible to the writer and detectable to a reader scanning for it.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing an Asymmetric Language check on a news article.
+
+# Methodology
+
+1. **Identify the parties.** List every named party, faction, country, institution, or movement that appears in adversarial, contrasting, or comparable roles within the article. (If there is no contrast structure, the article scores 100 by default.)
+
+2. **For each party, extract the language applied to them:**
+   - Verbs (especially of action, speech, and motivation)
+   - Adjectives and adjectival phrases
+   - Epithets, labels, or category terms (e.g., "extremist," "moderate," "experts," "officials")
+   - Sourcing verbs ("said," "claimed," "explained," "alleged," "admitted")
+
+3. **Compare the language across parties for asymmetry on these dimensions:**
+   - **Action verbs:** Does one party "lash out" while the other "responds"? Does one "attack" while the other "defends"? Does one "claim" while the other "explains"?
+   - **Motivation attribution:** Are motives assigned to one party but not the other? Is one party's behavior explained while the other's is treated as self-evidently bad?
+   - **Epithets and labels:** Is one side labeled with a contested term (e.g., "extremist," "radical") while the other gets a neutral term (e.g., "activist," "advocate")?
+   - **Sourcing verbs:** Does one party "say" while the other "claims" or "alleges"?
+   - **Visibility of agency:** Is one party's action described in active voice ("X attacked Y") while another's is described in passive voice ("Z were killed")?
+   - **Quantitative framing:** Are similar numbers framed differently for different parties (e.g., "only" vs "as many as")?
+
+4. **Score 0–100:**
+   - **90–100:** Symmetric or essentially symmetric treatment. Any small asymmetries are explainable by the actual asymmetry of the events.
+   - **75–89:** Minor asymmetries; possibly unintentional word choice.
+   - **60–74:** Noticeable patterns; multiple asymmetric word choices in the same direction.
+   - **40–59:** Systematic asymmetric framing visible across multiple dimensions.
+   - **20–39:** Severe; the article reads as advocacy through word choice.
+   - **0–19:** Pure rhetorical framing; the language alone tells the reader who to side with.
+
+5. **Confidence (0.0–1.0):** Lower confidence on articles where there is genuinely asymmetric reality being reported (e.g., reporting on a confirmed atrocity by one party). Asymmetric language can be appropriate when the underlying facts are asymmetric.
+
+# Important caveat
+
+Asymmetry in language is not always wrong. If party A has been convicted of a crime and party B has not, different verbs may be appropriate. The standard is *unjustified* asymmetry — language choices that pre-stage a conclusion the article has not earned through evidence. Note when asymmetry tracks established fact versus when it simply tilts the framing.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "asymmetric_language",
+  "version": "1.0",
+  "has_contrast_structure": true | false,
+  "parties_identified": [
+    {
+      "name": "<party name>",
+      "role": "<their role in the contrast>"
+    }
+  ],
+  "language_applied": [
+    {
+      "party": "<party name>",
+      "verbs": ["<verb 1>", "<verb 2>"],
+      "adjectives": ["<adj 1>"],
+      "epithets_or_labels": ["<label 1>"],
+      "sourcing_verbs": ["<verb>"]
+    }
+  ],
+  "asymmetry_findings": [
+    {
+      "dimension": "action_verbs" | "motivation_attribution" | "epithets" | "sourcing_verbs" | "voice_agency" | "quantitative_framing",
+      "party_a": "<name>",
+      "party_a_term": "<word/phrase>",
+      "party_b": "<name>",
+      "party_b_term": "<word/phrase>",
+      "evidence_quote_a": "<exact quote>",
+      "evidence_quote_b": "<exact quote>",
+      "justified_by_underlying_facts": true | false,
+      "justification_notes": "<if justified, why>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+\`\`\`
+
+---`,
+
+    number_hygiene:
+`# Module 03 — Number Hygiene
+
+**Purpose:** Audit every numerical claim in the article against three tests: does it have a denominator (where ratio matters), a base rate (for comparison to background), and a comparison class (versus what)? Most numbers in news fail at least one.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Number Hygiene check on a news article.
+
+# Methodology
+
+1. **Extract every numerical claim** in the article body. This includes:
+   - Counts and totals ("400 people attended")
+   - Percentages and ratios ("up 40%")
+   - Dollar/currency amounts
+   - Dates and timeframes used as evidence
+   - Comparisons ("twice as many," "the largest in a decade")
+   - Probabilities and forecasts
+   - Survey/poll results
+   - Rankings and rates
+
+2. **For each numerical claim, apply three tests:**
+
+   - **Denominator test:** When the claim is a count or change, is the relevant total or population provided? "400 arrests" without "out of how many encounters" or "compared to how many last year" fails this test. "400 of 1,200 protests resulted in arrests" passes.
+
+   - **Base rate test:** Is the historical or contextual baseline provided? "Crime up 40%" without prior years' levels, the long-run trend, or the absolute number fails. "Crime up 40% from a 30-year low" passes (and is a different story).
+
+   - **Comparison class test:** Is the comparison set defined and appropriate? "The largest in a decade" — largest *what*, in *which* category, by *which* measure? "$2 billion in damages — comparable to the 2018 fires which caused $X billion" passes; "$2 billion — a staggering sum" fails.
+
+3. **Note additional issues where present:**
+   - Cherry-picked timeframe (start/end dates chosen to maximize the apparent change)
+   - Survivorship bias (sample excludes relevant cases)
+   - Causation implied without evidence ("after X policy, Y rose")
+   - Precision mismatch (precise numbers reported with vague sourcing)
+   - Conflation of stocks and flows
+   - Aggregation hiding distribution (averages without ranges; totals without per-capita)
+
+4. **Score 0–100:**
+   - **90–100:** Numbers consistently contextualized with appropriate denominators, base rates, and comparisons.
+   - **75–89:** Most numbers contextualized; minor gaps.
+   - **60–74:** Mixed; some numbers well-handled, others bare.
+   - **40–59:** Most numerical claims fail at least one test.
+   - **20–39:** Numbers used rhetorically, with little context.
+   - **0–19:** Numbers function purely as emotional triggers; no numerate reader could derive meaning from them.
+
+5. **Confidence (0.0–1.0):** Lower if the article relies heavily on charts or tables you cannot evaluate.
+
+# Important note
+
+Not every number needs all three tests. A weather report saying "high of 78°F" needs no denominator. Apply the tests only where they are *relevant* to the claim's interpretive weight. The judgment call is whether a numerate reader could be misled by what's missing.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "number_hygiene",
+  "version": "1.0",
+  "numerical_claims": [
+    {
+      "id": 0,
+      "claim": "<the claim as it appears in context>",
+      "value": "<the number>",
+      "context": "<short summary of what the number is purporting to demonstrate>",
+      "denominator_test": "passed" | "failed" | "not_applicable",
+      "base_rate_test": "passed" | "failed" | "not_applicable",
+      "comparison_class_test": "passed" | "failed" | "not_applicable",
+      "additional_issues": ["cherry_picked_timeframe", "implied_causation", "precision_mismatch", "..."],
+      "evidence_quote": "<exact quote>",
+      "notes": "<what's done well or missing>"
+    }
+  ],
+  "summary": {
+    "total_claims": <integer>,
+    "claims_failing_at_least_one_test": <integer>,
+    "most_common_failure": "denominator" | "base_rate" | "comparison_class" | "none"
+  },
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+\`\`\`
+
+---`,
+
+    source_quality:
+`# Module 04 — Source Quality Audit
+
+**Purpose:** Count and classify every source the article uses; identify contested claims that rest on inadequate sourcing; check whether anonymous sourcing is justified and whether primary documents (when cited) are linked or quoted.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Source Quality audit on a news article.
+
+# Methodology
+
+1. **Identify every source the article relies on.** A "source" is anyone or anything providing factual claims, including:
+   - Named individuals quoted or paraphrased
+   - Anonymous individuals (with or without justification)
+   - Documents (court filings, government reports, leaked memos)
+   - Studies and data (peer-reviewed, working papers, datasets)
+   - Other media outlets (cited or republished)
+   - Vague attributions ("experts say," "officials told reporters," "according to people familiar with the matter")
+
+2. **Classify each source** into one of these categories:
+   - \`named_primary\` — Named, directly involved, on the record (e.g., a quoted official with relevant authority)
+   - \`named_secondary\` — Named, but commenting on events they were not directly part of (e.g., academics, analysts)
+   - \`anonymous_justified\` — Anonymous with stated justification ("granted anonymity to discuss internal deliberations") AND with the source's relationship to the matter described
+   - \`anonymous_bare\` — Anonymous with no justification or only a vague description
+   - \`document_cited\` — Specific document referenced; ideally linked or quoted
+   - \`study_cited\` — Specific study referenced; ideally with author, journal, date
+   - \`expert_says_vague\` — Group attributions without specific individuals ("experts say," "many believe")
+
+3. **Map sources to the claims they support.** For each major factual claim in the article, identify which sources back it.
+
+4. **Identify single-sourced contested claims.** A "contested claim" is any claim that:
+   - Other parties named in the article would likely dispute
+   - Concerns motivation, intent, or private knowledge
+   - Concerns events the source was not directly party to
+   - Is presented as fact but is reasonably subject to dispute
+
+   Single-sourcing such claims (especially via anonymous or vague sources) is a serious sourcing failure.
+
+5. **Evaluate anonymous sourcing justification.** When sources are anonymous, the article should say *why* anonymity was granted (e.g., "because they were not authorized to speak publicly") and describe the source's relationship to the matter ("a senior official at X department"). Bare anonymity ("a source said") fails this standard.
+
+6. **Evaluate primary source linking.** When the article cites documents, studies, or data, are they linked, quoted, or specifically identified such that a reader could retrieve them? Or are they characterized only by the article's framing?
+
+7. **Score 0–100:**
+   - **90–100:** Sources are predominantly named and primary; anonymous sourcing is sparse, justified, and described; documents are linked or quoted; contested claims are multi-sourced.
+   - **75–89:** Mostly named sourcing; anonymous sources justified; some documents linked.
+   - **60–74:** Mixed; reliance on \`expert_says_vague\` or unjustified anonymous sourcing in non-contested areas.
+   - **40–59:** Multiple contested claims rest on anonymous or vague sourcing without justification.
+   - **20–39:** Article essentially built on anonymous sourcing or single-sourced contested claims.
+   - **0–19:** No identifiable sourcing for major claims, or sources presented in ways that prevent reader verification.
+
+8. **Confidence (0.0–1.0):** Lower confidence on stories where anonymous sourcing may be genuinely necessary (national security, internal corporate matters, personal safety) and where the underlying sourcing quality is unverifiable from the article alone.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "source_quality",
+  "version": "1.0",
+  "sources": [
+    {
+      "id": 0,
+      "label": "<short identifier, e.g., 'unnamed senior official' or 'Sarah Chen, professor at MIT'>",
+      "type": "named_primary" | "named_secondary" | "anonymous_justified" | "anonymous_bare" | "document_cited" | "study_cited" | "expert_says_vague",
+      "anonymity_justification": "<exact quote, or null if not anonymous>",
+      "relationship_to_matter": "<as described in article>",
+      "evidence_quote": "<exact quote where source is introduced>"
+    }
+  ],
+  "claim_to_source_map": [
+    {
+      "claim": "<the factual claim>",
+      "source_ids": [0, 2],
+      "is_contested": true | false,
+      "contested_reason": "<why this claim is disputable, or null>",
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "single_sourced_contested_claims": [
+    {
+      "claim": "<the claim>",
+      "source_id": 0,
+      "source_type": "anonymous_bare" | "named_secondary" | "...",
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "primary_documents": [
+    {
+      "document": "<what document>",
+      "linked_or_quoted": true | false,
+      "specific_enough_to_retrieve": true | false,
+      "evidence_quote": "<exact quote>"
+    }
+  ],
+  "summary": {
+    "total_sources": <integer>,
+    "named_count": <integer>,
+    "anonymous_count": <integer>,
+    "anonymous_justified_count": <integer>,
+    "expert_says_vague_count": <integer>,
+    "documents_cited": <integer>,
+    "documents_specifically_identified": <integer>
+  },
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine, e.g., 'cannot verify the actual quality of anonymous sources from the article alone'>"]
+}
+\`\`\`
+
+---`,
+
+    internal_coherence:
+`# Module 05 — Internal Coherence
+
+**Purpose:** Detect contradictions and inconsistencies within the article itself — between paragraphs, between text and any embedded data references, between framing and evidence. Internal incoherence is the cheapest signal of editorial sloppiness or motivated framing.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing an Internal Coherence check on a news article.
+
+# Methodology
+
+1. **Read the full article carefully**, building a mental model of every factual, causal, and evaluative claim.
+
+2. **Look for contradictions of these types:**
+
+   - **Factual contradiction:** Two statements that cannot both be true. ("The protest had 5,000 attendees." Later: "The crowd of several hundred...")
+   - **Numerical contradiction:** Numbers that don't reconcile. (Sum of subgroup totals doesn't match the stated total; percentages add to more than 100; chart caption disagrees with text.)
+   - **Causal contradiction:** Cause-and-effect chains that conflict. ("X happened because of Y." Later: "Z, which began before Y, caused X.")
+   - **Tonal/evaluative contradiction:** Different emotional or evaluative framings of the same event in different parts of the article.
+   - **Modality contradiction:** Claim asserted as fact in one place and as allegation, possibility, or denial in another.
+   - **Quote-paraphrase contradiction:** A direct quote that doesn't support the article's paraphrase or characterization of it.
+   - **Caption-text contradiction:** Image or chart captions that contradict the body text.
+   - **Lead-body contradiction:** The lede frames the story one way; the body's content supports a different (often more nuanced or contrary) framing.
+
+3. **Look for logical inconsistencies even without direct contradiction:**
+   - Conclusions that don't follow from the evidence presented
+   - Claims that prove too much or too little
+   - Premises that, if true, would undermine the article's framing
+
+4. **Distinguish genuine contradiction from intentional dialectic.** A piece that fairly presents two opposing views and notes the conflict is not internally incoherent — that's the article doing its job. A piece that asserts both views as its own factual frame is.
+
+5. **Score 0–100:**
+   - **90–100:** Internally coherent throughout; any tensions are explicitly flagged and contextualized.
+   - **75–89:** Minor inconsistencies; possibly editing artifacts.
+   - **60–74:** Noticeable contradictions or logical gaps that a careful reader would catch.
+   - **40–59:** Multiple significant inconsistencies; framing not supported by article's own content.
+   - **20–39:** Severe; the article's own evidence contradicts its conclusions.
+   - **0–19:** The article actively confuses or misleads through internal contradiction.
+
+6. **Confidence (0.0–1.0):** Lower confidence on long articles, articles relying heavily on charts/images you cannot evaluate, or articles in highly technical domains where apparent contradiction may reflect specialized usage.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "internal_coherence",
+  "version": "1.0",
+  "contradictions": [
+    {
+      "type": "factual" | "numerical" | "causal" | "tonal" | "modality" | "quote_paraphrase" | "caption_text" | "lead_body",
+      "claim_a": "<first claim>",
+      "claim_b": "<contradicting claim>",
+      "evidence_quote_a": "<exact quote>",
+      "evidence_quote_b": "<exact quote>",
+      "is_dialectic_intent": true | false,
+      "severity": "low" | "medium" | "high",
+      "notes": "<short explanation>"
+    }
+  ],
+  "logical_gaps": [
+    {
+      "description": "<the gap>",
+      "evidence_quote": "<exact quote>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+\`\`\`
+
+---`,
+
+    definitional_precision:
+`# Module 06 — Definitional Precision
+
+**Purpose:** Identify contested terms used in the article and check whether they are defined or smuggled. Undefined contested terms quietly prefigure conclusions; defining them forces the writer to make explicit what would otherwise be assumed.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing a Definitional Precision check on a news article.
+
+# Methodology
+
+1. **Identify contested terms** the article uses to characterize events, parties, or concepts. A term is "contested" when reasonable people disagree about what it means or when it applies. Examples:
+
+   - **Political/social:** "extremist," "moderate," "radical," "mainstream," "fringe," "patriot," "insurgent," "terrorist," "freedom fighter," "activist," "advocate"
+   - **Action-characterizing:** "violence," "peaceful protest," "riot," "uprising," "crackdown," "intervention," "invasion"
+   - **Epistemic authority:** "expert," "scientist," "researcher," "official," "spokesperson"
+   - **Quantitative-sounding but vague:** "many," "most," "few," "some," "widespread," "rare," "growing," "declining"
+   - **Economic:** "inflation," "recession," "growth," "stimulus," "austerity," "free market," "regulation"
+   - **Identity:** "left," "right," "progressive," "conservative," "liberal" (these mean different things in different contexts)
+   - **Technical:** Any specialized term used without definition in a piece for general readers
+
+2. **For each contested term, check:**
+   - Is the term defined in the article (explicitly or via clear context)?
+   - If defined, is the definition appropriate and disclosed (rather than buried)?
+   - If not defined, what assumption is being smuggled? (e.g., calling a group "extremist" without definition assumes the reader shares the writer's threshold for that label.)
+   - Is the term used consistently? Or does its meaning shift across the article?
+
+3. **Look for "weasel quantifiers"** — words like "many," "some," "growing," "increasingly" — that imply quantitative claims without quantitative evidence. These should be backed by numbers or scoped explicitly.
+
+4. **Look for category laundering** — using a contested category as if it were a settled one. ("Misinformation," "hate speech," "election denier," "national security threat" are often used this way.)
+
+5. **Score 0–100:**
+   - **90–100:** Contested terms are defined, scoped, or sourced. Weasel quantifiers are backed.
+   - **75–89:** Most contested terms handled; minor smuggling.
+   - **60–74:** Several contested terms used without definition; some load-bearing for the article's frame.
+   - **40–59:** Contested terms central to the article's claims are not defined.
+   - **20–39:** Article's frame depends on contested terms used as if settled.
+   - **0–19:** The article is built on smuggled definitions; without them, its conclusions evaporate.
+
+6. **Confidence (0.0–1.0):** High by default for this dimension — definitions are surface-detectable. Lower if the article is highly technical and you may be misjudging which terms are contested in that field.
+
+# Important caveat
+
+Not every word is contested. A piece on baseball using "shortstop" without definition is fine. Apply this lens only to terms whose meaning is *load-bearing* for the article's claims and where reasonable readers would diverge on application.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "definitional_precision",
+  "version": "1.0",
+  "contested_terms": [
+    {
+      "term": "<the term>",
+      "occurrences": <integer>,
+      "first_use_quote": "<exact quote of first use>",
+      "defined_in_text": true | false,
+      "definition_quote": "<exact quote, or null>",
+      "definition_quality": "explicit" | "contextual" | "absent",
+      "smuggled_assumption": "<what is assumed when the term is used undefined, or null>",
+      "load_bearing": true | false,
+      "used_consistently": true | false,
+      "severity_if_undefined": "low" | "medium" | "high"
+    }
+  ],
+  "weasel_quantifiers": [
+    {
+      "term": "<e.g., 'many', 'growing', 'most'>",
+      "evidence_quote": "<exact quote>",
+      "backed_by_evidence": true | false,
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "category_laundering": [
+    {
+      "category": "<the contested category>",
+      "evidence_quote": "<exact quote>",
+      "treatment": "<how the article treats it as if settled>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence>",
+  "auditor_caveats": ["<things this scan cannot determine>"]
+}
+\`\`\`
+
+---`,
+
+    omission:
+`# Module 07 — Omission Test
+
+**Purpose:** Identify who is quoted, who is referenced but not given voice, and who is conspicuously absent given the article's topic. The pattern of who gets the microphone is often more revealing than what they say.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor performing an Omission Test on a news article.
+
+# Methodology
+
+1. **Catalog the voices that appear in the article:**
+   - **Directly quoted:** Anyone whose words appear in quotation marks (with attribution).
+   - **Paraphrased:** Anyone whose position is summarized by the article ("X said that...").
+   - **Referenced but silent:** Parties named or alluded to but not given voice (e.g., "company representatives did not respond" or simply absent).
+   - **Implicit:** Stakeholders whose existence is implied by the topic but who are not named.
+
+2. **Identify the topic's natural stakeholder set.** For any given news topic, there are roles that a balanced piece would normally include. Examples:
+
+   - A story about a labor dispute should include workers, management, union representation (if any), and ideally an outside observer.
+   - A story about a regulation should include the regulator, the regulated industry, the proponents (often advocacy groups or affected populations), and critics.
+   - A story about a court ruling should include both sides' counsel, the court's reasoning, and ideally legal commentators not party to the case.
+   - A story about a study should include the study's authors, methodology context, and outside experts capable of evaluating the work.
+   - A story about a foreign policy decision should include the originating government, affected parties, and (where reachable) those most affected by the policy.
+   - A story about a community impact should include members of that community, not only officials describing the community.
+
+3. **Compare the catalog to the natural stakeholder set.** Identify roles that should plausibly be heard from but are absent. For each absence, note whether the article addresses why (e.g., "X declined to comment," "Y could not be reached," "the agency has not responded to requests for comment") or whether the absence is unexplained.
+
+4. **Look for asymmetric quotation density.** Even when both sides are technically represented, count column-inches or quote-density given to each. Heavy imbalance can be a form of omission.
+
+5. **Check for "speaks-for" omission.** When the article allows one party to characterize another party's position rather than quoting that party directly, this is a common omission pattern. ("Critics worry that X..." with no critic actually quoted.)
+
+6. **Check for community-versus-officials omission.** Stories about communities (e.g., a neighborhood, a profession, an affected population) that quote only officials, experts, or institutional spokespersons fail this dimension.
+
+7. **Score 0–100:**
+   - **90–100:** Stakeholder set well-represented; quotation density roughly balanced; absences (if any) explicitly addressed.
+   - **75–89:** Most stakeholders heard from; minor imbalance.
+   - **60–74:** One or two important voices missing; or one perspective dominates the quote density.
+   - **40–59:** Significant absences; the story tells one side substantively.
+   - **20–39:** Severe; the story is essentially one-sided through omission.
+   - **0–19:** Article presents a topic while excluding the parties most relevant to it.
+
+8. **Confidence (0.0–1.0):** Lower confidence when you cannot identify the natural stakeholder set with high confidence (e.g., highly technical or jurisdiction-specific stories). Higher when the topic has well-understood stakeholder geometry.
+
+# Important caveat
+
+Not every story needs every voice. A breaking-news report 30 minutes after an event cannot include all stakeholders; an investigative piece months in development should. Calibrate expectations to the article's apparent reporting timeline and scope. Use the article's own framing of itself as a guide.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "omission",
+  "version": "1.0",
+  "topic_summary": "<one sentence on what the article is about>",
+  "voices_directly_quoted": [
+    {
+      "name_or_role": "<who>",
+      "perspective_summary": "<short summary>",
+      "quote_density": "high" | "medium" | "low",
+      "evidence_quote": "<exact quote of one of their statements>"
+    }
+  ],
+  "voices_paraphrased_only": [
+    {
+      "name_or_role": "<who>",
+      "perspective_summary": "<short summary>",
+      "evidence_quote": "<exact quote of paraphrase>"
+    }
+  ],
+  "voices_referenced_but_silent": [
+    {
+      "name_or_role": "<who>",
+      "absence_addressed": true | false,
+      "absence_explanation": "<exact quote, or null>"
+    }
+  ],
+  "natural_stakeholder_set": [
+    "<role 1>",
+    "<role 2>"
+  ],
+  "voices_expected_but_absent": [
+    {
+      "role": "<who would normally be heard from>",
+      "why_expected": "<reason this voice is normally part of this kind of story>",
+      "absence_addressed": true | false,
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "speaks_for_instances": [
+    {
+      "speaking_party": "<who>",
+      "spoken_for_party": "<whose position is being characterized>",
+      "evidence_quote": "<exact quote>",
+      "severity": "low" | "medium" | "high"
+    }
+  ],
+  "quotation_balance_notes": "<observations about quote density across perspectives>",
+  "score": 0-100,
+  "confidence": 0.0-1.0,
+  "confidence_notes": "<what limits confidence; e.g., 'unfamiliar with full stakeholder set in this jurisdiction'>",
+  "auditor_caveats": ["<things this scan cannot determine, e.g., 'cannot verify whether absent voices were actually contacted'>"]
+}
+\`\`\`
+
+---`,
+
+    prediction_extraction:
+`# Module 08 — Prediction Extraction
+
+**Purpose:** Extract every testable prediction the article makes (explicit or implicit) for the long-term prediction ledger. Predictions are *not scored at extraction* — they are scored later when reality resolves them. This module produces the input to the ledger; over time, the ledger produces the most powerful retrospective evidence about an author or publication's calibration.
+
+**Input:** Article markdown.
+
+**Output:** A single JSON object, no preamble or fences.
+
+---
+
+You are an epistemic auditor extracting predictions from a news article for a long-term prediction ledger.
+
+# Methodology
+
+1. **Identify every claim in the article that makes a prediction about the future.** Predictions can be:
+
+   - **Explicit:** "X will happen by Y date." "Experts predict Z." "Analysts expect..."
+   - **Implicit:** Claims that, while not framed as predictions, presuppose future outcomes. (e.g., "The new policy will reduce emissions by 20%" — this asserts a future outcome.)
+   - **Conditional:** "If X, then Y will follow." (Log both the condition and the predicted consequence.)
+   - **Negative:** "Z is unlikely to happen." "There is no evidence Y will occur."
+   - **Counterfactual-with-future:** "Without X, Y would have happened" combined with "now Y will not happen."
+
+2. **For each prediction, capture:**
+
+   - **The prediction itself** in clear, testable language.
+   - **Type:** explicit, implicit, conditional, negative, counterfactual.
+   - **Hedge level:** confident, hedged ("could," "might," "may," "is expected to"), or speculative ("some worry that," "it's possible").
+   - **Source within the article:** Is the prediction made by the article's own voice, or attributed to a named source, or attributed vaguely ("experts say")?
+   - **Resolution horizon:** When could this be resolved? An ISO date if computable; otherwise a description ("within the next 12 months," "by the next election," "unspecified").
+   - **Resolution criteria:** What observable event or measurement would resolve this true or false? Be concrete.
+   - **Tractability:** Is this prediction *in principle* resolvable from public information? (Some predictions about classified or private matters may never resolve publicly.)
+
+3. **Do not score the predictions.** Resolution and scoring happen later. Your job is to make the prediction ledger entry as clear and verifiable-later as possible.
+
+4. **Skip non-predictions.** Speculation framed as analysis ("X means we should think about Y") is not a prediction. Past-tense claims are not predictions. Statements about ongoing trends without a future-pointing component are not predictions.
+
+# Guidance on hedge levels
+
+- **Confident:** No hedge language. ("X will happen.")
+- **Hedged:** Modal verbs or qualifiers. ("X could happen," "X is likely to happen," "X is expected to happen.")
+- **Speculative:** Multiple layers of distance. ("Some worry that X might happen.")
+
+The hedge level matters because the calibration multiplier in the eventual scoring rewards hedged-and-wrong less harshly than confident-and-wrong, and rewards confident-and-right more than hedged-and-right.
+
+# Output
+
+Return only this JSON:
+
+\`\`\`json
+{
+  "module": "prediction_extraction",
+  "version": "1.0",
+  "predictions": [
+    {
+      "id": 0,
+      "prediction": "<clear, testable statement of the prediction>",
+      "type": "explicit" | "implicit" | "conditional" | "negative" | "counterfactual",
+      "hedge_level": "confident" | "hedged" | "speculative",
+      "attributed_to": "article_voice" | "named_source" | "vague_attribution",
+      "attributed_source_name": "<name if attributed, or null>",
+      "condition": "<for conditional predictions, the antecedent; null otherwise>",
+      "resolution_horizon": "<ISO date if computable, else descriptive string>",
+      "resolution_criteria": "<concrete, observable criteria>",
+      "tractability": "publicly_resolvable" | "requires_private_info" | "ambiguous",
+      "evidence_quote": "<exact quote from article>"
+    }
+  ],
+  "summary": {
+    "total_predictions": <integer>,
+    "explicit_count": <integer>,
+    "implicit_count": <integer>,
+    "confident_count": <integer>,
+    "hedged_count": <integer>,
+    "speculative_count": <integer>,
+    "publicly_resolvable_count": <integer>
+  },
+  "auditor_caveats": ["<e.g., 'some implicit predictions may have been missed'>"]
+}
+\`\`\`
+
+---`,
+
+});

--- a/src/shared/llm-client.js
+++ b/src/shared/llm-client.js
@@ -19,8 +19,9 @@ import { Utils } from './utils.js';
 import { loadFlags, isEnabled } from './metadata/feature-flags.js';
 import {
     ANTHROPIC_API_URL, ANTHROPIC_VERSION, resolveModel,
-    LLM_KEY_STORAGE, LLM_MODEL_STORAGE,
-    buildSuggestTool, buildSystemPrompt, buildUserPrompt
+    LLM_KEY_STORAGE, LLM_MODEL_STORAGE, LLM_SUGGEST_KINDS_STORAGE,
+    buildSuggestTool, buildSystemPrompt, buildUserPrompt,
+    normalizeSuggestKinds, categoryOfProposalKind
 } from './llm-prompts.js';
 import {
     AUDIT_TOOL_NAME, STANDING_SINGLE_SHOT_CAVEAT,
@@ -204,9 +205,19 @@ export async function runSuggestionPass(req = {}) {
         return { ok: false, error: 'No article text to analyze.' };
     }
 
+    // Which artifact categories to propose. Default ON = entities +
+    // claims (extraction); relationships / assessments / findings are
+    // opt-in via Options. We both SCOPE the prompt to the enabled kinds
+    // (fewer off-target proposals, smaller prompt) and FILTER the result
+    // (defense in depth — the model can't smuggle a disabled kind past it).
+    const enabledKinds = normalizeSuggestKinds(
+        (await storageGetRaw([LLM_SUGGEST_KINDS_STORAGE]))[LLM_SUGGEST_KINDS_STORAGE]);
+    if (enabledKinds.length === 0) {
+        return { ok: false, error: 'No suggestion types are enabled. Turn some on in Options → Advanced → LLM assist.' };
+    }
+
     const model = await readModel();
-    const task  = req.task || 'all';
-    const system = buildSystemPrompt({ task, url: req.articleUrl || '', title: req.articleTitle || '' });
+    const system = buildSystemPrompt({ tasks: enabledKinds, url: req.articleUrl || '', title: req.articleTitle || '' });
     const userContent = buildUserPrompt({ articleText, context: req.context || '' });
     const tool = buildSuggestTool();
 
@@ -220,7 +231,7 @@ export async function runSuggestionPass(req = {}) {
         messages: [{ role: 'user', content: userContent }]
     };
 
-    Utils.log('[X-Ray LLM] suggestion pass:', { task, model, chars: articleText.length });
+    Utils.log('[X-Ray LLM] suggestion pass:', { kinds: enabledKinds, model, chars: articleText.length });
 
     const res = await postMessages(payload, apiKey);
     if (!res.ok) return res;
@@ -235,11 +246,15 @@ export async function runSuggestionPass(req = {}) {
         return { ok: false, error: 'The model did not return a structured proposal set. Try again.' };
     }
 
-    Utils.log('[X-Ray LLM] proposals:', proposals.length);
+    // Drop anything outside the enabled categories (the model occasionally
+    // volunteers an off-target kind even when unasked).
+    const filtered = proposals.filter((p) => enabledKinds.includes(categoryOfProposalKind(p && p.kind)));
+
+    Utils.log('[X-Ray LLM] proposals:', filtered.length, 'of', proposals.length);
     return {
         ok: true,
         model: (data && data.model) || model,
-        proposals,
+        proposals: filtered,
         usage: data && data.usage ? data.usage : undefined
     };
 }

--- a/src/shared/llm-client.js
+++ b/src/shared/llm-client.js
@@ -23,8 +23,11 @@ import {
     buildSuggestTool, buildSystemPrompt, buildUserPrompt
 } from './llm-prompts.js';
 import {
-    AUDIT_TOOL_NAME, buildAuditTool, buildAuditSystemPrompt, buildAuditUserPrompt, assembleAudit
+    AUDIT_TOOL_NAME, STANDING_SINGLE_SHOT_CAVEAT,
+    buildAuditTool, buildAuditSystemPrompt, buildAuditUserPrompt, assembleAudit,
+    buildSingleModuleTool, buildModuleSystemPrompt
 } from './audit/audit-prompt.js';
+import { MODULE_NAMES } from './audit/findings-schemas.js';
 
 // Re-exported for callers that wrote against the client (the keys are
 // defined in the pure prompts module so the Options page can share them).
@@ -40,6 +43,9 @@ const MAX_OUTPUT_TOKENS = 8192;
 // A full eight-module audit is much larger than a proposal set (eight
 // nested findings payloads in one tool call), so it gets its own cap.
 const MAX_AUDIT_OUTPUT_TOKENS = 16384;
+// The per-module ("thorough") path emits ONE module's findings per call,
+// so a smaller cap is plenty and keeps each call cheap.
+const MAX_MODULE_OUTPUT_TOKENS = 8192;
 
 // ------------------------------------------------------------------
 // Storage helpers (callback → promise; SW-safe)
@@ -291,6 +297,13 @@ export async function runAuditPass(req = {}) {
     }
 
     const model = await readModel();
+
+    // Thorough mode: one independent call per dimension, each with its
+    // full vendored methodology and its own output budget.
+    if (req.mode === 'per_module') {
+        return runPerModuleAudit({ apiKey, model, markdown, req });
+    }
+
     const system = buildAuditSystemPrompt({ url: req.articleUrl || '', title: req.articleTitle || '' });
     const userContent = buildAuditUserPrompt({ articleText: markdown });
     const tool = buildAuditTool();
@@ -322,7 +335,10 @@ export async function runAuditPass(req = {}) {
     const usedModel = (data && data.model) || model;
     let audit;
     try {
-        audit = await assembleAudit({ toolInput, model: usedModel, markdown, metadata: req.metadata || {} });
+        audit = await assembleAudit({
+            toolInput, model: usedModel, markdown, metadata: req.metadata || {},
+            standingCaveat: STANDING_SINGLE_SHOT_CAVEAT
+        });
     } catch (err) {
         Utils.error('[X-Ray LLM] audit assembly failed:', err && err.message);
         return { ok: false, error: 'Could not assemble the audit from the model output.' };
@@ -335,4 +351,61 @@ export async function runAuditPass(req = {}) {
         audit,
         usage: data && data.usage ? data.usage : undefined
     };
+}
+
+/**
+ * Thorough audit: eight independent module calls, run in parallel (they
+ * are blind to each other — that's the point), each with its full
+ * methodology prompt and a single-module tool. Successful modules are
+ * collected and handed to the SAME assembleAudit; a failed call simply
+ * leaves its module absent, which assembleAudit records as a FAILED
+ * result (the rest still produce an aggregate). No standing single-shot
+ * caveat — this IS the rigorous path.
+ */
+async function runPerModuleAudit({ apiKey, model, markdown, req }) {
+    Utils.log('[X-Ray LLM] thorough audit:', { model, chars: markdown.length, modules: MODULE_NAMES.length });
+    const userContent = buildAuditUserPrompt({ articleText: markdown });
+
+    const results = await Promise.all(MODULE_NAMES.map(async (name) => {
+        const tool = buildSingleModuleTool(name);
+        const payload = {
+            model,
+            max_tokens: MAX_MODULE_OUTPUT_TOKENS,
+            system: buildModuleSystemPrompt(name, { url: req.articleUrl || '', title: req.articleTitle || '' }),
+            tools: [tool],
+            tool_choice: { type: 'tool', name: tool.name },
+            messages: [{ role: 'user', content: userContent }]
+        };
+        const res = await postMessages(payload, apiKey);
+        if (!res.ok) { Utils.error('[X-Ray LLM] module failed', name, res.error); return { name }; }
+        const data = res.data;
+        if (data && data.stop_reason === 'max_tokens') { Utils.error('[X-Ray LLM] module truncated', name); return { name }; }
+        const input = extractToolInput(data, tool.name);
+        if (input === null) { Utils.error('[X-Ray LLM] module no tool output', name); return { name }; }
+        return { name, findings: input, usedModel: (data && data.model) || model };
+    }));
+
+    const modules = {};
+    let okCount = 0;
+    let usedModel = model;
+    for (const r of results) {
+        if (r.findings) { modules[r.name] = r.findings; usedModel = r.usedModel || usedModel; okCount += 1; }
+    }
+    if (okCount === 0) {
+        return { ok: false, error: 'Every module call failed — check your connection and key, then try again.' };
+    }
+
+    let audit;
+    try {
+        audit = await assembleAudit({
+            toolInput: { modules }, model: usedModel, markdown,
+            metadata: req.metadata || {}, standingCaveat: null
+        });
+    } catch (err) {
+        Utils.error('[X-Ray LLM] thorough assembly failed:', err && err.message);
+        return { ok: false, error: 'Could not assemble the audit from the model output.' };
+    }
+
+    Utils.log('[X-Ray LLM] thorough modules ok:', okCount);
+    return { ok: true, model: usedModel, audit, modulesOk: okCount };
 }

--- a/src/shared/llm-client.js
+++ b/src/shared/llm-client.js
@@ -22,6 +22,9 @@ import {
     LLM_KEY_STORAGE, LLM_MODEL_STORAGE,
     buildSuggestTool, buildSystemPrompt, buildUserPrompt
 } from './llm-prompts.js';
+import {
+    AUDIT_TOOL_NAME, buildAuditTool, buildAuditSystemPrompt, buildAuditUserPrompt, assembleAudit
+} from './audit/audit-prompt.js';
 
 // Re-exported for callers that wrote against the client (the keys are
 // defined in the pure prompts module so the Options page can share them).
@@ -34,6 +37,9 @@ const MAX_ARTICLE_CHARS = 120000;
 // proposal set; if the model still hits it we surface a clear error
 // rather than feeding truncated JSON to the validators.
 const MAX_OUTPUT_TOKENS = 8192;
+// A full eight-module audit is much larger than a proposal set (eight
+// nested findings payloads in one tool call), so it gets its own cap.
+const MAX_AUDIT_OUTPUT_TOKENS = 16384;
 
 // ------------------------------------------------------------------
 // Storage helpers (callback → promise; SW-safe)
@@ -97,6 +103,70 @@ function mapHttpError(status, bodyText) {
 }
 
 // ------------------------------------------------------------------
+// Shared request path
+// ------------------------------------------------------------------
+
+/**
+ * POST one Messages payload and return the parsed response. Handles
+ * network failure, HTTP errors, and unreadable bodies; the caller checks
+ * stop_reason and pulls its tool out. NEVER logs the key or request body.
+ *
+ * @returns {Promise<{ok:true, data:object} | {ok:false, error:string, status?:number}>}
+ */
+async function postMessages(payload, apiKey) {
+    let resp;
+    try {
+        resp = await fetch(ANTHROPIC_API_URL, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'x-api-key': apiKey,
+                'anthropic-version': ANTHROPIC_VERSION,
+                // Browser-origin calls require this opt-in; CORS is enabled
+                // for it. The fetch runs in the SW, not a page with site CSP.
+                'anthropic-dangerous-direct-browser-access': 'true'
+            },
+            body: JSON.stringify(payload)
+        });
+    } catch (err) {
+        // Network failure — DO NOT include the key or request body.
+        Utils.error('[X-Ray LLM] network error:', err && err.message);
+        return { ok: false, error: 'Could not reach the Anthropic API (network error). Check your connection and host permissions.' };
+    }
+
+    if (!resp.ok) {
+        let bodyText = '';
+        try { bodyText = await resp.text(); } catch (_) { /* ignore */ }
+        const error = mapHttpError(resp.status, bodyText);
+        Utils.error('[X-Ray LLM] HTTP', resp.status, error);
+        return { ok: false, error, status: resp.status };
+    }
+
+    let data;
+    try {
+        data = await resp.json();
+    } catch (_) {
+        return { ok: false, error: 'Anthropic returned an unreadable response.' };
+    }
+    return { ok: true, data };
+}
+
+/**
+ * Pull a forced tool's `input` out of a Messages response, by tool name.
+ * Returns the input object, or null if no matching tool_use was found.
+ * Exported for unit tests (no network involved).
+ */
+export function extractToolInput(data, toolName) {
+    const blocks = (data && Array.isArray(data.content)) ? data.content : [];
+    for (const block of blocks) {
+        if (block && block.type === 'tool_use' && block.name === toolName) {
+            return block.input || {};
+        }
+    }
+    return null;
+}
+
+// ------------------------------------------------------------------
 // Public entry point
 // ------------------------------------------------------------------
 
@@ -146,40 +216,9 @@ export async function runSuggestionPass(req = {}) {
 
     Utils.log('[X-Ray LLM] suggestion pass:', { task, model, chars: articleText.length });
 
-    let resp;
-    try {
-        resp = await fetch(ANTHROPIC_API_URL, {
-            method: 'POST',
-            headers: {
-                'content-type': 'application/json',
-                'x-api-key': apiKey,
-                'anthropic-version': ANTHROPIC_VERSION,
-                // Browser-origin calls require this opt-in; CORS is enabled
-                // for it. The fetch runs in the SW, not a page with site CSP.
-                'anthropic-dangerous-direct-browser-access': 'true'
-            },
-            body: JSON.stringify(payload)
-        });
-    } catch (err) {
-        // Network failure — DO NOT include the key or request body.
-        Utils.error('[X-Ray LLM] network error:', err && err.message);
-        return { ok: false, error: 'Could not reach the Anthropic API (network error). Check your connection and host permissions.' };
-    }
-
-    if (!resp.ok) {
-        let bodyText = '';
-        try { bodyText = await resp.text(); } catch (_) { /* ignore */ }
-        const error = mapHttpError(resp.status, bodyText);
-        Utils.error('[X-Ray LLM] HTTP', resp.status, error);
-        return { ok: false, error, status: resp.status };
-    }
-
-    let data;
-    try {
-        data = await resp.json();
-    } catch (_) {
-        return { ok: false, error: 'Anthropic returned an unreadable response.' };
-    }
+    const res = await postMessages(payload, apiKey);
+    if (!res.ok) return res;
+    const data = res.data;
 
     if (data && data.stop_reason === 'max_tokens') {
         return { ok: false, error: 'The model hit its output limit before finishing. Try a shorter article or fewer tasks.' };
@@ -214,4 +253,86 @@ export function extractProposals(data) {
         }
     }
     return null;
+}
+
+/**
+ * Run one user-invoked epistemic-audit pass: a single forced tool call
+ * that scores all eight dimensions, assembled into the canonical
+ * scorer-export shape the reader feeds to importAuditJson. The aggregate
+ * is computed in code, never taken from the model.
+ *
+ * Same two consent gates as Suggest (llmAssist flag + key). This never
+ * persists or publishes — the reader runs importAuditJson (which re-hashes
+ * and schema-validates) and publishing stays behind `epistemicAuditing`.
+ *
+ * @param {object} req
+ * @param {string} req.markdown        the article body markdown (the SAME
+ *                                     text the reader hashes for the gate)
+ * @param {object} [req.metadata]      headline / byline / url / etc.
+ * @param {string} [req.articleUrl]
+ * @param {string} [req.articleTitle]
+ * @returns {Promise<{ok:true, model:string, audit:object, usage?:object}
+ *                  | {ok:false, error:string, status?:number}>}
+ */
+export async function runAuditPass(req = {}) {
+    await loadFlags();
+    if (!isEnabled('llmAssist')) {
+        return { ok: false, error: 'LLM assist is off. Enable it in Options → Advanced → LLM assist.' };
+    }
+
+    const apiKey = await readApiKey();
+    if (!apiKey) {
+        return { ok: false, error: 'No Anthropic API key set. Add one in Options → Advanced → LLM assist.' };
+    }
+
+    const markdown = String(req.markdown || '').slice(0, MAX_ARTICLE_CHARS);
+    if (!markdown.trim()) {
+        return { ok: false, error: 'No article text to audit.' };
+    }
+
+    const model = await readModel();
+    const system = buildAuditSystemPrompt({ url: req.articleUrl || '', title: req.articleTitle || '' });
+    const userContent = buildAuditUserPrompt({ articleText: markdown });
+    const tool = buildAuditTool();
+
+    const payload = {
+        model,
+        max_tokens: MAX_AUDIT_OUTPUT_TOKENS,
+        system,
+        tools: [tool],
+        tool_choice: { type: 'tool', name: tool.name },
+        messages: [{ role: 'user', content: userContent }]
+    };
+
+    Utils.log('[X-Ray LLM] audit pass:', { model, chars: markdown.length });
+
+    const res = await postMessages(payload, apiKey);
+    if (!res.ok) return res;
+    const data = res.data;
+
+    if (data && data.stop_reason === 'max_tokens') {
+        return { ok: false, error: 'The model hit its output limit before finishing the audit. Try a shorter article.' };
+    }
+
+    const toolInput = extractToolInput(data, AUDIT_TOOL_NAME);
+    if (toolInput === null) {
+        return { ok: false, error: 'The model did not return a structured audit. Try again.' };
+    }
+
+    const usedModel = (data && data.model) || model;
+    let audit;
+    try {
+        audit = await assembleAudit({ toolInput, model: usedModel, markdown, metadata: req.metadata || {} });
+    } catch (err) {
+        Utils.error('[X-Ray LLM] audit assembly failed:', err && err.message);
+        return { ok: false, error: 'Could not assemble the audit from the model output.' };
+    }
+
+    Utils.log('[X-Ray LLM] audit modules:', audit.module_results.length);
+    return {
+        ok: true,
+        model: usedModel,
+        audit,
+        usage: data && data.usage ? data.usage : undefined
+    };
 }

--- a/src/shared/llm-prompts.js
+++ b/src/shared/llm-prompts.js
@@ -62,6 +62,55 @@ export const SUGGEST_TASKS = Object.freeze([
     'all', 'entities', 'claims', 'assessments', 'relationships', 'findings'
 ]);
 
+// The selectable suggestion categories (SUGGEST_TASKS without the 'all'
+// convenience). Each maps to a rules block in buildSystemPrompt and a
+// checkbox in Options. Default ON = the EXTRACTION kinds only (entities,
+// claims); the JUDGMENT kinds (relationships, assessments, findings) are
+// opt-in. The rationale: a false-positive extraction is a one-click
+// reject, but a false-positive judgment is the tool manufacturing a
+// verdict — the exact thing X-Ray refuses to render automatically.
+export const SUGGEST_KINDS = Object.freeze(SUGGEST_TASKS.filter((t) => t !== 'all'));
+export const SUGGEST_DEFAULT_KINDS = Object.freeze(['entities', 'claims']);
+export const LLM_SUGGEST_KINDS_STORAGE = 'xray:llm:suggest_kinds';
+
+// Category metadata for the Options checkboxes (rendered in this order).
+export const SUGGEST_KIND_LABELS = Object.freeze([
+    { kind: 'entities', label: 'Entities',
+        hint: 'people, organizations, places, and things named in the text' },
+    { kind: 'claims', label: 'Claims',
+        hint: 'atomized assertions the article makes, each anchored to a verbatim quote' },
+    { kind: 'relationships', label: 'Relationships (evidence links)',
+        hint: 'typed links between claims — most useful across multiple articles' },
+    { kind: 'assessments', label: 'Assessments',
+        hint: 'a stance / issue labels on a claim — your judgment to own, not the model’s' },
+    { kind: 'findings', label: 'Forensic findings',
+        hint: 'structural maneuvers, plus baselines & story-change edges — experimental' }
+]);
+
+// Proposal kind → selectable category. Baselines and revisions ride with
+// the forensic-findings layer (the prompt bundles their rules with it).
+const PROPOSAL_KIND_TO_CATEGORY = Object.freeze({
+    entity: 'entities', claim: 'claims', assessment: 'assessments',
+    relationship: 'relationships', finding: 'findings',
+    baseline: 'findings', revision: 'findings'
+});
+
+/** The selectable category a raw proposal kind belongs to (or null). */
+export function categoryOfProposalKind(kind) {
+    return PROPOSAL_KIND_TO_CATEGORY[kind] || null;
+}
+
+/**
+ * Coerce a stored value into a valid enabled-kinds array. An ABSENT
+ * value (not an array) falls back to the defaults; an explicit array is
+ * filtered to known categories (and may be empty — the user turned
+ * everything off, which the caller treats as "nothing to suggest").
+ */
+export function normalizeSuggestKinds(value) {
+    if (!Array.isArray(value)) return SUGGEST_DEFAULT_KINDS.slice();
+    return value.filter((k) => SUGGEST_KINDS.includes(k));
+}
+
 // ------------------------------------------------------------------
 // Tool schema — one discriminated-union tool keyed by `kind`. We do NOT
 // use strict mode: the real firewall is each model's create() at accept
@@ -318,18 +367,24 @@ BASELINES (a subject's established register — secondary, descriptive prose, no
 }
 
 /**
- * Build the system prompt for a pass. `task` ('all' by default) selects
- * which artifact rules to embed; the heavy maneuver guide is only
- * included when findings are in scope, to bound tokens.
+ * Build the system prompt for a pass. `tasks` (an array of categories)
+ * selects which artifact rules to embed; the heavy maneuver guide is only
+ * included when findings are in scope, to bound tokens. `task` (a single
+ * string, 'all' by default) is kept for back-compat and is used only when
+ * `tasks` is not supplied.
  *
  * @param {object} [opts]
- * @param {string} [opts.task='all']
+ * @param {string[]} [opts.tasks]   enabled categories (preferred)
+ * @param {string} [opts.task='all'] single category, or 'all' (fallback)
  * @param {string} [opts.url]
  * @param {string} [opts.title]
  */
-export function buildSystemPrompt({ task = 'all', url = '', title = '' } = {}) {
-    const t = SUGGEST_TASKS.includes(task) ? task : 'all';
-    const wants = (kind) => t === 'all' || t === kind;
+export function buildSystemPrompt({ tasks = null, task = 'all', url = '', title = '' } = {}) {
+    const effective = Array.isArray(tasks)
+        ? tasks.filter((t) => SUGGEST_KINDS.includes(t))
+        : (task === 'all' ? SUGGEST_KINDS.slice()
+            : (SUGGEST_KINDS.includes(task) ? [task] : SUGGEST_KINDS.slice()));
+    const wants = (kind) => effective.includes(kind);
 
     const head = `You are X-Ray's capture assistant. You read an article a person has captured and propose structured "capture artifacts" — entities, claims, assessments, relationships, and forensic findings — for that person to review and confirm. X-Ray is an evidence tool: it records WHAT was said and the STRUCTURE of how it was argued, and it renders no automated verdicts on truth or intent.`;
 

--- a/tests/audit-llm.test.mjs
+++ b/tests/audit-llm.test.mjs
@@ -1,0 +1,236 @@
+// In-extension epistemic auditor (the LLM execution path): the tool
+// schema is built from the validator's PAYLOADS, the aggregate is
+// computed in code (never taken from the model), and a clean pass
+// assembles into an object importAuditJson accepts end to end.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+await import('fake-indexeddb/auto');
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const {
+    buildAuditTool, assembleAudit, AUDIT_TOOL_NAME, STANDING_SINGLE_SHOT_CAVEAT, MODULE_WEIGHTS
+} = await import('../src/shared/audit/audit-prompt.js');
+const { extractToolInput } = await import('../src/shared/llm-client.js');
+const { MODULE_NAMES, SCOREABLE_MODULES, validateFindings } = await import('../src/shared/audit/findings-schemas.js');
+const { articleHash, normalizeForHash } = await import('../src/shared/audit/article-hash.js');
+const { importAuditJson } = await import('../src/shared/audit/import.js');
+const { AuditRunModel, PredictionModel } = await import('../src/shared/audit/audit-model.js');
+const { clear } = await import('../src/shared/audit/audit-cache.js');
+
+const MD = '# A Story\n\nThe minister said the program would end by December. Critics disagreed.';
+
+// A minimal-but-schema-valid findings object per module — exactly the
+// shape buildAuditTool guides the model toward (envelope score/confidence
+// + payload). module/version are injected by assembleAudit, NOT here.
+function fullModules() {
+    return {
+        headline_body_fidelity: {
+            score: 80, confidence: 0.8, auditor_caveats: [],
+            headline: 'A Story', subhead: null,
+            headline_implications: [], body_findings: [], structural_issues: []
+        },
+        asymmetric_language: {
+            score: 85, confidence: 0.7, auditor_caveats: [],
+            has_contrast_structure: false, parties_identified: [],
+            language_applied: [], asymmetry_findings: []
+        },
+        number_hygiene: {
+            score: 90, confidence: 0.9, auditor_caveats: [],
+            numerical_claims: [],
+            summary: { total_claims: 0, claims_failing_at_least_one_test: 0 }
+        },
+        source_quality: {
+            score: 70, confidence: 0.6, auditor_caveats: [],
+            sources: [], claim_to_source_map: [], single_sourced_contested_claims: [],
+            primary_documents: [],
+            // Drives the knowability-ceiling heuristic: 3/4 named, 0 bare
+            // anonymous, all documents specifically identified.
+            summary: {
+                total_sources: 4, named_count: 3, anonymous_count: 1,
+                anonymous_justified_count: 1, expert_says_vague_count: 0,
+                documents_cited: 2, documents_specifically_identified: 2
+            }
+        },
+        internal_coherence: {
+            score: 75, confidence: 0.8, auditor_caveats: [],
+            contradictions: [], logical_gaps: []
+        },
+        definitional_precision: {
+            score: 65, confidence: 0.7, auditor_caveats: [],
+            contested_terms: [], weasel_quantifiers: [], category_laundering: []
+        },
+        omission: {
+            score: 60, confidence: 0.65, auditor_caveats: [],
+            topic_summary: 'A program ending.', voices_directly_quoted: [],
+            voices_paraphrased_only: [], voices_referenced_but_silent: [],
+            natural_stakeholder_set: [], voices_expected_but_absent: [],
+            speaks_for_instances: []
+        },
+        prediction_extraction: {
+            auditor_caveats: ['Horizon approximate.'],
+            predictions: [{
+                prediction: 'The program will end by December.',
+                type: 'explicit', hedge_level: 'confident',
+                attributed_to: 'named_source', attributed_source_name: 'the minister',
+                resolution_horizon: 'by December',
+                resolution_criteria: 'program shut down by Dec 31',
+                tractability: 'publicly_resolvable',
+                evidence_quote: 'would end by December'
+            }],
+            summary: { total_predictions: 1 }
+        }
+    };
+}
+
+const MODEL = 'claude-opus-4-8';
+
+test.beforeEach(async () => { await clear(); });
+
+// --- tool schema is derived from the validator's shapes ---------------------
+
+test('buildAuditTool: one schema per module, derived from PAYLOADS', () => {
+    const tool = buildAuditTool();
+    assert.equal(tool.name, AUDIT_TOOL_NAME);
+    const mods = tool.input_schema.properties.modules;
+    assert.deepEqual(mods.required, MODULE_NAMES.slice(), 'all eight modules required');
+
+    for (const name of SCOREABLE_MODULES) {
+        const s = mods.properties[name];
+        assert.ok(s.required.includes('score'), `${name} requires score`);
+        assert.ok(s.required.includes('confidence'), `${name} requires confidence`);
+        assert.ok(s.required.includes('auditor_caveats'), `${name} requires auditor_caveats`);
+    }
+    // 08 is unscored — score/confidence must be neither asked nor present.
+    const pe = mods.properties.prediction_extraction;
+    assert.ok(!pe.required.includes('score'));
+    assert.ok(!pe.properties.score, 'prediction_extraction has no score property');
+    assert.ok(pe.required.includes('auditor_caveats'));
+});
+
+// --- assembly produces import-clean canonical output ------------------------
+
+test('assembleAudit: every module validates against its findings schema', async () => {
+    const audit = await assembleAudit({ toolInput: { modules: fullModules() }, model: MODEL, markdown: MD });
+    assert.equal(audit.module_results.length, 8);
+    for (const r of audit.module_results) {
+        const { valid, errors } = validateFindings(r.module, r.findings);
+        assert.ok(valid, `${r.module} should validate: ${JSON.stringify(errors)}`);
+        // Wrapper score/version match findings (import's tamper check).
+        assert.equal(r.module_version, r.findings.version);
+        if (r.module !== 'prediction_extraction') {
+            assert.equal(r.score, r.findings.score);
+            assert.equal(r.confidence, r.findings.confidence);
+        }
+        // The standing single-shot caveat rides on every module (P12).
+        assert.ok(r.findings.auditor_caveats.includes(STANDING_SINGLE_SHOT_CAVEAT));
+        assert.equal(r.auditor.kind, 'model');
+        assert.equal(r.auditor.id, `anthropic/${MODEL}`);
+    }
+});
+
+test('assembleAudit: hash binds to the audited text', async () => {
+    const audit = await assembleAudit({ toolInput: { modules: fullModules() }, model: MODEL, markdown: MD });
+    assert.equal(audit.article.hash, await articleHash(MD));
+    assert.equal(audit.article.body_markdown, normalizeForHash(MD));
+});
+
+test('assembleAudit: aggregate is computed in code, not the model', async () => {
+    const audit = await assembleAudit({ toolInput: { modules: fullModules() }, model: MODEL, markdown: MD });
+    const agg = audit.aggregate;
+
+    // Ceiling from the source_quality summary heuristic:
+    // round(60 + 25*0.75 + 10*1 + 5*0.25 - 15*0) = 90.
+    assert.equal(agg.knowability_ceiling, 90);
+    assert.equal(agg.ceiling_source, 'heuristic:source-quality/1.0');
+
+    // Weighted over the seven scoreable modules:
+    // 80*.15+85*.15+90*.10+70*.20+75*.10+65*.10+60*.20 = 73.75 → 73.8.
+    assert.equal(agg.raw_weighted_score, 73.8);
+    assert.equal(agg.final_score, 73.8, 'below the ceiling, so no cap');
+    assert.equal(agg.ceiling_binding, false);
+
+    // Confidence stacks: min(confidences) × success fraction = 0.6 × 1.
+    assert.equal(agg.overall_confidence, 0.6);
+
+    assert.equal(agg.module_contributions.length, SCOREABLE_MODULES.length);
+    assert.ok(agg.top_strengths.includes('number_hygiene: 90'));
+    assert.ok(agg.top_strengths.includes('asymmetric_language: 85'));
+    // Pipeline weights are the documented public constants.
+    assert.equal(MODULE_WEIGHTS.source_quality, 0.20);
+});
+
+test('assembleAudit: ceiling binds when the raw score exceeds it', async () => {
+    const mods = fullModules();
+    // All-anonymous-bare sourcing → a low ceiling that caps a high raw.
+    mods.source_quality.summary = {
+        total_sources: 4, named_count: 0, anonymous_count: 4,
+        anonymous_justified_count: 0, expert_says_vague_count: 0,
+        documents_cited: 0, documents_specifically_identified: 0
+    };
+    for (const m of SCOREABLE_MODULES) mods[m].score = 95;
+    const { aggregate: agg } = await assembleAudit({ toolInput: { modules: mods }, model: MODEL, markdown: MD });
+    // ceiling = round(60 + 0 + 10*1(docs default) + 0 - 15*1) = 55.
+    assert.equal(agg.knowability_ceiling, 55);
+    assert.equal(agg.raw_weighted_score, 95);
+    assert.equal(agg.final_score, 55, 'capped at the ceiling');
+    assert.equal(agg.ceiling_binding, true);
+});
+
+// --- the round-trip: assemble → importAuditJson (the real firewall) ---------
+
+test('round-trip: a clean pass imports end to end', async () => {
+    const audit = await assembleAudit({ toolInput: { modules: fullModules() }, model: MODEL, markdown: MD });
+    const localHash = await articleHash(MD);
+    const summary = await importAuditJson(audit, { localArticleHash: localHash });
+
+    assert.equal(summary.modulesValid, 8, 'all eight modules pass the firewall');
+    assert.equal(summary.modulesFailed, 0);
+    assert.equal(summary.predictionsImported, 1);
+    assert.equal(summary.articleHash, localHash);
+
+    const runs = await AuditRunModel.getByArticleHash(localHash);
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].aggregate.final_score, 73.8);
+    assert.equal(runs[0].aggregate.ceiling_source, 'heuristic:source-quality/1.0');
+
+    const preds = await PredictionModel.getByArticleHash(localHash);
+    assert.equal(preds.length, 1);
+    assert.equal(preds[0].attributed_source_name, 'the minister');
+});
+
+test('round-trip: a capture-hash mismatch is rejected at the door', async () => {
+    const audit = await assembleAudit({ toolInput: { modules: fullModules() }, model: MODEL, markdown: MD });
+    await assert.rejects(
+        () => importAuditJson(audit, { localArticleHash: 'f'.repeat(64) }),
+        /scored different text|does not match/
+    );
+});
+
+test('assembleAudit: an absent module imports as a failed result, not a rejection', async () => {
+    const mods = fullModules();
+    delete mods.omission;
+    const audit = await assembleAudit({ toolInput: { modules: mods }, model: MODEL, markdown: MD });
+    const omission = audit.module_results.find((r) => r.module === 'omission');
+    assert.equal(omission.score, null);
+    assert.equal(omission._error, true);
+
+    const summary = await importAuditJson(audit, { localArticleHash: await articleHash(MD) });
+    assert.equal(summary.modulesFailed >= 1, true);
+    assert.equal(summary.modulesValid, 7, 'the rest still import');
+});
+
+// --- tool-output extraction --------------------------------------------------
+
+test('extractToolInput: pulls the forced tool input, null when absent', () => {
+    const data = { content: [
+        { type: 'text', text: 'ignored' },
+        { type: 'tool_use', name: AUDIT_TOOL_NAME, input: { modules: { x: 1 } } }
+    ] };
+    assert.deepEqual(extractToolInput(data, AUDIT_TOOL_NAME), { modules: { x: 1 } });
+    assert.equal(extractToolInput({ content: [{ type: 'text', text: 'hi' }] }, AUDIT_TOOL_NAME), null);
+    assert.equal(extractToolInput({}, AUDIT_TOOL_NAME), null);
+});

--- a/tests/audit-llm.test.mjs
+++ b/tests/audit-llm.test.mjs
@@ -12,7 +12,8 @@ globalThis.chrome = globalThis.chrome || {
 };
 
 const {
-    buildAuditTool, assembleAudit, AUDIT_TOOL_NAME, STANDING_SINGLE_SHOT_CAVEAT, MODULE_WEIGHTS
+    buildAuditTool, assembleAudit, AUDIT_TOOL_NAME, STANDING_SINGLE_SHOT_CAVEAT, MODULE_WEIGHTS,
+    buildSingleModuleTool, buildModuleSystemPrompt
 } = await import('../src/shared/audit/audit-prompt.js');
 const { extractToolInput } = await import('../src/shared/llm-client.js');
 const { MODULE_NAMES, SCOREABLE_MODULES, validateFindings } = await import('../src/shared/audit/findings-schemas.js');
@@ -114,7 +115,10 @@ test('buildAuditTool: one schema per module, derived from PAYLOADS', () => {
 // --- assembly produces import-clean canonical output ------------------------
 
 test('assembleAudit: every module validates against its findings schema', async () => {
-    const audit = await assembleAudit({ toolInput: { modules: fullModules() }, model: MODEL, markdown: MD });
+    const audit = await assembleAudit({
+        toolInput: { modules: fullModules() }, model: MODEL, markdown: MD,
+        standingCaveat: STANDING_SINGLE_SHOT_CAVEAT
+    });
     assert.equal(audit.module_results.length, 8);
     for (const r of audit.module_results) {
         const { valid, errors } = validateFindings(r.module, r.findings);
@@ -221,6 +225,43 @@ test('assembleAudit: an absent module imports as a failed result, not a rejectio
     const summary = await importAuditJson(audit, { localArticleHash: await articleHash(MD) });
     assert.equal(summary.modulesFailed >= 1, true);
     assert.equal(summary.modulesValid, 7, 'the rest still import');
+});
+
+// --- per-module ("thorough") path --------------------------------------------
+
+test('buildSingleModuleTool + buildModuleSystemPrompt: one module, full methodology', () => {
+    const tool = buildSingleModuleTool('source_quality');
+    assert.equal(tool.name, 'emit_source_quality');
+    // input_schema IS the module's findings schema (envelope + payload).
+    assert.ok(tool.input_schema.required.includes('score'));
+    assert.ok(tool.input_schema.required.includes('summary'));
+
+    const sys = buildModuleSystemPrompt('source_quality', { title: 'A Story' });
+    assert.match(sys, /Module 04/, 'carries the vendored methodology');
+    assert.match(sys, /emit_source_quality/, 'points at its tool');
+
+    // 08 must tell the model not to score (envelope forbids it).
+    const pe = buildSingleModuleTool('prediction_extraction');
+    assert.ok(!pe.input_schema.required.includes('score'));
+    assert.match(buildModuleSystemPrompt('prediction_extraction', {}), /NOT scored/);
+});
+
+test('per-module assembly carries NO single-shot caveat, still round-trips', async () => {
+    const audit = await assembleAudit({
+        toolInput: { modules: fullModules() }, model: MODEL, markdown: MD,
+        standingCaveat: null
+    });
+    for (const r of audit.module_results) {
+        assert.ok(!r.findings.auditor_caveats.includes(STANDING_SINGLE_SHOT_CAVEAT),
+            `${r.module} should not carry the single-shot caveat in thorough mode`);
+    }
+    // The model's own per-module caveat survives.
+    const pe = audit.module_results.find((r) => r.module === 'prediction_extraction');
+    assert.ok(pe.findings.auditor_caveats.includes('Horizon approximate.'));
+
+    const summary = await importAuditJson(audit, { localArticleHash: await articleHash(MD) });
+    assert.equal(summary.modulesValid, 8);
+    assert.equal(summary.modulesFailed, 0);
 });
 
 // --- tool-output extraction --------------------------------------------------

--- a/tests/llm-suggest-kinds.test.mjs
+++ b/tests/llm-suggest-kinds.test.mjs
@@ -1,0 +1,63 @@
+// LLM Suggest — per-kind defaults + scoping. Default ON is the
+// extraction kinds (entities, claims); the judgment kinds
+// (relationships, assessments, findings) are opt-in.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// llm-prompts pulls entity-model transitively, which reads chrome.storage
+// at module load — stub it before importing (as the other LLM tests do).
+globalThis.chrome = globalThis.chrome || {
+    storage: { local: { get(_k, cb) { cb({}); }, set(_o, cb) { cb && cb(); }, remove(_k, cb) { cb && cb(); } } }
+};
+
+const {
+    SUGGEST_KINDS, SUGGEST_DEFAULT_KINDS, SUGGEST_KIND_LABELS,
+    normalizeSuggestKinds, categoryOfProposalKind, buildSystemPrompt
+} = await import('../src/shared/llm-prompts.js');
+
+test('default ON = entities + claims only (extraction, not judgment)', () => {
+    assert.deepEqual([...SUGGEST_DEFAULT_KINDS], ['entities', 'claims']);
+    for (const judgment of ['relationships', 'assessments', 'findings']) {
+        assert.ok(!SUGGEST_DEFAULT_KINDS.includes(judgment), `${judgment} must be opt-in`);
+        assert.ok(SUGGEST_KINDS.includes(judgment), `${judgment} is still a selectable kind`);
+    }
+});
+
+test('normalizeSuggestKinds: absent → defaults, explicit → filtered (empty allowed)', () => {
+    assert.deepEqual(normalizeSuggestKinds(undefined), ['entities', 'claims']);
+    assert.deepEqual(normalizeSuggestKinds(null), ['entities', 'claims']);
+    assert.deepEqual(normalizeSuggestKinds('all'), ['entities', 'claims'], 'non-array → defaults');
+    assert.deepEqual(normalizeSuggestKinds([]), [], 'explicit empty is honored, not defaulted');
+    assert.deepEqual(normalizeSuggestKinds(['claims', 'bogus', 'findings']), ['claims', 'findings']);
+});
+
+test('categoryOfProposalKind: forensic kinds collapse to findings', () => {
+    assert.equal(categoryOfProposalKind('entity'), 'entities');
+    assert.equal(categoryOfProposalKind('claim'), 'claims');
+    assert.equal(categoryOfProposalKind('relationship'), 'relationships');
+    assert.equal(categoryOfProposalKind('assessment'), 'assessments');
+    for (const k of ['finding', 'baseline', 'revision']) {
+        assert.equal(categoryOfProposalKind(k), 'findings', `${k} → findings`);
+    }
+    assert.equal(categoryOfProposalKind('nope'), null);
+});
+
+test('SUGGEST_KIND_LABELS covers every selectable kind', () => {
+    assert.deepEqual(SUGGEST_KIND_LABELS.map((k) => k.kind).sort(), [...SUGGEST_KINDS].sort());
+});
+
+test('buildSystemPrompt scopes to tasks: default omits assessments + the maneuver guide', () => {
+    const def = buildSystemPrompt({ tasks: ['entities', 'claims'] });
+    assert.match(def, /ENTITIES/);
+    assert.match(def, /CLAIMS/);
+    assert.ok(!/ASSESSMENTS/.test(def), 'no assessment rules when not enabled');
+    assert.ok(!/MANEUVER GUIDE/.test(def), 'no heavy forensic guide when findings off');
+
+    const withFindings = buildSystemPrompt({ tasks: ['findings'] });
+    assert.match(withFindings, /MANEUVER GUIDE/, 'findings pulls in the guide');
+
+    // Back-compat: the single-string task path still works.
+    assert.match(buildSystemPrompt({ task: 'entities' }), /ENTITIES/);
+    assert.match(buildSystemPrompt({ task: 'all' }), /MANEUVER GUIDE/);
+});

--- a/tools/gen-module-prompts.mjs
+++ b/tools/gen-module-prompts.mjs
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const MAP = {
+    '01-headline-body-fidelity.md': 'headline_body_fidelity',
+    '02-asymmetric-language.md':    'asymmetric_language',
+    '03-number-hygiene.md':         'number_hygiene',
+    '04-source-quality.md':         'source_quality',
+    '05-internal-coherence.md':     'internal_coherence',
+    '06-definitional-precision.md': 'definitional_precision',
+    '07-omission.md':               'omission',
+    '08-prediction-extraction.md':  'prediction_extraction'
+};
+
+const marker = /^#+\s*ARTICLE\s*$/m;
+const dir = 'docs/auditor-prototype/prompts';
+
+function toTemplate(s) {
+    return '`' + s.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${') + '`';
+}
+
+let body = '';
+for (const [file, mod] of Object.entries(MAP)) {
+    const content = readFileSync(`${dir}/${file}`, 'utf8');
+    const m = content.match(marker);
+    if (!m) throw new Error(`no # ARTICLE marker in ${file}`);
+    const instructions = content.slice(0, m.index).trim();
+    body += `    ${mod}:\n${toTemplate(instructions)},\n\n`;
+}
+
+const header = `// X-Ray — vendored per-module audit methodology prompts.
+//
+// GENERATED, verbatim, from docs/auditor-prototype/prompts/01-08 (the
+// instruction portion before each file's "# ARTICLE" marker — exactly the
+// CLI scorer's loadPrompt() slice). The extension can't read docs/ at
+// runtime, so the per-module ("thorough") auditor vendors them here. These
+// are the SAME methodology the findings schemas were derived from; the
+// single-shot orchestrator uses a condensed summary instead.
+//
+// To regenerate after editing a prompt: node tools/gen-module-prompts.mjs
+//
+// Imported only by the background service worker (the audit runner), so it
+// never weighs down the reader bundle.
+
+export const MODULE_PROMPTS = Object.freeze({
+${body}});
+`;
+
+writeFileSync('src/shared/audit/module-prompts.js', header);
+console.log('wrote src/shared/audit/module-prompts.js');


### PR DESCRIPTION
## What

Adds the **in-extension epistemic auditor** — the "(b) local-first runner" the design note staged behind the CLI path. Reader buttons score the open capture against all eight dimensions via the Anthropic Messages API (background SW), then ingest the result through the **existing `importAuditJson` firewall**.

Two rigor modes:
- **Quick audit** — one forced tool call, all eight modules (single-shot; cheaper, lower rigor). Carries a standing "lower rigor" caveat.
- **Thorough audit** — one **independent** call per dimension (parallelized), each with its **full vendored methodology** (`shared/audit/module-prompts.js`, generated verbatim from `docs/auditor-prototype/prompts/01–08`) and its own output budget. The orchestrator doc's production recommendation, ~8× cost, gated by a confirm. No single-shot caveat.

This is the LLM *execution* path beside the two Phase‑13 paths (CLI scorer + file importer). **Stacked on `claude/admiring-rubin-kxd8pe`** (Phase 14.5 LLM-assist), so this diff is just the audit work + the Suggest-defaults refinement below. Retarget to `main` once the base merges.

## Also in this PR — Suggest defaults (a Phase 14.5 refinement)

Defaults the LLM **Suggest** pass to **Entities + Claims** (extraction); **relationships, assessments, and forensic findings are opt-in** via new Options ▸ Advanced ▸ LLM assist checkboxes. The line is *extraction vs judgment*: a false-positive extraction is a one-click reject, but an auto-suggested *stance* or *maneuver* is the tool manufacturing the verdict X-Ray refuses to render. The pass both scopes its prompt to the enabled kinds and filters the result to them. Logically a 14.5 change — it rides here so it's testable alongside the auditor (both touch `llm-client.js`); `#72` stays the pure Suggest PR. New: `tests/llm-suggest-kinds.test.mjs`; `SUGGEST_DEFAULT_KINDS` / `normalizeSuggestKinds` / `categoryOfProposalKind` in `llm-prompts.js`; `xray:llm:suggest_kinds` storage.

## How the auditor stays honest

- **Tool schema built from the validator's `PAYLOADS`** — one source of truth, so a clean pass can't drift out of schema.
- **Aggregate computed in code, never the model's** — weights + source-quality knowability-ceiling heuristic + confidence stacking ported from the CLI scorer (PHILOSOPHY §4).
- **Reuse the firewall, don't fork it** — both modes assemble the canonical `{article, module_results, predictions, aggregate}` and feed the same `importAuditJson`: same RQ1 hash gate (we send the same markdown we hash), same per-module schema validation, same per-module failure posture (absent/malformed module → FAILED, the rest still aggregate).
- **Gating** — same `llmAssist` flag + key as Suggest; flag-off or no-key ⇒ no network call reachable. Running/importing local-only; **publishing stays behind `epistemicAuditing`**.
- **No constitution change** — §8 already makes a model a first-class auditor; methodology version stays `1.0`.

## Files

- **new** `src/shared/audit/audit-prompt.js` — prompts, tools (`buildAuditTool` / `buildSingleModuleTool`), `assembleAudit` (with `standingCaveat` param), deterministic aggregate.
- **new** `src/shared/audit/module-prompts.js` (+ `tools/gen-module-prompts.mjs`) — the eight methodology prompts vendored verbatim; SW-bundle only.
- `src/shared/llm-client.js` — `runAuditPass` / `runPerModuleAudit` / `extractToolInput`; the Suggest-kinds scoping + filter; Anthropic fetch factored into a shared `postMessages`.
- `src/shared/llm-prompts.js` — Suggest-kinds constants/helpers; `buildSystemPrompt` accepts `tasks`.
- `src/background/index.js` — `xray:audit:run`.
- `src/reader/index.{html,js}` — Quick + Thorough controls; Suggest no longer hardcodes `task:'all'`.
- `src/options/{options.html,index.js}` — per-kind Suggest checkboxes.
- `src/shared/audit/findings-schemas.js` — export `PAYLOADS`.
- docs: CHANGELOG, JOURNAL, EPISTEMIC_AUDIT_DESIGN, SMOKE_TEST §13.7a–f + §14.5.

## Tests / checks

- **new** `tests/audit-llm.test.mjs` (11) + `tests/llm-suggest-kinds.test.mjs` (5).
- `npm test` **936 green** · `npm run build` clean · `web-ext lint --self-hosted` **0 errors**.

## Manual test

Options ▸ Advanced ▸ LLM assist: enable `llmAssist` + save a key; confirm Suggest defaults to **Entities + Claims**. Capture an article → **Quick audit** / **Thorough audit**. Walk `docs/SMOKE_TEST.md` §13.7a–f and §14.5.4b/5b. (Headless container can't drive a browser; verified by tests + lint here. Thorough audit makes a live ~8-call request — use a spend-capped key.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B