### PR TITLE
fix(audit): normalize percentage-scale confidence in single-shot audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,21 @@ Sections per release: **Added** (new features), **Changed**
 
 ### Fixed
 
+- **In-extension single-shot ("Quick") audit: percentage-scale confidence
+  no longer sinks the whole import.** The single-shot model sometimes
+  emits a dimension's `confidence` as a 0–100 percentage instead of a
+  0.0–1.0 fraction; `buildAggregate` then produced an `overall_confidence`
+  (and module-contribution rows) outside `[0, 1]`, which `importAuditJson`
+  rejected wholesale — surfacing as the reader's "Audit import failed"
+  toast (Thorough mode was unaffected; each module had its own budget and
+  the firewall short-circuited on the aggregate first). `assembleAudit`
+  now normalizes a recovered percentage back into `[0, 1]` (and clamps
+  scores to `[0, 100]`) in the findings it builds, records the degrade as
+  an auditor caveat (P12, never silent), and the reader logs the full
+  import error to the console. The tamper firewall (hash gate,
+  ceiling-source, version/score divergence, schema validation) is
+  unchanged — a recoverable model quirk degrades a number instead of
+  masquerading as corruption.
 - **Publish-path hash fork (blocking, predates Phase 13).** Articles
   whose converted markdown contained `<` (inline small images, code
   fences) were converted to markdown TWICE at publish — mangling the

--- a/src/reader/index.js
+++ b/src/reader/index.js
@@ -1199,7 +1199,10 @@ async function runAuditFromReader(mode = 'single') {
         await refreshAuditStatus();
     } catch (err) {
         // importAuditJson is the firewall — surface its reason verbatim.
-        toast('Audit import failed: ' + (err && err.message), 'error', 7000);
+        // Log the full error (stack + the assembled audit) for diagnosis;
+        // the toast is the human-readable one-liner.
+        console.error('[xray] audit import failed', err, resp && resp.audit);
+        toast('Audit import failed: ' + ((err && err.message) || 'unknown error'), 'error', 7000);
     }
 }
 

--- a/src/shared/audit/audit-prompt.js
+++ b/src/shared/audit/audit-prompt.js
@@ -102,8 +102,10 @@ function moduleToolSchema(name) {
         };
         properties.confidence = {
             type: 'number', minimum: 0, maximum: 1,
-            description: '0.0-1.0 confidence in this score given how much is evaluable from the '
-                + 'article alone. Lower it where surface evaluation is structurally limited.'
+            description: 'Confidence in this score as a DECIMAL FRACTION between 0.0 and 1.0 '
+                + '(e.g. 0.7 means 70% confident) — NOT a 0-100 percentage. It must never '
+                + 'exceed 1. Lower it where surface evaluation is structurally limited, given '
+                + 'how much is evaluable from the article alone.'
         };
         required.push('score', 'confidence');
     }
@@ -171,7 +173,7 @@ GOVERNING PRINCIPLES (non-negotiable):
 
 SCORING (dimensions 1-7 only; prediction_extraction is NOT scored):
 - 90-100 exemplary, affirmative best practice visible; 75-89 solid, minor issues; 60-74 acceptable with noticeable concerns; 40-59 significant problems; 20-39 severe; 0-19 catastrophic.
