### PR TITLE
docs: finalize Phase 15 (truth adjudication) + add Phase 16 (moral-lens) design drafts

### DIFF
--- a/docs/BONDING_NOTES.md
+++ b/docs/BONDING_NOTES.md
@@ -1,0 +1,137 @@
+# BONDING_NOTES.md
+
+**Status:** parking-lot exploration, not a spec. Captures the
+"money-where-your-mouth-is" bonding idea so we can pick it up later.
+**Deferred, out of v1 scope** for the truth-adjudication layer — the
+integrity substrate it builds on is
+[`TRUTH_ADJUDICATION_DESIGN.md`](TRUTH_ADJUDICATION_DESIGN.md) §3.4 (the
+"integrity doc" / "INTEGRITY_DESIGN.md" referenced below is that section;
+there is no separate integrity file).
+
+**The pitch (your framing):** the integrity/resolution substrate could
+be the base layer for a **decentralized Kalshi/Polymarket that actually
+incentivizes truth-seeking** — not just truth-*betting*. Bonds attach to
+the claims and predictions we already model; resolution and reputation
+are already half-built. The market *is* the epistemic graph, not a
+separate venue.
+
+---
+
+## Why this composes cleanly with what we have
+
+The integrity doc already defines the non-financial version of skin in
+the game: a pubkey's calibration / accuracy / correction record, derived
+from resolutions (30059) and disputes (30061), gated to claims that can
+be *wrong in a resolvable way*. **Bonding is the same substrate with an
+economic layer bolted on:**
+
+- A bond is an optional Lightning stake attached to a
+  **reputation-eligible** claim — i.e. a prediction (30058) with
+  pre-stated resolution criteria, or an `enacted` fact-claim with a
+  resolution path. (Same eligibility gate. Interpretations and stance
+  stay un-bondable, by construction — you cannot stake on a value.)
+- Resolution against the pre-stated criteria settles the bond: correct
+  -> stake returned + reward; wrong -> slashed.
+- Reputation and stake can combine (reputation-weighted stake), so truth
+  is not purely capital-weighted (see hard problem #2).
+
+So the schema work in the integrity layer
+([`TRUTH_ADJUDICATION_DESIGN.md`](TRUTH_ADJUDICATION_DESIGN.md) §3.4) is the
+prerequisite; bonding is a layer on top, not a parallel system.
+
+> **Vocabulary note.** These notes predate the truth-adjudication doc and
+> use `enacted` / `ascribed` / `broken-by-conduct`. The canonical
+> vocabulary is that doc's `proposition_class` (`event-fact` /
+> `state-fact` / `prediction` / `stated-commitment` / `stated-value` /
+> `interpretation`) and match states (`fulfilled` / `broken` /
+> `consistent` / `contradicted` …). Read `enacted` ≈ `event-fact` /
+> `state-fact`, `ascribed` ≈ `interpretation` / `stated-value`,
+> `broken-by-conduct` ≈ a `contradicted` IntegrityFinding.
+
+## What makes it "truth-seeking," not just a prediction market
+
+Kalshi (centralized, CFTC-regulated) and Polymarket (centralized
+resolution via UMA's optimistic oracle) price **future events**. The
+interesting extension here is broader:
+
+- **Present-fact bonding** — stake on "this `enacted` claim about
+  reality is true," resolved by corroboration / surviving dispute, not
+  just on "will X happen."
+- **Integrity bonding** — stake on a documented word<->deed contradiction
+  (a `broken-by-conduct` edge), resolved on the evidence.
+- **Pay people to find reality** — rewards can flow to whoever supplies
+  the corroborating primary-source claim (a `supports` edge), not only
+  to whoever guessed the outcome. That incentivizes *documentation and
+  discovery*, which is the part prediction markets don't reward.
+
+That's the difference between "a market that prices beliefs" and "a
+market that pays for verified reality."
+
+## Prior art to study before designing
+
+- **UMA optimistic oracle** — the assert-then-challenge pattern that
+  resolves Polymarket. The cleanest decentralized resolution primitive.
+- **Augur** — fully decentralized, REP-token Schelling-point resolution.
+  Study both the design and *why it struggled* (liquidity, slow/awkward
+  resolution, fork mechanics).
+- **Kleros** — decentralized arbitration via staked jurors; the model for
+  making *challengers* stake too.
+- **Reality.eth** — escalation-game oracle; good reference for crowd
+  resolution with bonded answers.
+- **Robin Hanson, futarchy** — the theoretical north star (decisions by
+  prediction market), plus **proper scoring rules** (Brier, log) for
+  incentive-compatible forecasting — ties directly to `calibration.js`.
+- **Community Notes bridging** — for resolution that resists faction
+  capture (see #2).
+
+## Hard problems (the honest list)
+
+1. **The oracle problem.** Who/what declares resolution? Options:
+   designated trusted-source list, optimistic oracle + challenge window,
+   bonded crowd vote, or bridging-consensus. Each has a failure mode;
+   probably different mechanisms for different claim types
+   (a court record resolves cleanly; "did his conduct contradict his
+   value" does not).
+2. **Capital-weighted truth — the central danger.** If resolution is
+   stake-weighted voting, the rich buy "truth." A truth market that
+   becomes "whoever has the most money is right" is worse than nothing.
+   Mitigations to evaluate: reputation-weighting (not just capital),
+   bridging (reward cross-faction agreement), quadratic mechanisms,
+   conviction over time. This is the make-or-break constraint.
+3. **The subjectivity boundary.** Only *cleanly falsifiable* claims are
+   bondable. The `role` + resolution-criteria gate is the firewall:
+   bond `enacted` facts and `prediction`s with criteria; never
+   `ascribed` interpretations, stance, or moral-lens verdicts. Get this
+   wrong and you are paying people to enforce an orthodoxy.
+4. **Regulatory exposure.** Event-contract / prediction markets touch
+   CFTC, gambling, money-transmission, and possibly securities law
+   (Kalshi spent years litigating the CFTC; decentralized venues raise
+   their own money-transmitter questions). A Lightning-bonded version
+   does not escape these by being decentralized. Flagging as a real
+   design constraint — **not legal advice; this needs actual counsel
+   before anything ships.**
+5. **Griefing / frivolous challenges.** Symmetric staking (Kleros-style)
+   so challengers also have something at risk.
+6. **Cold start.** Markets need liquidity and participants; the
+   epistemic-graph framing (bonds on claims people already make) is one
+   bootstrap path, but worth thinking through.
+
+## Open questions for the future session
+
+- Lightning mechanics: hold-invoices / escrow / DLCs (Discreet Log
+  Contracts are the native Bitcoin primitive for oracle-settled bets —
+  likely the right substrate, given the stack)?
+- Where does the reward pool come from — slashed counter-bonds, a fee,
+  or both?
+- Reputation-weighted vs pure-capital stake — can we make the former the
+  default so #2 is mitigated from day one?
+- Which claim types are bondable at launch (likely: predictions with
+  criteria only), and what is the staged path to present-fact and
+  integrity bonding?
+- DLC/oracle design for the resolution source per claim type.
+
+**Bottom line:** the substrate you'd need is mostly the integrity layer.
+Bonding is a believable second act — but the whole thing lives or dies
+on resolution design (problem #1) and resisting capital capture (#2).
+Worth a dedicated session once the `role` + conduct-edge + reputation
+primitives exist to attach bonds to.

--- a/docs/BONDING_NOTES.md
+++ b/docs/BONDING_NOTES.md
@@ -43,9 +43,10 @@ prerequisite; bonding is a layer on top, not a parallel system.
 > use `enacted` / `ascribed` / `broken-by-conduct`. The canonical
 > vocabulary is that doc's `proposition_class` (`event-fact` /
 > `state-fact` / `prediction` / `stated-commitment` / `stated-value` /
-> `interpretation`) and match states (`fulfilled` / `broken` /
-> `consistent` / `contradicted` …). Read `enacted` ≈ `event-fact` /
-> `state-fact`, `ascribed` ≈ `interpretation` / `stated-value`,
+> `interpretation`) plus its **`subject_role`** axis (`stated` / `enacted` /
+> `ascribed`) and match states (`fulfilled` / `broken` / `consistent` /
+> `contradicted` …). Read `enacted` ≈ `subject_role: enacted` over an
+> `event-fact` / `state-fact`, `ascribed` ≈ `subject_role: ascribed`,
 > `broken-by-conduct` ≈ a `contradicted` IntegrityFinding.
 
 ## What makes it "truth-seeking," not just a prediction market

--- a/docs/MORAL_LENS_JURISDICTION_DESIGN.md
+++ b/docs/MORAL_LENS_JURISDICTION_DESIGN.md
@@ -1,0 +1,291 @@
+# Moral-Lens Evaluation — design (Phase 16)
+
+> **Status:** design draft (2026-06-24). **Phase 16.** Depends on Phase 14.5
+> (LLM-assist client) landing and sits on the far side of the Phase-15 truth
+> firewall (`docs/TRUTH_ADJUDICATION_DESIGN.md`). **Derived/advisory only:**
+> no wire kind, nothing auto-saved, computed-on-open. This doc evaluates and
+> specifies the engine sketched in the `moral-lens-jurisdiction` system-prompt
+> draft; the prompt artifact itself is authored at implementation (16.2).
+
+This layer answers a question the rest of the stack deliberately refuses:
+*"Under a named perspective J, how would assertion A be read, and on what
+authority?"* It never asks *"is A true?"* — that firewall is the whole point.
+
+---
+
+## §1. Why this exists — the missing half of the truth firewall
+
+Phase 15 (`TRUTH_ADJUDICATION_DESIGN.md` §3.1) draws a hard line. A
+proposition is adjudicable as true/false only when it is an `event-fact`,
+`state-fact`, `prediction`, or `stated-commitment`. **Interpretations and
+bare values are explicitly *not* adjudicable** — "only the honesty of the
+reasoning behind them is assessable… the firewall against the tool becoming
+an orthodoxy enforcer."
+
+That leaves a real gap. An article's load-bearing work is often *normative*
+("men should step down from hierarchy") or *framing* (what the title
+emphasizes, what is omitted, the tone). Phase 15 correctly declines to call
+these true or false. But declining to adjudicate is not the same as having
+nothing useful to say. This layer takes exactly the proposition classes the
+truth layer firewalls off and does the only honest thing available:
+**reconstructs how specific, named perspectives would read them, grounded in
+those perspectives' own authorities** — and reports its own evidentiary
+honesty as the payoff.
+
+The truth layer and this layer are two sides of one wall:
+
+| | Truth layer (Phase 15) | Lens-reading layer (Phase 16) |
+|---|---|---|
+| Owns | `event-fact` / `state-fact` / `prediction` / `stated-commitment` | `interpretation` / `stated-value` / `normative` / `framing` |
+| Asks | "Is the proposition true?" | "How would perspective J read it?" |
+| Output | descriptive truth-state (true/false/contested/unresolved) | a `disposition` *under a named jurisdiction*, never in the tool's voice |
+| Voice | the world | the perspective |
+| Persisted | wire kinds `30063`/`30064` (gated) | nothing — derived view only |
+
+---
+
+## §2. Position in the judgment stack
+
+X-Ray already separates several judgment kinds by wire kind so none can be
+mistaken for another. This layer extends that discipline and is the first
+that produces **no canonical wire artifact at all**.
+
+| Layer | Kind | What it judges | Form |
+|---|---|---|---|
+| Assessment | `30054` | the reader's own stance on a claim | stance + labels |
+| Audit | `30056`–`30061` | article craft / epistemics | 0–100 **estimation** w/ knowability ceiling |
+| Forensic | `30062` | behavioral maneuvers | categorical, no score |
+| Truth | `30063`/`30064` | truth-value of facts & commitments | descriptive state, measurements only |
+| **Lens-reading** | **none (derived)** | **how a named perspective reads normative/framing/value** | **per-jurisdiction `disposition` + integrity report** |
+
+**Firewall map.** This layer owns precisely the proposition classes Phase 15
+§3.1 excludes. A reader who wants "is this true" goes to the truth layer; a
+reader who wants "how would this tradition / author / legal code see it" comes
+here. Neither answers the other's question.
+
+---
+
+## §3. Division of labor with the truth layer (the central integration)
+
+Assertions are tagged, as in the source prompt, `factual | normative |
+framing`. The boundary with Phase 15 is sharp and one-directional:
+
+- **`normative`, `framing`, and value/`interpretation` assertions** are this
+  layer's to evaluate — perspectivally, never as truth.
+- **`factual` assertions** are **deferred to the truth layer.** This engine
+  does **not** pronounce a fact true or false even when a jurisdiction's
+  corpus takes a side. The most it may say about a factual assertion is the
+  *descriptive* observation **"jurisdiction J's loaded corpus asserts / denies
+  / is silent on this,"** which is a statement about the corpus, not about
+  reality. Any actual truth-adjudication routes to Phase 15.
+
+This keeps the two layers from quietly competing: a `worldview` "ruling" that
+a factual claim is false would be truth-policing in perspectival costume, and
+is forbidden here.
+
+---
+
+## §4. Core concepts mapped to existing infrastructure
+
+The source prompt's three abstractions already have homes in the codebase —
+nothing new is invented at the storage layer.
+
+| Prompt concept | X-Ray substrate | File |
+|---|---|---|
+| **Jurisdiction** (codified / worldview / persona) | an **entity** (`person`/`organization`, with `description`, `canonical_id` alias, keypair) | `src/shared/entity-model.js` |
+| **Authority** (statute §, scripture + tradition, book locator, captured excerpt) | a **captured claim + W3C anchor** (verbatim quote + locator, rehydratable) | `src/shared/claim-model.js`, `src/shared/metadata/anchor-capture.js`, `anchor-resolver.js` |
+| **Target** (the article under review) | a captured article (`30023`) | existing capture pipeline |
+| **Opinion** | a **derived view**, computed-on-open, never auto-saved | follows `src/shared/audit/dossier.js` pattern |
+
+The three jurisdiction **definition templates** from the prompt (codified /
+worldview / persona, with the bell hooks / Celeste Davis / multi-tradition
+Christianity / US-federal examples) are carried forward verbatim as *inputs*
+to the engine, not part of it.
+
+---
+
+## §5. Design principles — adopt all eight, with three corrections
+
+The source prompt's eight principles (ground-in-corpus, lens-vs-truth
+separation, steelman, encoded pluralism, living-person guardrail, calibrated
+confidence, cite-precedent/flag-silence, split-content-from-framing) are
+adopted as written — they are already congruent with `PHILOSOPHY.md` (P3
+verbatim-evidence, the never-score-a-conclusion rule, §3.2 steel-manning).
+Three points need explicit reconciliation so the layer doesn't contradict the
+rest of the stack:
+
+### 5.1 Confidence is a *legitimate estimation*, not a stray score
+
+The truth layer's §1 forbids estimated scores standing in for verdicts:
+*"Verdicts are descriptive states. Quantities are measurements, never
+estimations."* This engine's `high | medium | low` confidence **is** an
+estimation. It is nonetheless **admissible here, for the same reason the
+audit's 0–100 is** (truth-doc §1: an estimation is legitimate where scope is
+"limited" and purpose is "heuristic"):
+
+> A lens-reading is **not a truth-verdict.** Its confidence measures the
+> *fidelity of a perspectival reconstruction* — how directly the loaded
+> corpus addresses the assertion, how unified the tradition is, how much
+> inference was required — never how true the assertion is or how strongly
+> the jurisdiction "feels." Because it makes no claim about reality at human
+> stakes, the §1 prohibition does not bind it; it sits on the
+> estimation-legitimate side of the same line the audit score sits on.
+
+This must be stated wherever confidence is surfaced, or it reads as a
+violation of §1 when it is in fact an instance of §1's own carve-out.
+
+### 5.2 Surface framing is **"lens-reading," not a court**
+
+The source prompt's "Online Court of Justice / rulings / verdicts / opinion"
+metaphor collides with two things: the truth layer's own reserved word
+**"verdict,"** and X-Ray's under-claiming posture (`CRIMINOLOGY_DESIGN.md`'s
+"structural observations, not verdicts"). The *structure* is kept —
+authorities, confidence, content-vs-framing split, integrity report — but the
+surface vocabulary changes:
+
+| Prompt term | This layer's term |
+|---|---|
+| ruling / verdict | **reading** / `disposition` |
+| court opinion | **perspectival reconstruction** |
+| jurisdiction | jurisdiction *(kept — it is descriptive)* |
+
+"Verdict" is reserved for Phase 15 so the firewall stays legible at a glance.
+The `disposition` vocabulary itself is unchanged from the prompt:
+`endorses | rejects | partially_endorses | reframes | out_of_scope | silent`.
+
+### 5.3 Panel composition is a symmetry obligation (new)
+
+The prompt's integrity report covers *per-jurisdiction* honesty well
+(grounded vs inferred, thin-coverage, recommended sources). It does not cover
+the bias that enters one level up: **which** jurisdictions get empaneled.
+Loading only lenses hostile to a target turns the panel into a hit piece
+while every individual reading stays scrupulously grounded. `PHILOSOPHY.md`
+**P5 (symmetry is existential)** applies directly:
+
+> The empaneled jurisdictions, and the basis for selecting *these and not
+> others*, are disclosed in the integrity report's new `panel_composition`
+> field. A panel with no jurisdiction a fair observer would expect to be
+> sympathetic to the target is flagged, exactly as an audit that is never
+> "uncomfortable for every camp" is flagged. Selection is itself a judgment
+> call, and asymmetric selection is how this tool would die quietly.
+
+---
+
+## §6. Architecture and reuse
+
+- **The model call** uses the Phase 14.5 client (`src/shared/llm-client.js`,
+  built in 14.5): Anthropic Messages API from the background service worker,
+  `anthropic-dangerous-direct-browser-access`, API key in
+  `chrome.storage.local` (`xray:llm:key`). This layer is purely a *consumer*
+  of that seam and ships nothing of its own at the transport layer.
+- **The opinion is a derived view**, following `audit/dossier.js`: "DERIVED,
+  REPRODUCIBLE… computed-on-open." The model pass is not deterministic, but
+  its **inputs are pinned and reproducible** — authorities cited by edition /
+  ISBN / locator, the target article hash, the jurisdiction definitions, and
+  the prompt version. Provenance is `suggested_by: 'llm:<model>'`, the seam
+  already baked into every model.
+- **Nothing auto-saves and nothing publishes**, inheriting the Phase 14.5
+  rule. A lens-reading is shown, can be discarded, and only its *constituent
+  artifacts* (a captured authority excerpt, an entity) persist through the
+  existing `create()` paths on explicit user confirmation.
+- **Gating:** a new `moralLens` flag in `FLAGS_DEFAULTS`
+  (`src/shared/metadata/feature-flags.js`), default off, **plus** the API-key
+  second consent gate inherited from 14.5 (article text leaves the device).
+- **No wire kind.** Kind **`30066` is left free**; if lens-readings ever
+  become shareable on relays that is a deferred, separately-designed act
+  (§9), not part of v1.
+
+---
+
+## §7. Output contract
+
+The engine emits a machine-readable object plus a human-readable
+reconstruction, structurally the source prompt's schema with the §5.2 renames
+and the §5.3 addition. Sketch (full schema authored at 16.2):
+
+```json
+{
+  "target": { "title": "…", "url": "…|null",
+    "claims": [ { "id": "c1", "text": "verbatim", "type": "factual|normative|framing" } ] },
+  "jurisdictions": [ {
+    "id": "bell-hooks", "type": "persona|worldview|codified",
+    "display_name": "…", "is_living_person": false,
+    "authorities_loaded": [ { "authority_id": "…", "citation": "work+edition+locator", "coverage": "high|medium|low" } ],
+    "internal_divisions": [ "…" ],
+    "readings": [ {
+      "claim_id": "c1",
+      "disposition": "endorses|rejects|partially_endorses|reframes|out_of_scope|silent",
+      "reasoning": "in the jurisdiction's own logic",
+      "authorities_cited": [ { "authority_id": "…", "locator": "…", "grounding": "direct_quote|paraphrase|inference" } ],
+      "content_vs_framing": "how substance vs. framing fare, separately",
+      "confidence": "high|medium|low",
+      "confidence_rationale": "coverage + unity + inference load (fidelity, not feeling — §5.1)"
+    } ],
+    "reconstruction_summary": "short narrative in the jurisdiction's voice",
+    "integrity": {
+      "grounded_count": 0, "inferred_count": 0,
+      "thin_coverage_flags": [ "…" ], "recommended_sources": [ "…" ]
+    }
+  } ],
+  "panel_composition": {
+    "empaneled": [ "…" ],
+    "selection_basis": "why these jurisdictions",
+    "symmetry_flags": [ "no jurisdiction sympathetic to the target was loaded" ]
+  },
+  "panel_comparison": {
+    "agreements": [ "…" ],
+    "divergences": [ { "claim_id": "c1", "split": "who reads what, and the premise driving it" } ]
+  }
+}
+```
+
+Quoting discipline inherits X-Ray's copyright rules: authorities cited by
+locator, content paraphrased; short attributed excerpts only where exact
+wording is load-bearing.
+
+**Hard stops** (refuse or downgrade, never fabricate): no corpus loaded for a
+jurisdiction → do not read, report "jurisdiction not grounded"; corpus does
+not address a claim → `silent`, not a guess; living-person persona → the
+guardrail is non-negotiable; a locator that can't be anchored to a named
+edition → `grounding: inference` and flag it.
+
+---
+
+## §8. Slice plan (Phase 16.x)
+
+- **16.0 — gate.** Phase 14.5 LLM-assist (`llm-client.js`, `llmAssist` flag,
+  key-consent UI) merged. This layer does not start before it.
+- **16.1 — jurisdiction model.** Entity-backed jurisdiction records; the three
+  definition templates (codified / worldview / persona); corpus-loading that
+  binds authorities to captured claims + anchors; exhaustive-enum tests for
+  `type` and `disposition`.
+- **16.2 — the lens-reading engine.** System prompt (hardened from the draft
+  with the §5 corrections) + `llm-client` call + structured-output parse into
+  the §7 contract; derived view, never saved.
+- **16.3 — surfaces.** Reader/portal rendering of the reconstruction + the
+  integrity report + the **`panel_composition` disclosure**; the
+  content-vs-framing split shown per reading.
+- **16.4 — guardrails as tests.** Living-person guardrail enforcement;
+  symmetry/selection-discipline checks (thin corpus → `silent`,
+  unloaded jurisdiction → refuse, one-sided panel → flag).
+- **(deferred)** publishable wire kind `30066`; persona-corpus capture
+  tooling; multi-target panels.
+
+---
+
+## §9. Open questions / deferred
+
+1. **Persona corpus provenance.** The living-person guardrail says "published
+   positions only," but X-Ray captures social posts that may not be
+   publications. Persona jurisdictions should require a genuine published
+   corpus, not scraped semi-private posts — needs a concrete admissibility
+   rule.
+2. **Factual hand-off UX.** How a `factual` assertion visibly routes from this
+   layer to Phase 15 in the reader, so the firewall is legible to the user and
+   not just to the code.
+3. **Built-in vs user-authored jurisdictions.** Whether a curated set ships
+   (with its own selection-bias exposure) or jurisdictions are entirely
+   user-defined.
+4. **Wire format, if ever.** Should lens-readings become shareable, `30066`
+   and a NIP draft framing them as *perspectival reconstructions, not
+   verdicts* — a separate design, gated on demand that does not yet exist.

