### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Sections per release: **Added** (new features), **Changed**
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-24
+
 ### Added
 
 - **Phase 14.5 — LLM assist (in-extension suggestion engine).** A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ extension approves in-context.
 **Message bus:** everything is `chrome.runtime` messages typed `xray:*`
 (e.g. `xray:capture`, `xray:capture:publish`, `xray:relay:publish`,
 `xray:relay:query`, `xray:sign`, `xray:youtube:fetch`,
-`xray:screenshot:capture`, `xray:flags:reload`, `xray:llm:suggest`). When adding a cross-context
+`xray:screenshot:capture`, `xray:flags:reload`, `xray:llm:suggest`, `xray:audit:run`). When adding a cross-context
 call, add an `xray:*` message rather than reaching across contexts directly.
 
 ### Shared layer (`src/shared/`)

--- a/README.md
+++ b/README.md
@@ -12,18 +12,39 @@ has already said about it.*
 
 ## Status
 
-Phases 0–9 of the roadmap are complete (parity with the v4.2 userscript),
-plus a v0.5.x **post-parity cleanup** (de-FAB / single capture surface,
-settings consolidation, wire-format hygiene). The extension captures
-across every shipped platform handler, publishes events end-to-end, syncs
-entity data across devices, reconstructs paywalled content from cached or
-relay copies, and carries the wire-format foundation for crowdsourced
-URL metadata (annotations / fact-checks / topic-trust — see
-[`docs/NIP_DRAFT.md`](docs/NIP_DRAFT.md)) plus a stable cross-platform
-identity layer (captured commenters and post authors become dedup-able
-identities; cross-platform accounts can be collapsed into one person).
-The codebase operates as a pure WebExtension and is moving toward the
-next milestone — **claim tracking** (see [`docs/ROADMAP.md`](docs/ROADMAP.md)).
+**v0.6.0.** Phases 0–9 (parity with the v4.2 userscript) and the v0.5.x
+post-parity cleanup are complete, and the project has moved well past
+parity into its claim-tracking and epistemic-tooling milestones:
+
+- **Phases 10–11 — claims & assessments.** Atomized claim events
+  (`kind 30040`), typed claim↔claim relationships, and personal
+  assessments (graded stance + issue labels) — opinions to debate, never
+  automated truth verdicts.
+- **Phase 12 — "My Archive" portal.** A full-tab, read-only view of
+  everything you've published, reconciled against relays.
+- **Phase 13 — epistemic audits.** An eight-dimension audit of an
+  article's journalistic quality (headline fidelity, sourcing, omission,
+  …), governed by a normative constitution
+  ([`docs/PHILOSOPHY.md`](docs/PHILOSOPHY.md)): evidence-bound, calibrated,
+  with code-computed aggregates and a knowability ceiling — never naked
+  scores.
+- **Phase 14 — forensic findings.** A behavioral-pattern layer that names
+  structural *maneuvers* with a required counter-read and quoted evidence
+  — structure, never a verdict on intent.
+- **Phase 14.5 — LLM assist (opt-in).** A user-invoked **Suggest** pass
+  proposes capture artifacts (entities + claims by default) for review,
+  and an **in-extension epistemic auditor** runs the audit itself
+  (**Quick** single-shot or **Thorough** per-module). Both call the
+  Anthropic API only when you enable the `llmAssist` flag **and** supply
+  your own key; nothing auto-saves or auto-publishes.
+
+The extension still captures across every shipped platform handler,
+publishes end-to-end, syncs entity data across devices, reconstructs
+paywalled content from cached or relay copies, and carries the
+wire-format foundation for crowdsourced URL metadata (see
+[`docs/NIP_DRAFT.md`](docs/NIP_DRAFT.md)) and a cross-platform identity
+layer. Next up are Phases 15 (truth adjudication) and 16 (moral lens) —
+see [`docs/ROADMAP.md`](docs/ROADMAP.md).
 
 The [**roadmap**](docs/ROADMAP.md) tracks per-phase scope. The
 [**engineering journal**](docs/JOURNAL.md) logs significant bugs, design
@@ -61,9 +82,26 @@ manual checklist that exercises every shipped surface.
 - **Entity system** — per-entity keypairs (publications, people,
   organizations), text-selection tagger in the reader, side-panel
   entity browser, alias resolution, kind-0 profile publishing.
-- **Claims + evidence** — structured claim events (`kind 30040`),
-  entity relationships (`kind 32125`), evidence links
-  (`kind 30043`).
+- **Claims, assessments & relationships** — structured claim events
+  (`kind 30040`), entity↔article relationships (`kind 32125`), and typed
+  claim↔claim links + personal assessments (`kind 30055` / `30054`). The
+  old evidence `kind 30043` is retired. Stances and labels are opinions to
+  debate, never automated verdicts.
+- **Epistemic audits** — an eight-dimension journalistic-quality audit
+  (`kind 30056`–`30061`) governed by [`docs/PHILOSOPHY.md`](docs/PHILOSOPHY.md);
+  import a scorer-CLI JSON or run it in-extension (see LLM assist).
+  Aggregates are computed in code with a knowability ceiling; a score
+  never shows without its confidence.
+- **Forensic findings** — a behavioral-pattern layer (`kind 30062`) that
+  names structural maneuvers with a required counter-read and quoted
+  evidence — structure, not a verdict on intent.
+- **"My Archive" portal** — a full-tab, read-only view of everything
+  you've published, reconciled against relays.
+- **LLM assist (opt-in)** — a **Suggest** pass proposes capture artifacts
+  (entities + claims by default; relationships / assessments / findings
+  opt-in) and an **in-extension auditor** (Quick / Thorough) runs the
+  audit. Both require the `llmAssist` flag **and** your own Anthropic key;
+  every result is a draft you review, and nothing auto-saves or publishes.
 - **Entity sync across devices** — NIP-78 (`kind 30078`) with NIP-44 v2
   encrypt-to-self.
 - **Archive reader** — IndexedDB cache + paywall detection +

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -62,26 +62,30 @@ Phase 12 ████████████████████  complete 
                                 portal (docs/PORTAL_DESIGN.md). 12.1–12.7
                                 shipped incl. adversarial-review fixes;
                                 §Phase 12 smoke-run pending