-- Each scored dimension also gets a confidence 0.0-1.0 reflecting how much is evaluable from the article alone.
+- Each scored dimension also gets a confidence expressed as a DECIMAL FRACTION between 0.0 and 1.0 (e.g. 0.7, never 70) reflecting how much is evaluable from the article alone. Confidence must never exceed 1.
 
 OUTPUT:
 - Use the ${AUDIT_TOOL_NAME} tool and nothing else. Fill every dimension under \`modules\`, each matching its schema.
@@ -244,6 +246,28 @@ export function collectEvidenceQuotes(findings) {
     return [...quotes].map((quote) => ({ quote }));
 }
 
+// Coerce a model-supplied score/confidence into the range the validator
+// AND the aggregate require, BEFORE either consumes it. A recoverable
+// model quirk (the common one: confidence emitted as a 0-100 percentage
+// rather than a 0.0-1.0 fraction) must degrade a number, never discard
+// the whole eight-module audit at the import firewall. This is NOT a
+// tamper-gate relaxation — import.js still validates everything; we are
+// keeping the value we hand it in-range so a quirk doesn't masquerade as
+// corruption. A non-number stays non-number (assembleAudit nulls it,
+// import takes the per-module failed posture).
+function clampScore(v) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return v;
+    return Math.max(0, Math.min(100, v));
+}
+function clampConfidence(v) {
+    if (typeof v !== 'number' || !Number.isFinite(v)) return v;
+    // Clearly a percentage (1 < v <= 100) → it's a 0-100 value the model
+    // mislabeled; recover the fraction. Anything still out of range
+    // (negatives, >100) clamps to the bound.
+    if (v > 1 && v <= 100) v = v / 100;
+    return Math.max(0, Math.min(1, v));
+}
+
 // The deterministic aggregate — scorer.js aggregate(), ported. The
 // knowability ceiling is derived from source_quality's summary counts;
 // the weighted score uses only the scoreable modules; confidence stacks
@@ -284,11 +308,12 @@ function buildAggregate({ hash, byModule, model, runAt }) {
             moduleContributions.push({ module: m, module_result_id: null, score: null, confidence: 0, weight: 0 });
             continue;
         }
-        weightedSum += r.score * weight;
+        const score = clampScore(r.score);
+        weightedSum += score * weight;
         totalWeightApplied += weight;
         moduleContributions.push({
             module: m, module_result_id: null,
-            score: r.score, confidence: typeof r.confidence === 'number' ? r.confidence : 0.5, weight
+            score, confidence: clampConfidence(typeof r.confidence === 'number' ? r.confidence : 0.5), weight
         });
     }
 
@@ -299,7 +324,7 @@ function buildAggregate({ hash, byModule, model, runAt }) {
     const successful = moduleContributions.filter((c) => c.score !== null);
     const minConfidence = successful.length ? Math.min(...successful.map((c) => c.confidence)) : 0;
     const successFraction = successful.length / SCOREABLE_MODULES.length;
-    const overallConfidence = Number((minConfidence * successFraction).toFixed(2));
+    const overallConfidence = clampConfidence(Number((minConfidence * successFraction).toFixed(2)));
 
     const topStrengths = [];
     const topConcerns = [];
@@ -393,6 +418,21 @@ export async function assembleAudit({ toolInput, model, markdown, metadata = {},
         const caveats = Array.isArray(raw.auditor_caveats) ? raw.auditor_caveats.slice() : [];
         if (standingCaveat && !caveats.includes(standingCaveat)) caveats.unshift(standingCaveat);
         findings.auditor_caveats = caveats;
+
+        // Normalize score/confidence IN the findings object so the wrapper,
+        // the validated findings, and buildAggregate all see one in-range
+        // value (and import's tamper check, which requires wrapper ===
+        // findings, still passes). A recovered percentage is noted so the
+        // degrade is transparent (P12), not silent.
+        if (name !== 'prediction_extraction') {
+            if (typeof findings.confidence === 'number'
+                && Number.isFinite(findings.confidence) && findings.confidence > 1) {
+                caveats.push(
+                    `confidence ${findings.confidence} was out of range and normalized into 0.0-1.0`);
+            }
+            findings.score = clampScore(findings.score);
+            findings.confidence = clampConfidence(findings.confidence);
+        }
 
         const score = typeof findings.score === 'number' ? findings.score : null;
         const confidence = typeof findings.confidence === 'number' ? findings.confidence : null;

--- a/tests/audit-llm.test.mjs
+++ b/tests/audit-llm.test.mjs
@@ -227,6 +227,44 @@ test('assembleAudit: an absent module imports as a failed result, not a rejectio
     assert.equal(summary.modulesValid, 7, 'the rest still import');
 });
 
+test('round-trip: percentage-scale confidence is normalized, not rejected (regression)', async () => {
+    // The single-shot model sometimes emits confidence as a 0-100 PERCENTAGE
+    // instead of a 0.0-1.0 fraction. That used to poison the aggregate and make
+    // importAuditJson hard-throw ("aggregate.overall_confidence must be a number
+    // in [0, 1] (got 60)"), surfacing as the reader's "Audit import failed" toast.
+    // assembleAudit now recovers the fraction and notes the degrade (P12).
+    const mods = fullModules();
+    for (const name of Object.keys(mods)) {
+        if (name === 'prediction_extraction') continue;
+        mods[name].confidence = mods[name].confidence * 100;   // 0.8 -> 80, 0.6 -> 60, …
+    }
+    const audit = await assembleAudit({
+        toolInput: { modules: mods }, model: MODEL, markdown: MD,
+        standingCaveat: STANDING_SINGLE_SHOT_CAVEAT
+    });
+
+    // Recovered into [0,1] in the findings the firewall validates (so the
+    // module PASSES rather than failing) — and in the aggregate it feeds.
+    for (const r of audit.module_results) {
+        if (r.module === 'prediction_extraction') continue;
+        assert.ok(r.findings.confidence >= 0 && r.findings.confidence <= 1,
+            `${r.module} confidence normalized into [0,1]`);
+    }
+    assert.ok(audit.aggregate.overall_confidence >= 0 && audit.aggregate.overall_confidence <= 1);
+    for (const c of audit.aggregate.module_contributions) {
+        assert.ok(c.confidence >= 0 && c.confidence <= 1, `${c.module} contribution confidence in [0,1]`);
+    }
+    // Transparency: the normalization is surfaced as a caveat, not silent.
+    const noted = audit.module_results.some((r) =>
+        (r.findings.auditor_caveats || []).some((c) => /normalized into 0\.0-1\.0/.test(c)));
+    assert.ok(noted, 'normalization recorded as an auditor caveat (P12)');
+
+    // The whole point: it now IMPORTS cleanly (was a hard throw).
+    const summary = await importAuditJson(audit, { localArticleHash: await articleHash(MD) });
+    assert.equal(summary.modulesValid, 8, 'imports cleanly after normalization');
+    assert.equal(summary.modulesFailed, 0);
+});
+
 // --- per-module ("thorough") path --------------------------------------------
 
 test('buildSingleModuleTool + buildModuleSystemPrompt: one module, full methodology', () => {


### PR DESCRIPTION
## Bug

The single-shot (**Quick**) epistemic audit failed with the reader toast **"Audit import failed: …aggregate.overall_confidence must be a number in [0, 1] (got 60)"**. Thorough mode worked.

## Root cause (reproduced in Node)

The single-shot model sometimes emits a dimension's **`confidence` as a 0–100 percentage** instead of a 0.0–1.0 fraction. `buildAggregate` copied it through verbatim, so `overall_confidence` (and `module_contributions` rows) landed outside `[0, 1]` → `importAuditJson` rejected the **whole** audit at `import.js:117`. (A single out-of-range confidence trips the contribution-row check at `import.js:152` the same way.) The earlier success was an article where the model happened to return proper fractions; max-tokens was never involved. Thorough mode is immune because the aggregate guard short-circuits before any per-module posture and each call is independent.

This was confirmed by a reproduction workflow: a percentage-confidence input threw the exact message; a fully-valid control imported cleanly; and the fix was adversarially verified (`weakens_firewall: false`, legitimate audits import identically).

## Fix

- **`assembleAudit`** — `clampConfidence` recovers a mislabeled percentage (`1 < v ≤ 100` → `/100`, e.g. `85→0.85`) then clamps `[0,1]`; `clampScore` clamps `[0,100]`; non-numbers pass through (so they still null out → graceful per-module FAILED). Normalization happens **in the findings object**, so `wrapper === findings` (import's tamper check still passes) and the module now **passes** `validateFindings` instead of failing; the degrade is recorded as an **auditor caveat** (P12 — never silent).
- **`buildAggregate`** clamps contribution + `overall_confidence` (defense in depth).
- **Prompt/tool hardening** — `confidence` is described as a *decimal fraction, never a 0–100 percentage*.
- **Reader** — `console.error`s the full import error + the assembled audit, so a failure is diagnosable instead of a flashing toast.

**The tamper firewall is unchanged** — hash gate (RQ1), ceiling-source (RQ2), version/score divergence, and schema validation all still apply. A recoverable model quirk now degrades a number instead of masquerading as corruption.

Folds into the **untagged `v0.6.0`** (a `Fixed` entry, not a new version).

## Checks

- **new regression** in `tests/audit-llm.test.mjs`: percentage-scale confidence → `assembleAudit` → `importAuditJson` imports cleanly + carries the normalization caveat.
- `npm test` **937 green** · `npm run build` clean · `web-ext lint --self-hosted` **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMsDfS63yrcbaQwoZGUT1B)_