--- a/docs/MORAL_LENS_JURISDICTION_DESIGN.md
+++ b/docs/MORAL_LENS_JURISDICTION_DESIGN.md
@@ -83,6 +83,14 @@ This keeps the two layers from quietly competing: a `worldview` "ruling" that
 a factual claim is false would be truth-policing in perspectival costume, and
 is forbidden here.
 
+The firewall runs the other way too: a lens-reading is **never** an input to
+integrity or asserter reputation. The truth layer's own lineage notes the same
+boundary from the integrity side — its v0 (`INTEGRITY_DESIGN.md`, now
+`TRUTH_ADJUDICATION_DESIGN.md` §3.1) held that "integrity is orthogonal to
+morality… the moral axis's output is never a truth claim and never feeds
+integrity or reputation." This layer is that axis; it stays out of the
+reputation-eligible set (§3.5 of the truth doc) by construction.
+
 ---
 
 ## §4. Core concepts mapped to existing infrastructure

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1231,6 +1231,66 @@ Slices (one PR each; `claude/phase-15-*`):
 
 ---
 
+## Phase 16 — Moral-lens evaluation (lens-readings) 📝 design draft
+
+**The far side of the Phase-15 firewall, and an LLM-assist consumer.** Where
+Phase 15 §3.1 declares interpretations and bare values **not** adjudicable as
+true/false, this layer takes exactly those firewalled-off proposition classes
+— `normative` / `framing` / `interpretation` / `stated-value` — and does the
+only honest thing left: it **reconstructs how named perspectives would read
+them**, grounded in those perspectives' own authorities, and reports its
+evidentiary honesty as the payoff. It never asks "is A true?"; it asks "under
+jurisdiction J, how would A be read, on what authority?" `factual` assertions
+are **deferred to Phase 15** — this layer may only describe whether a
+jurisdiction's corpus asserts/denies/is silent, never pronounce the fact.
+
+A **jurisdiction** is `codified` (a legal code), `worldview` (a tradition,
+pluralism encoded — never one decree for "Christianity"), or `persona` (an
+author's corpus, with a non-negotiable **living-person guardrail**: published
+positions only, never private belief/motive/character). These map onto
+existing substrate — jurisdictions are **entities** (`entity-model.js`),
+authorities are **captured claims + W3C anchors** (`claim-model.js`), the
+target is a captured `30023`.
+
+**Derived/advisory only — no wire kind.** The opinion follows the
+`audit/dossier.js` computed-on-open pattern: the model pass isn't
+deterministic but its inputs are pinned (authorities by edition/locator,
+article hash, jurisdiction defs, prompt version), provenance
+`suggested_by: 'llm:<model>'`. **Nothing auto-saves; nothing publishes**
+(inherited from Phase 14.5). Gated by a new `moralLens` flag (default off)
+**plus** the API-key second consent gate, since article text leaves the
+device. Kind **`30066` is left free**; a shareable wire format is a deferred,
+separately-designed act.
+
+Three corrections to the source prompt are load-bearing: confidence is a
+**legitimate estimation** (fidelity of reconstruction, admissible under
+truth-doc §1's own carve-out — not a truth-verdict); the **surface framing is
+"lens-reading," not a court** ("verdict" stays reserved for Phase 15); and
+**panel composition is a P5 symmetry obligation** — which jurisdictions are
+empaneled, and why, is disclosed and a one-sided panel is flagged.
+
+Full design: [`docs/MORAL_LENS_JURISDICTION_DESIGN.md`](MORAL_LENS_JURISDICTION_DESIGN.md)
+— design draft.
+
+Slices (one PR each; `claude/phase-16-*`):
+
+- 📝 **16.0** Gate — Phase 14.5 LLM-assist (`llm-client.js`, `llmAssist`
+  flag, key consent) merged; this layer does not start before it.
+- 📝 **16.1** Jurisdiction model — entity-backed records; the three
+  definition templates; corpus-loading binding authorities to captured
+  claims + anchors; exhaustive-enum tests.
+- 📝 **16.2** Lens-reading engine — hardened system prompt + `llm-client`
+  call + structured-output parse; derived view, never saved.
+- 📝 **16.3** Surfaces — reader/portal rendering of the reconstruction +
+  integrity report + `panel_composition` disclosure; content-vs-framing split.
+- 📝 **16.4** Guardrails as tests — living-person guardrail;
+  symmetry/selection discipline (thin corpus → `silent`, unloaded → refuse,
+  one-sided panel → flag).
+- 📝 **(deferred)** publishable wire kind `30066`; persona-corpus tooling;
+  multi-target panels.
+
+---
+
 ## Abandonment criteria
 
 From issue #20 — bears repeating. At any phase boundary, if the cost

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,6 +74,10 @@ Phase 13 ███████████░░░░░░░░░  in progre
 Phase 14 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
                                 behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
                                 builds on Phase 13; 14.1–14.4 built, 14.5 pending
+Phase 15 ░░░░░░░░░░░░░░░░░░░░  design draft — truth adjudication: verdicts on
+                                propositions + words-vs-deeds integrity
+                                (docs/TRUTH_ADJUDICATION_DESIGN.md). Builds on
+                                Phase 14; kinds 30063/30064 (30065 reserved)
 ```
 
 Parity with the v4.2 userscript is reached; the project now operates as a
@@ -1151,6 +1155,79 @@ Acceptance demo: the source video itself
 ([`0axZ8EGLaxQ`](https://www.youtube.com/watch?v=0axZ8EGLaxQ)) — profile both
 interlocutors (the symmetry check), with evidence chains, counter-notes, and
 diachronic revision edges visible across the four lenses.
+
+---
+
+## Phase 15 — Truth adjudication (verdicts + words-vs-deeds) 📝 design draft
+
+**Builds on Phase 14.** The Phase 14 forensic chain must land on `main`
+first; this layer composes its findings (`30062`) as a raw signal and takes
+the **next disjoint wire kinds** — **`30063`** `AdjudicatedVerdict` and
+**`30064`** `IntegrityFinding` (with **`30065`** reserved for a precedent
+citation), gated by a separate **`truthAdjudicationPublishing`** flag. New
+development is paused until the Phase 14 chain merges, at which point this
+branch rebases onto it.
+
+This is the **truth-verdict layer Phase 14 deliberately deferred** (its
+non-goals: "truth verdicts on subjects, intent attribution"). Where Phase 11
+registers a personal stance on a claim and Phase 14 names a *maneuver*
+without a verdict, Phase 15 **adjudicates whether an atomized proposition is
+true** — `established-true` / `established-false` / `contested` /
+`unresolved` / `insufficient-evidence` — on a declared common-law
+**standard of proof**, with verbatim two-sided evidence, tiered sources,
+adjudicator identity + mandatory caveats, and append-only supersession. Its
+**spine** (§1 of the design): *verdicts are descriptive states; every number
+is a reproducible **measurement** that shows its derivation, never an
+estimated score* — the deliberate departure from the epistemic audit's
+0-100 + knowability-ceiling. Its headline *use* is the **integrity
+application**: linking an adjudicated `stated-commitment` / `stated-value`
+to adjudicated **action-facts** (the corroborated convergence of
+*independent* attestations) and ruling the word-deed `match`
+(`fulfilled` / `broken` / `contradicted` …) as its own verdict — **intent
+never adjudicated**, values never policed as true/false, only the observable
+gap. Entity records are **dimension-separated and coverage-bound** (the
+coverage fraction caps every aggregate); the optional rollup is a lossy
+ratio of measured outcomes, never a fused score.
+
+**v1 scope** is authoring + wire + local records — the same posture Phases
+11/13/14 take. The client emits well-structured verdict events behind a flag
+and keeps dimension-separated local records; the **aggregation-layer
+defenses** (cross-author bridging, reputation/track-record weighting, Sybil
+resistance, capital bonding) are **deferred** — the wire carries the fields a
+future protocol layer would consume, but the client does not compute them,
+exactly as Phase 13 shipped `30061` wire-only. Disputes inherit that
+wire-only posture (no adjudication runtime in v1).
+
+Full design, the form-of-judgment spine, the pitfall→defense table, wire
+formats, and red lines:
+[`docs/TRUTH_ADJUDICATION_DESIGN.md`](TRUTH_ADJUDICATION_DESIGN.md) — design
+draft. The deferred bonded-resolution second act is parked in
+[`docs/BONDING_NOTES.md`](BONDING_NOTES.md).
+
+Slices (one PR each; `claude/phase-15-*`):
+
+- 📝 **15.1** Adjudicable-proposition model (local, no wire) —
+  `proposition_class` + `resolution_criteria` atomization over existing
+  claims; the interpretation/value firewall; exhaustive-enum tests.
+- 📝 **15.2** Evidence tiers + attestation graph — tiered evidence;
+  independent-attestation convergence for action-facts (composing 30055
+  `supports`); independence checks.
+- 📝 **15.3** Verdict model + dispute reuse — `AdjudicatedVerdict`
+  (descriptive states, standard-of-proof, verbatim evidence, caveats);
+  multi-adjudicator variance *surface*; supersession; reuse the `30061`
+  dispute wire format. No estimated-score path exists to build.
+- 📝 **15.4** Integrity application — `IntegrityFinding` (commitment/value
+  vs action match as a verdict; gap-decomposition; intent excluded; the
+  value firewall; revision-as-credit composing 30062).
+- 📝 **15.5** Entity record + coverage — dimension-separated descriptive
+  records; the coverage measurement + cap; the optional gated rollup;
+  calibration from resolved predictions (reusing `audit/calibration.js`).
+- 📝 **15.6** Wire + NIP draft (flag-gated) — `30063`/`30064` builders +
+  parsers; `truthAdjudicationPublishing` flag; NIP draft framing verdicts as
+  evidence-bound descriptive adjudications with required caveats; precedent
+  citation grammar reserved.
+- 📝 **(later)** Precedent + bridging weighting — stare-decisis corpus;
+  bridging-weighted standing (the deferred aggregation-layer tail).
 
 ---
 

--- a/docs/TRUTH_ADJUDICATION_DESIGN.md
+++ b/docs/TRUTH_ADJUDICATION_DESIGN.md
@@ -142,6 +142,15 @@ orthodoxy enforcer. The `stated-value` class is the sharp case: see the
 §3.4 firewall — a value is **never** adjudicated true/false; only the
 **observable gap** between a value and an action is.
 
+> **Companion layer.** Declining to adjudicate is not the same as having
+> nothing to say. The proposition classes this firewall excludes —
+> `interpretation`, `stated-value`, and an article's `normative` / `framing`
+> work — are handled on the far side of the wall by **Phase 16 / moral-lens
+> evaluation** ([`docs/MORAL_LENS_JURISDICTION_DESIGN.md`](MORAL_LENS_JURISDICTION_DESIGN.md)),
+> which reconstructs *how named perspectives would read them* (never as
+> truth), grounded in cited authorities. The two layers are two sides of one
+> wall; "verdict" stays reserved for this side.
+
 ### §3.2 Evidence and attestation
 
 Each adjudicable proposition is anchored to evidence with a declared

--- a/docs/TRUTH_ADJUDICATION_DESIGN.md
+++ b/docs/TRUTH_ADJUDICATION_DESIGN.md
@@ -1,0 +1,409 @@
+# TRUTH_ADJUDICATION_DESIGN.md
+
+**Status:** design draft (Phase 15). A **new feature set**, governed by its
+own objective (below) — not a derivation of `PHILOSOPHY.md`, which governs
+the epistemic-audit layer only. Good ideas are borrowed from there with
+attribution (§4); none of its scoring machinery is inherited by default.
+
+**Depends on Phase 14** (`docs/CRIMINOLOGY_DESIGN.md`, forensic findings
+`30062`, the `forensicPublishing` flag) landing on `main` first — this layer
+composes `30062` as a raw signal and takes the **next disjoint wire kinds**
+(`30063`/`30064`, `30065` reserved). New development is paused until the
+Phase 14 chain merges, at which point this branch rebases onto it.
+
+This is the **truth-verdict layer the forensic phase deliberately deferred**
+(`CRIMINOLOGY_DESIGN.md` non-goals: "truth verdicts on subjects, intent
+attribution"). It composes claims (30040), assessments (30054), links
+(30055), predictions/resolutions (30058/30059), disputes (30061), and
+forensic findings (30062); it adds the verdict, the integrity application,
+the entity record, and a precedent primitive.
+
+> **Note on "v1/v2" below.** Where this doc refers to earlier "v1" and "v2"
+> drafts, it means the two *conceptual iterations* this design integrates —
+> the fused-score instinct and its descriptive-measurement correction — not
+> repo artifacts. There is no prior truth-adjudication doc; this is the
+> first.
+
+## Governing objective
+
+> **Adjudicate what is true and what is false, at human scale, on rigorous
+> evidence standards, in a way that is resistant to the foreseeable pitfalls
+> — and that under-claims by default when the evidence will not bear more.**
+
+Tractability is a first-class constraint, not an afterthought: the system
+declines to adjudicate what it cannot adjudicate honestly, and says so.
+
+## Scope of v1 (what the client actually ships)
+
+This layer follows the same posture the rest of X-Ray uses for judgment
+systems (Phase 11 assessments, Phase 13 audits, Phase 14 findings):
+**v1 is an authoring + wire + local-record layer.** The extension is a
+local-first, single-author **client** — it captures, adjudicates at
+analyst grade, records dimension-separated local results, and emits
+well-structured verdict/integrity events behind a flag. It **does not
+compute or enforce aggregation-layer guarantees** (cross-author bridging,
+reputation/track-record weighting, Sybil resistance, capital staking) — the
+wire format carries the fields those mechanisms would consume, but the
+computation is an ecosystem/protocol concern deferred past v1, exactly as
+Phase 13 shipped the `30061` dispute kind wire-only with the adjudication
+runtime deferred. §2 marks each defense **(v1)** or **(deferred)** on that
+basis, so the doc never claims protection it does not ship.
+
+---
+
+## §1. The form-of-judgment principle (the spine)
+
+A judgment may be expressed as a **score** only when what it measures is
+(a) genuinely graduated *and* (b) either low-stakes enough to tolerate
+approximation, or rigorous enough to defend at the stakes in play.
+
+- The epistemic audit's 0-100 with a **knowability ceiling** is an
+  **estimation** — a best-guess simplification. Legitimate there: limited
+  scope, heuristic purpose.
+- A forensic maneuver is **categorical** — scoring it would fabricate
+  precision. Hence `basis` + counter-indicators, no number.
+- **Truth-value at human scale is neither graduated-enough nor
+  approximation-tolerant.** A proposition is true, false, contested, or
+  unresolved — not "73% true" — and the stakes (adjudicating reality about
+  real people) forbid an estimated score standing in for a verdict.
+
+Therefore this layer obeys one rule above all:
+
+> **Verdicts are descriptive states. Quantities are measurements, never
+> estimations. Every number shows its derivation from evidence, or it does
+> not appear.**
+
+A **measurement** is reproducible and traceable: a count of independent
+corroborating sources; a Brier score computed from *resolved* predictions;
+an inter-adjudicator agreement coefficient; a coverage fraction. An
+**estimation** is an approximate evaluative judgment folded into a number (a
+guessed knowability ceiling; a fused "integrity score"). Measurements are
+admissible as evidence about a verdict; estimations are not admissible as a
+verdict.
+
+This is the precise integration of the two earlier drafts: resist the fused
+estimated score (v1's instinct, correct for the verdict); keep the rigorous
+descriptive measurements (v2's correction, correct for the evidence).
+
+---
+
+## §2. Foreseeable pitfalls and their structural defenses
+
+The objective names "resistant to foreseeable pitfalls." Each defense is a
+design element below — but several are **aggregation-layer** features the
+client cannot itself compute in v1. Each row is tagged **(v1)** when the
+client genuinely enforces it, or **(deferred)** when v1 only emits the
+wire fields a future protocol layer would consume. A defense tagged
+**(deferred)** is *not* a v1 guarantee; the doc claims no protection it
+does not ship.
+
+| Pitfall | Structural defense |
+| --- | --- |
+| **Political / ideological capture** | **(v1)** Symmetry is a hard requirement; adjudicator exposure published; the entity scoreboard must be periodically uncomfortable for every camp or calibration is broken. **(deferred)** Bridging-weighted validation (cross-prior agreement counts; co-partisan-only is discounted) — fields emitted, weighting computed at the aggregation layer. |
+| **Capital capture** ("money buys truth") | **(v1)** Resolution is **never purely stake-weighted** as a red line; interpretations are un-bondable by construction. **(deferred)** Reputation/bridging weighting that dominates stake, and bondable clean-resolution propositions — a financial second act parked in `BONDING_NOTES.md`, not in v1. |
+| **Selection bias / the denominator** | **(v1)** **Coverage is a published, descriptive quantity** — default "undetermined; sample, not census" — and it **caps** what any aggregate may conclude; mandatory balance-sheet symmetry (kept commitments sought as hard as broken); `insufficient-evidence` is a first-class verdict. |
+| **Brigading / Sybil** | **(v1)** Corroboration requires **demonstrated source independence**, not a vote count (independence is a per-verdict authoring discipline). **(deferred)** Adjudicator track-record weighting, web-of-trust, network-level Sybil resistance. |
+| **The oracle problem** | **(v1)** **Tiered evidence standards** + per-class resolution paths; **`unresolved` is a permanent, honest state**, never forced. **(deferred)** Optimistic challenge window + bridging-consensus resolution at the aggregation layer. |
+| **Estimated scores masquerading as measurements** | **(v1)** §1, applied throughout: descriptive verdicts; measurements only; every number carries its derivation. |
+| **Intent overreach** | **(v1)** Intent is **never adjudicated** (it is in the "cannot determine" set); only the observable gap and *documented* explanations are recorded; intent goes to the known-unknowns log. |
+| **Defamation / harm to the powerless** | **(v1)** Knowability + coverage gates make confident verdicts on thin records impossible; the system adjudicates **propositions, not persons** — the reader concludes about the person; **right-of-reply** is emittable in v1 via existing reply/annotation primitives (a subject-authored response event referenced from the verdict); a dedicated right-of-reply UI is deferred. |
+| **Goodharting** | **(v1)** Descriptive quantities are hard to game (you must actually keep commitments / corroborate facts); no single fused metric to optimize; orthogonal dimensions. |
+| **Decontextualization** | **(v1)** Machine-readable-first: no number travels without its evidence and caveats; the verdict and its derivation are one object. |
+| **Vague-rhetoric entrapment** | **(v1)** The **atomization gate**: a stated preference is adjudicable only once it is a specific proposition with resolution criteria; un-atomizable rhetoric is unscorable by construction. |
+| **Recursive trust / cold-start** | **(v1)** Bootstrap on high-knowability propositions (court records, official rolls) where resolution is near-objective. **(deferred)** Reputation and bridging grow from there at the aggregation layer. |
+| **Mutable history / stealth edits** | **(v1)** Content-addressing + append-only supersession (borrowed, P9): nothing overwritten; a stealth edit is a new artifact with a diff. |
+
+---
+
+## §3. Architecture
+
+Six layers. Each is evidence-bound and disputable; none introduces an
+estimated verdict-score.
+
+### §3.1 Adjudicable propositions (the gate)
+
+A claim (30040) is high-volume and thin. It becomes **adjudicable** only
+when atomized into a specific proposition carrying:
+
+- `proposition_class` — one of:
+  - `event-fact` (X did Y at T), `state-fact` (the state of the world is Z),
+    `prediction` (Y will occur by T), `stated-commitment` ("I will X"),
+    `stated-value` ("I value X"), `interpretation` (a reading / value claim).
+- `resolution_criteria` — what evidence would settle it (reuse the
+  Prediction-Extraction discipline: criteria + horizon + hedge +
+  tractability — the field set in `docs/auditor-prototype/prompts/
+  08-prediction-extraction.md`).
+- For `prediction`: a horizon. For facts: "already determinable."
+
+**Interpretations and bare values are not adjudicable as true/false** — only
+the *honesty of the reasoning* behind them is assessable (borrowed: never
+score a conclusion). This is the firewall against the tool becoming an
+orthodoxy enforcer. The `stated-value` class is the sharp case: see the
+§3.4 firewall — a value is **never** adjudicated true/false; only the
+**observable gap** between a value and an action is.
+
+### §3.2 Evidence and attestation
+
+Each adjudicable proposition is anchored to evidence with a declared
+**evidence tier**:
+
+- `tier-1` primary / official (court records, roll-call votes, filings,
+  datasets, signed records, primary recordings);
+- `tier-2` independent reporting;
+- `tier-3` single-source / anonymous / uncorroborated.
+
+**Actions are not textual artifacts.** An action enters the system only as a
+set of **content-addressed attesting artifacts**; the **action-fact is the
+corroborated convergence of independent attestations**, never a primary
+artifact. Its strength is a *measurement*: the count and tier of
+**independent** attestations (independence demonstrated, not assumed —
+two outlets on one wire are one source). Independence is a per-verdict
+authoring discipline in v1 (the author records *why* two sources are
+independent); network-level Sybil resistance over the same field is
+deferred (§2).
+
+### §3.3 The verdict (descriptive, measured — no estimated score)
+
+For each adjudicable proposition, an **AdjudicatedVerdict**:
+
+- `verdict` (descriptive state): `established-true` | `established-false` |
+  `contested` | `unresolved` | `insufficient-evidence`.
+- `standard_of_proof` declared and met (borrowed from common law):
+  `preponderance` | `clear-and-convincing` | `beyond-reasonable-doubt`.
+- `evidence` — verbatim, both sides (borrowed, P3); tiers cited.
+- `adjudicator` identity + method + timestamp + **mandatory caveats** (what
+  this verdict could not determine).
+- `agreement` — **measured**, not averaged: when multiple adjudicators rule,
+  publish each + the variance (borrowed, P8); never collapse to a consensus
+  number. *Wire-emittable in v1; the cross-author variance is computed at
+  the aggregation layer, not by the client.*
+- `bridging` — did adjudicators with divergent priors converge? *A measured
+  signal carried on the wire; weighting it into standing is deferred (§2).*
+- disputable and **superseded, never overwritten**.
+
+The role the epistemic audit gives to a single estimated score is filled
+here by a **bundle of measurements** — standard met, evidence tier,
+adjudicator agreement, bridging — plus a categorical verdict state. That is
+the operational meaning of "rigorous and descriptive."
+
+**Knowability is an honest descriptive limit, not a ceiling-score.** A
+proposition resting on unverifiable sources resolves `insufficient-evidence`
+or `unresolved` and says why — it is not assigned an approximate maximum.
+
+**Disputes (v1 posture).** A verdict reuses the **dispute wire format**
+(`30061` `AuditDispute`) and the **append-only supersession idiom** (§3.6,
+P9) — *not* an adjudication runtime. Phase 13 shipped `30061` wire-only and
+deferred the adjudication runtime (who can rule, status resolution); this
+layer inherits that posture. v1 emits disputes and superseding verdicts;
+the resolution machinery is deferred.
+
+### §3.4 The integrity application (words vs deeds)
+
+One *use* of the engine. An **IntegrityFinding** links an adjudicated
+`stated-commitment` (or `stated-value`) to one or more adjudicated
+action-facts, with:
+
+- `match` (descriptive state): `fulfilled` | `broken` (commitments) /
+  `consistent` | `contradicted` (values) | `unrelated` | `contested` |
+  `insufficient`. The match is itself adjudicated (standard of proof,
+  verbatim evidence, adjudicator agreement, bridging) — **it is a verdict,
+  not a drawn edge.**
+- `gap_decomposition` — when words != deeds, the cause is one of *lie /
+  revision / incapacity / constraint / misattribution*. The system records
+  the observable gap and the **documented** explanation as its own
+  adjudicated sub-claim where evidence exists. **Intent is not
+  adjudicated** (known-unknown). **Documented belief revision on new
+  evidence is potential credit**, not penalty (borrowed, calibration ethos);
+  only undisclosed reversal / post-hoc rationalization is negative — and
+  that is already a forensic `walks-back` / `narrative-patch` (30062),
+  composed in, not re-invented.
+
+**Value firewall (the sharp case).** For a `stated-value`, the system
+**never adjudicates the value as true or false** — values are not
+truth-apt, and policing them is exactly the orthodoxy-enforcement red line
+(§5). The `consistent` / `contradicted` match adjudicates only the
+**observable gap** between a stated value and a documented action-fact: did
+the deeds contradict the words? That is an evidence-bound factual question
+about behavior, not a verdict on the value itself. The value supplies the
+yardstick the subject chose; the action is what is measured against it.
+
+### §3.5 Entity record (dimension-separated, coverage-bound)
+
+Per confirmed default: **dimension-separated descriptive records are
+canonical; a single rollup is optional and lossy.**
+
+Canonical records (each a *measurement*, fully enumerable to its evidence):
+
+- **Commitment record** — the list of atomized commitments with verdict
+  states (kept / broken / pending). A count and a list, not a score.
+- **Stated-value consistency record** — value-vs-action adjudications.
+- **Calibration record** — Brier from *resolved* predictions only (a
+  measurement, reusing `src/shared/audit/calibration.js`; entities who
+  never predict simply have none).
+- **Correction-behavior record** — retractions vs maneuvers, composed from
+  supersessions + 30062 findings.
+
+**Coverage** is published with every record: how much of the identifiable
+commitment-universe was assessed. Default and usual value: *undetermined —
+this is a sample, not a census*, which **caps** any aggregate.
+
+The **optional single rollup**: a transparent function of the *resolved*
+records (e.g., "9 of 12 resolved high-standard commitments kept"),
+explicitly a lossy convenience, hard-gated by coverage, and **never an
+estimated evaluative score** — a ratio of measured outcomes with its
+coverage limit on its face, or it is not shown.
+
+### §3.6 Precedent (primitive in, implementation deferred)
+
+Per confirmed default: design the primitive now, ship later. An
+AdjudicatedVerdict / IntegrityFinding may **cite prior verdicts of the same
+proposition or match class** as `binding` or `persuasive` precedent,
+building a citable corpus so like cases are decided alike at scale. This is
+the most direct answer to the common-law framing; implementation is a later
+phase. (Deferred work; the field and the citation grammar land now so the
+record is precedent-ready from the first verdict.)
+
+---
+
+## §4. What it composes vs. what is new
+
+**Composes (existing):** claims (30040), assessment stance as a raw input
+signal (30054), `revision/*` edges (30055), predictions/resolutions
+(30058/30059), the dispute + supersession **wire format** (30061),
+forensic findings for the bad-faith / maneuver signal (30062), entity
+identities + keys.
+
+**New kinds (proposed, wire-disjoint, additive — following the 30062
+idioms: `{ event, body, dTag }` return shape, deterministic `d`,
+`p`-targeting, NIP-32 `L`/`l` where a label exists with a 1985 mirror,
+multi-letter non-indexed tags, publish behind a new flag; template is
+`buildBehavioralFindingEvent` in `src/shared/metadata/builders.js`):**
+
+- `30063` **AdjudicatedVerdict** — verdict on an adjudicable proposition.
+- `30064` **IntegrityFinding** — commitment/value vs action match.
+- `30065` (reserved) **PrecedentCitation** — or fold precedent into verdict
+  refs; decide at implementation.
+
+All three kind numbers are **confirmed free** (the registry runs through
+`30062`; `30043` is retired). Publishing is gated by a new
+**`truthAdjudicationPublishing`** flag in `FLAGS_DEFAULTS`
+(`src/shared/metadata/feature-flags.js`), slotting in beside
+`assessmentPublishing` / `epistemicAuditing` / `forensicPublishing`. The
+service worker **always accepts** inbound events of every kind (no gate);
+only publish paths and panel tabs gate.
+
+**Borrowed with attribution from the epistemic-audit philosophy (good
+ideas, not governance):** evidence-bound findings (P3); symmetry as
+existential (P5); disagreement-is-data / publish-variance / never-average
+(P8); under-claim (P11); content-addressing + append-only supersession +
+lineage (P9); calibration from *resolved* outcomes (P7); the dispute wire
+format + supersession idiom; first-class adjudicator identity; mandatory
+caveats / known-unknowns log. **Deliberately not borrowed:** the estimated
+0-100 score and the knowability *ceiling-as-score* (§1).
+
+---
+
+## §5. Red lines (non-goals, by construction)
+
+1. **No estimated score as a verdict.** Verdicts are descriptive states;
+   numbers are measurements with shown derivation. (§1)
+2. **No intent adjudication.** The gap is observable; the motive is not.
+   Intent -> known-unknowns. (§3.4)
+3. **Verdicts attach to propositions, not persons.** An entity record is a
+   coverage-bound rollup of proposition-level verdicts; the reader draws the
+   conclusion about the person. (§3.5)
+4. **No aggregate without published coverage.** A confident entity-level
+   claim on an undisclosed sample is forbidden. (§2, §3.5)
+5. **No verdict the reader cannot re-derive.** Every verdict ships its
+   evidence, tiers, standard, adjudicators, and caveats. (§2)
+6. **No asymmetry by valence.** Standards and weights are never tuned to a
+   target; the scoreboard discomforts every camp or it is broken. (§2)
+7. **No value policed as true/false.** Values are not truth-apt; only the
+   observable word-deed gap is adjudicated. (§3.1, §3.4)
+
+A feature requiring one of these crossings is a different, worse system.
+
+---
+
+## §6. Decided defaults / open questions
+
+**Decided (this session):**
+- Dimension-separated records canonical; optional lossy rollup, coverage- and
+  standard-gated.
+- Action-attestation via tiered sources + per-verdict independence
+  discipline; optimistic challenge + bridging-consensus deferred to the
+  aggregation layer.
+- Precedent primitive lands now; implementation deferred.
+- v1 is authoring + wire + local records; network-layer defenses (bridging,
+  reputation weighting, Sybil resistance, bonding) deferred (Scope of v1).
+- Disputes inherit the `30061` wire-only posture; no adjudication runtime in
+  v1.
+
+**Open (settle at implementation):**
+1. Standard-of-proof default per proposition class (e.g., commitments ->
+   clear-and-convincing; facts -> preponderance unless reputationally
+   heavy).
+2. Bridging metric: which concrete cross-prior agreement measure, and how it
+   weights standing without becoming capital/popularity in disguise. *Gated
+   to the deferred aggregation layer — v1 makes no claim resting on it.*
+3. Coverage estimation method: how to bound the "identifiable commitment
+   universe" honestly enough that the coverage fraction is itself a
+   defensible measurement and not a back-door estimation. *Load-bearing for
+   §3.5; the cap is honored in v1 even while the method is refined.*
+4. Precedent: separate `30065` vs. verdict-internal citation refs.
+
+---
+
+## §7. Slice plan (one concern per PR; the A-E cadence)
+
+Branches `claude/phase-15-*`. The wire slice (15.6) depends on the Phase 14
+chain having merged.
+
+- **15.1 — Adjudicable-proposition model (local, no wire).**
+  `proposition_class` + `resolution_criteria` atomization over existing
+  claims; the interpretation/value firewall; exhaustive-enum tests.
+- **15.2 — Evidence tiers + attestation graph.** Tiered evidence on
+  propositions; the independent-attestation convergence for action-facts
+  (composing 30055 `supports`); independence checks.
+- **15.3 — Verdict model + dispute reuse.** `AdjudicatedVerdict` (descriptive
+  states, standard-of-proof, verbatim evidence, caveats); multi-adjudicator
+  variance *surface* (emitted, not computed); supersession; reuse the
+  dispute wire format. No estimated-score path exists to build.
+- **15.4 — Integrity application.** `IntegrityFinding` (commitment/value vs
+  action match as a verdict; gap-decomposition; intent excluded; the
+  value firewall; revision-as-credit composing 30062).
+- **15.5 — Entity record + coverage.** Dimension-separated descriptive
+  records; the coverage measurement + cap; the optional gated rollup;
+  calibration from resolved predictions.
+- **15.6 — Wire + NIP draft (flag-gated).** `30063`/`30064` builders +
+  parsers (first wire tests); `truthAdjudicationPublishing` flag; NIP draft
+  framing verdicts as *evidence-bound descriptive adjudications with required
+  caveats*, never pronouncements; precedent citation grammar reserved.
+- **(later) — Precedent + bridging weighting.** Stare-decisis corpus;
+  bridging-weighted standing — the deferred aggregation-layer tail.
+
+## Implementation seams
+
+`src/shared/claim-model.js` (atomization fields, kept off the high-volume
+capture path — analyst-grade, deliberate, not a tax on casual claims),
+`src/shared/assessment-taxonomy.js` (verdict-state + match + standard-of-proof
+enums, exhaustive-enum pinned, with tests in
+`tests/assessment-taxonomy.test.mjs`), `src/shared/evidence-linker.js` (tiers,
+independence), `src/shared/audit/calibration.js` (resolved-prediction Brier,
+reused), new `src/shared/truth-adjudication-model.js` +
+`src/shared/integrity-model.js` following the `assessment-model.js` /
+`forensic-model.js` patterns, portal `src/portal/entity-view.js` /
+`src/portal/timeline.js` for the coverage-bound record render (alongside the
+existing dossier-block / findings-block components).
+
+## Related notes
+
+- `docs/BONDING_NOTES.md` — the deferred "money-where-your-mouth-is" second
+  act (Lightning-bonded resolution). Parking-lot exploration, not a spec;
+  out of v1 scope. **Vocabulary reconciliation:** this doc's
+  `proposition_class` (`event-fact` / `state-fact` / `interpretation` …) and
+  match states (`fulfilled` / `broken` / `contradicted` …) are canonical;
+  `BONDING_NOTES.md`'s `enacted` / `ascribed` / `broken-by-conduct` terms
+  are an earlier framing of the same ideas, and its `INTEGRITY_DESIGN.md`
+  reference means **§3.4 of this doc** (the integrity layer lives here, not
+  in a separate file).

--- a/docs/TRUTH_ADJUDICATION_DESIGN.md
+++ b/docs/TRUTH_ADJUDICATION_DESIGN.md
@@ -134,6 +134,25 @@ when atomized into a specific proposition carrying:
   tractability — the field set in `docs/auditor-prototype/prompts/
   08-prediction-extraction.md`).
 - For `prediction`: a horizon. For facts: "already determinable."
+- `subject_role` — the proposition's relationship to the entity in `about`,
+  **orthogonal to `proposition_class`** (which types the proposition; this
+  types the *subject-relationship*). One of `stated` (the entity's own word —
+  a profession or commitment), `enacted` (the entity's deed — an action-fact
+  about them), or `ascribed` (a third party's characterization of the entity,
+  neither their word nor their deed). **Absence = `unclassified`. `ascribed`
+  and `unclassified` propositions are excluded from IntegrityFindings by
+  construction** — never default a substantive role, since that would
+  manufacture a word/deed reading the author did not assert. (An IntegrityFinding
+  matches a `stated` commitment/value against `enacted` action-facts about the
+  same entity; an `ascribed` claim is *about* the entity but is not theirs to
+  be held to.)
+- `occurred_at` / `occurred_precision` — the event-time of the deed or
+  utterance (Unix seconds), **distinct from `created`** (when the record was
+  made): it is what lets a deed be matched against the words contemporaneous
+  with it, and what the integrity timeline orders on (§3.4). `occurred_precision`
+  is `exact | day | month | year` — the same no-false-precision discipline as
+  the forensic `basis` enum, so a 1987 action never masquerades as a precise
+  timestamp.
 
 **Interpretations and bare values are not adjudicable as true/false** — only
 the *honesty of the reasoning* behind them is assessable (borrowed: never
@@ -237,7 +256,17 @@ action-facts, with:
   evidence is potential credit**, not penalty (borrowed, calibration ethos);
   only undisclosed reversal / post-hoc rationalization is negative — and
   that is already a forensic `walks-back` / `narrative-patch` (30062),
-  composed in, not re-invented.
+  composed in, not re-invented. The `constraint` cause is **evidence, not an
+  excuse**: a `broken`/`contradicted` match may carry a `constraint_ref` to a
+  *corroborated* action-fact (e.g. "the bill was blocked in committee," anchored
+  to a primary record) that **discounts** the finding — but the constraint
+  claim must clear the same corroboration/dispute bar as any other proposition,
+  so it is never a free pass.
+
+A finding is read as **pattern, not instance**: IntegrityFindings for an entity
+order on the matched action-facts' `occurred_at` (§3.1), so the integrity record
+is a time series (`src/portal/timeline.js`), not a gotcha. A single match is
+noise; a trend is a finding.
 
 **Value firewall (the sharp case).** For a `stated-value`, the system
 **never adjudicates the value as true or false** — values are not
@@ -273,6 +302,38 @@ records (e.g., "9 of 12 resolved high-standard commitments kept"),
 explicitly a lossy convenience, hard-gated by coverage, and **never an
 estimated evaluative score** — a ratio of measured outcomes with its
 coverage limit on its face, or it is not shown.
+
+**Asserter vs. subject — the defamation firewall (principle, not a v1
+deliverable).** Two populations must never be confused. A **subject** is a
+profiled entity an article is *about* (e.g. a public figure): they get the
+coverage-bound catalog above — sourced propositions, verdicts, and findings —
+and **never an auto-emitted person-grade or "liar"/"hypocrite" label**; the
+reader draws the conclusion (§5.3). An **asserter** is a *pubkey that signs*
+verdicts, findings, disputes, or predictions: their track record is a pure
+function of their own public events, recomputable by anyone from relays (the
+`reconcile.js` posture), never an authoritative stored score. Three principles
+constrain how any such record may ever be computed — they bind the design now
+even though the **record itself stays deferred** (Scope of v1; no reputation
+*display* or *weighting* ships in v1):
+
+- **Good-faith-wrong is not bad-faith.** *Wrong* + (well-calibrated **or**
+  retracted) is honest error and **must not be penalized like deception** —
+  punishing it manufactures the chilling effect that kills good-faith
+  participation. Only *wrong* + non-retraction + maneuvering (each evidenced by
+  existing primitives: resolution outcome, absence of an `updates`/supersession,
+  and 30062 `defense/*`/`neutralization/*` findings against the asserter's own
+  conduct) is bad-faith. The reputation layer **adds no new judgment** — it
+  composes already-signed, already-falsifiable evidence.
+- **Symmetric accountability — no free shots.** Assessments (30054), findings
+  (30062), and disputes (30061) are themselves signed claims; their *authors*
+  accrue records too (do the disputes they file survive? do their conduct edges
+  hold up?). You cannot weaponize the accusation machinery without standing on
+  it yourself.
+- **Reputation-eligibility gate.** Only claims that can be *wrong in a
+  resolvable way* count — predictions with pre-stated criteria, and corroborated
+  fact-claims. **Interpretations, stance, and values are never
+  reputation-eligible** (you cannot be "wrong" about a value in a way that
+  resolves); scoring them would just punish dissent — the same firewall as §3.1.
 
 ### §3.6 Precedent (primitive in, implementation deferred)
 
@@ -426,7 +487,25 @@ existing dossier-block / findings-block components).
   out of v1 scope. **Vocabulary reconciliation:** this doc's
   `proposition_class` (`event-fact` / `state-fact` / `interpretation` …) and
   match states (`fulfilled` / `broken` / `contradicted` …) are canonical;
-  `BONDING_NOTES.md`'s `enacted` / `ascribed` / `broken-by-conduct` terms
-  are an earlier framing of the same ideas, and its `INTEGRITY_DESIGN.md`
-  reference means **§3.4 of this doc** (the integrity layer lives here, not
-  in a separate file).
+  `BONDING_NOTES.md`'s `enacted` / `ascribed` terms now map onto this doc's
+  **`subject_role`** axis (§3.1 — `enacted` ≈ `subject_role: enacted` over an
+  `event-fact`/`state-fact`; `ascribed` ≈ `subject_role: ascribed`), and
+  `broken-by-conduct` ≈ a `contradicted` IntegrityFinding. Its
+  `INTEGRITY_DESIGN.md` reference means **§3.4 of this doc** (the integrity
+  layer lives here, not in a separate file).
+
+- **Lineage — the superseded `INTEGRITY_DESIGN.md` (v0).** This layer began as
+  a standalone integrity design that was folded into §3.4–§3.5 here. **Kept from
+  it:** the word/deed/`ascribed` subject axis (now `subject_role`, §3.1), the
+  `occurred_at` / `occurred_precision` event-time primitive (§3.1) and its
+  pattern-not-instance timeline read (§3.4), constraint-as-evidence
+  (`constraint_ref`, §3.4), and the asserter-reputation principles —
+  good-faith-wrong vs bad-faith, symmetric accountability, the asserter/subject
+  firewall, and the reputation-eligibility gate (§3.5). **Changed in the
+  supersession:** v0's *no-new-event-kinds* approach (a `role` tag plus conduct
+  *edges* on 30055) became this doc's first-class addressable kinds
+  `30063`/`30064` — because an adjudicated word-deed *match* deserves to be
+  disputable and supersedable, which a drawn edge is not; and v0's emergent
+  "fact = corroboration gradient" became the explicit evidence-tier +
+  standard-of-proof apparatus of §3.2–§3.3. There is **no separate
+  `INTEGRITY_DESIGN.md` file**; this is its canonical home.

--- a/docs/TRUTH_ADJUDICATION_DESIGN.md
+++ b/docs/TRUTH_ADJUDICATION_DESIGN.md
@@ -164,6 +164,17 @@ deferred (§2).
 
 ### §3.3 The verdict (descriptive, measured — no estimated score)
 
+**Structure: single-author verdict, read-time aggregate.** A `30063` is
+**one author's** ruling on one proposition — an addressable event keyed to
+`(author, proposition)`, exactly as a `30054` assessment is one author's
+stance. There is no consensus event and no authoritative-adjudicator role.
+When several authors rule on the same proposition, **agreement, variance,
+and bridging are computed at read time** over their separate `30063`
+events and **never collapsed into a single number** (borrowed, P8). The
+`agreement`/`bridging` fields below therefore describe what a *reader* (or a
+future aggregation layer) derives across many verdicts — not a value any one
+event asserts about a crowd.
+
 For each adjudicable proposition, an **AdjudicatedVerdict**:
 
 - `verdict` (descriptive state): `established-true` | `established-false` |
@@ -173,12 +184,13 @@ For each adjudicable proposition, an **AdjudicatedVerdict**:
 - `evidence` — verbatim, both sides (borrowed, P3); tiers cited.
 - `adjudicator` identity + method + timestamp + **mandatory caveats** (what
   this verdict could not determine).
-- `agreement` — **measured**, not averaged: when multiple adjudicators rule,
-  publish each + the variance (borrowed, P8); never collapse to a consensus
-  number. *Wire-emittable in v1; the cross-author variance is computed at
-  the aggregation layer, not by the client.*
-- `bridging` — did adjudicators with divergent priors converge? *A measured
-  signal carried on the wire; weighting it into standing is deferred (§2).*
+- `agreement` — **measured**, not averaged: a reader holding many authors'
+  `30063` events on one proposition sees each verdict + the variance
+  (borrowed, P8); they are never collapsed to a consensus number. *Computed
+  read-time across single-author events; no event asserts it.*
+- `bridging` — did authors with divergent priors converge? *A read-time
+  signal over the same event set; weighting it into standing is deferred
+  (§2).*
 - disputable and **superseded, never overwritten**.
 
 The role the epistemic audit gives to a single estimated score is filled
@@ -365,10 +377,12 @@ chain having merged.
 - **15.2 — Evidence tiers + attestation graph.** Tiered evidence on
   propositions; the independent-attestation convergence for action-facts
   (composing 30055 `supports`); independence checks.
-- **15.3 — Verdict model + dispute reuse.** `AdjudicatedVerdict` (descriptive
-  states, standard-of-proof, verbatim evidence, caveats); multi-adjudicator
-  variance *surface* (emitted, not computed); supersession; reuse the
-  dispute wire format. No estimated-score path exists to build.
+- **15.3 — Verdict model + dispute reuse.** `AdjudicatedVerdict` as a
+  **single-author** addressable record keyed to `(author, proposition)`
+  (descriptive states, standard-of-proof, verbatim evidence, caveats);
+  read-time multi-author variance/bridging surface (derived, never an event
+  field); supersession; reuse the dispute wire format. No estimated-score
+  path exists to build.
 - **15.4 — Integrity application.** `IntegrityFinding` (commitment/value vs
   action match as a verdict; gap-decomposition; intent excluded; the
   value firewall; revision-as-credit composing 30062).


### PR DESCRIPTION
## What this is

You asked me to **evaluate** the truth-adjudication design prompt and finalize it, and then to **evaluate** a second artifact — the `moral-lens-jurisdiction` system prompt — and plan it. This PR is docs-only: it adds both design docs, a deferred bonding parking-lot note, and ROADMAP entries. No source code yet — implementation is Phase 15.1+ / 16.0+, gated on the designs.

---

## Part 1 — Phase 15: Truth adjudication

The draft is **philosophically strong and internally rigorous** — the §1 *measurement-vs-estimation* spine is a genuine sharpening, the pitfall table is thorough, and I verified its factual claims against the codebase:

- Kinds `30063`/`30064`/`30065` are **genuinely free** (`30043` retired).
- The borrowed principle citations (**P3/P5/P7/P8/P9/P11**) all match `PHILOSOPHY.md`.
- Every composition surface is real (`30040`/`30054`/`30055`/`30058`/`30059`/`30061`/`30062`); `audit/calibration.js` already computes Brier from *resolved* predictions; the `30062` builder is the wire template.

Its one real weakness was **scope honesty**: it conflated a *network-protocol aspiration* (bridging-weighted, reputation-weighted, Sybil-resistant, capital-bonded adjudication) with a *shippable extension feature*. The fix — confirmed via four decisions — scopes v1 the way Phases 11/13/14 already do (authoring + wire + local records; aggregation-layer defenses deferred). A late sharpening also made `30063` explicitly **single-author, read-time aggregate** (one author's verdict keyed to `(author, proposition)`; agreement/variance/bridging computed at read time, never a consensus event — P8).

Files: `docs/TRUTH_ADJUDICATION_DESIGN.md` (new), `docs/BONDING_NOTES.md` (new, deferred parking-lot), `docs/ROADMAP.md` (Phase 15 section).

---

## Part 2 — Phase 16: Moral-lens evaluation (companion)

The second artifact turns out to be **the missing half of the Phase-15 firewall.** Phase 15 §3.1 declares interpretations and bare values **not** adjudicable as true/false. Phase 16 takes exactly those firewalled-off proposition classes (`normative` / `framing` / `interpretation` / `stated-value`) and reconstructs **how named perspectives ("jurisdictions": codified law / worldview / persona) would read them**, grounded in cited authorities, with an integrity report. It never adjudicates truth; `factual` assertions defer to Phase 15.

Evaluation outcome — strong and disciplined (corpus-grounding, encoded pluralism, living-person guardrail, lens-vs-truth separation all congruent with `PHILOSOPHY.md`). Three decisions applied:

1. **Phase 16 design doc** (not code, not a standalone prompt).
2. **Derived/advisory only** — computed-on-open via the `audit/dossier.js` pattern, `suggested_by: 'llm:'`, **nothing auto-saves**, **no wire kind** (`30066` left free), gated by a new `moralLens` flag + the Phase 14.5 API-key consent gate.
3. **Soften to "lens-reading"** — keep the opinion *structure* (authorities/confidence/integrity); drop "Court of Justice"/"verdict"/"ruling" surface naming ("verdict" stays reserved for Phase 15).

Three corrections baked into the doc: confidence is a **legitimate estimation** under truth-doc §1's own carve-out (fidelity of reconstruction, not a truth-verdict); the surface framing is **lens-reading, not a court**; **panel composition is a P5 symmetry obligation** (disclose which jurisdictions are empaneled; flag one-sided panels). Reuse is grounded — jurisdictions → entities (`entity-model.js`), authorities → captured claims + anchors (`claim-model.js`), the LLM call → the Phase 14.5 client.

Files: `docs/MORAL_LENS_JURISDICTION_DESIGN.md` (new), `docs/ROADMAP.md` (Phase 16 section).

---

## Part 3 — Reconcile the superseded v0 `INTEGRITY_DESIGN.md`

You surfaced the **original `INTEGRITY_DESIGN.md`** — the predecessor that Phase 15 absorbed into §3.4–§3.5 — and asked for a merits + fit/conflict evaluation. Verdict: **a strong v0 that the truth doc correctly superseded on its two biggest calls, but the supersession dropped 3–4 better ideas worth reclaiming.** No conflict with Phase 16 — v0's §3.1 actually *predicts* the moral-lens engine and firewalls it off from reputation.

**Kept the truth doc's choices** where it's superior: new addressable kinds `30063`/`30064` over v0's no-new-kinds conduct *edges* (a word-deed *match* deserves to be disputable/supersedable, which a drawn edge is not); the measurement-vs-estimation spine; evidence-tiers + standard-of-proof over v0's emergent "corroboration gradient."

**Reclaimed v0's better ideas** into the canonical truth doc (docs-only, no new kinds):
- **`subject_role`** (stated/enacted/ascribed), orthogonal to `proposition_class`, giving the previously-homeless `ascribed` class a clean home — excluded from IntegrityFindings by construction (§3.1).
- **`occurred_at` / `occurred_precision`** event-time primitive + the pattern-not-instance timeline read (§3.1, §3.4).
- **constraint-as-evidence** (`constraint_ref` discounts a corroborated finding, never a free pass — §3.4).
- **asserter-reputation principles** (framing only, per your call — display and weighting stay deferred): good-faith-wrong vs bad-faith, symmetric accountability, the asserter-vs-subject defamation firewall, the reputation-eligibility gate (§3.5).
- a **lineage note** recording what was kept vs changed, so the supersession is honest and `BONDING_NOTES`'s redirect stays accurate.

`BONDING_NOTES.md` and the moral-lens doc updated to stay consistent with the now-explicit `subject_role` axis.

---

## Verification

- `30063`/`30064`/`30065` confirmed absent from `src/`; `30066` confirmed free before asserting it. v0's primitives (`occurred_at`/`subject_role`/conduct edges) confirmed absent from code — reconciliation is paper-only, zero migration cost.
- Docs-only diff (`git status` shows only docs).
- `npm test` → **895 passing, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKteYcj2M6gE9ZmQHojfrU