-Phase 13 ███████████░░░░░░░░░  in progress — epistemic audits
-                                (docs/EPISTEMIC_AUDIT_DESIGN.md; design
-                                accepted 2026-06-11, all eight review
-                                questions answered, the recovered
-                                philosophy vendored normatively at
-                                docs/PHILOSOPHY.md). Kinds 30056–30061
-                                confirmed; 13.1–13.5 merged, 13.6–13.9
-                                (panel / portal / publish / hardening)
-                                pending smoke-test
-Phase 14 ░░░░░░░░░░░░░░░░░░░░  design agreed 2026-06-14 — forensic findings:
-                                behavioral-pattern layer (docs/CRIMINOLOGY_DESIGN.md).
-                                builds on Phase 13; 14.1–14.5 built
+Phase 13 ████████████████████  complete — epistemic audits
+                                (docs/EPISTEMIC_AUDIT_DESIGN.md; normative
+                                constitution docs/PHILOSOPHY.md). Kinds
+                                30056–30061; CLI-import AND in-extension LLM
+                                execution paths; 13.1–13.9 shipped
+Phase 14 ████████████████████  complete — forensic findings:
+                                behavioral-pattern layer
+                                (docs/CRIMINOLOGY_DESIGN.md, kind 30062).
+                                14.1–14.5 shipped
+Phase 14.5 ████████████████░░  complete — in-extension LLM assist: a Suggest
+                                engine (entities/claims by default; the rest
+                                opt-in) + the epistemic auditor (Quick
+                                single-shot / Thorough per-module). Flag- +
+                                key-gated, opt-in, nothing auto-saves
 Phase 15 ░░░░░░░░░░░░░░░░░░░░  design draft — truth adjudication: verdicts on
                                 propositions + words-vs-deeds integrity
                                 (docs/TRUTH_ADJUDICATION_DESIGN.md). Builds on
                                 Phase 14; kinds 30063/30064 (30065 reserved)
 ```
 
-Parity with the v4.2 userscript is reached; the project now operates as a
-pure WebExtension and is moving past parity toward the claim-tracking goal.
+Parity with the v4.2 userscript is long reached; the project now ships
+claims, assessments, the "My Archive" portal, epistemic audits, forensic
+findings, and opt-in LLM assist (**v0.6.0**), and is moving on to truth
+adjudication (Phase 15) and the moral lens (Phase 16).
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X-Ray — NOSTR URL Metadata & Article Capture",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Capture articles as Markdown and publish to NOSTR — Chrome/Firefox MV3 extension.",
   "author": "Decentralized News Network",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xray-extension",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "description": "NOSTR-sourced URL metadata & article capture — Chrome/Firefox MV3 WebExtension.",
   "repository": "github:bryanmatthewsimonson/xray",


### PR DESCRIPTION
Cuts **v0.6.0** — the first release since v0.5.1 (Phase 12), shipping everything merged since: Phases 13 (epistemic audits), 14 (forensic findings), and 14.5 (in-extension LLM assist — the Suggest engine + the Quick/Thorough epistemic auditor), alongside the claims / assessments / portal work.

### Release chores
- **Version bump** to `0.6.0` in lockstep (`package.json` + `manifest.json`) via `npm run version:set`.
- **CHANGELOG**: cut `[Unreleased]` → `[0.6.0] — 2026-06-24` (the release workflow pulls this section verbatim into the GitHub Release body).

### Documentation refresh ("up to date")
- **README**: `Status` and `Features` were stuck at Phase 9 — rewritten to cover claims/assessments, the portal, epistemic audits, forensic findings, and opt-in LLM assist; dropped the **retired `kind 30043`** reference.
- **docs/ROADMAP.md**: Phases 13 / 14 / 14.5 marked complete + shipped; status snapshot and closing line updated.
- **CLAUDE.md**: phase/version status refreshed; `xray:audit:run` added to the message-bus list.

### Checks
- `npm test` **936 green** · `npm run build` clean · `web-ext lint --self-hosted` **0 errors**.
- The manual `docs/SMOKE_TEST.md` pass (CONTRIBUTING release step 3) is a browser task — the new Suggest / Quick audit / Thorough audit surfaces were exercised manually during development.

Merging this, then tagging `v0.6.0` on `main` triggers `release.yml` (build → package → GitHub Release with the `.zip`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B)_